### PR TITLE
Bflat

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,33 +59,35 @@ Everything in the [**external linkage**](https://stackoverflow.com/questions/135
 |Supported|Description|
 |:-:|-|
 |:white_check_mark:|Function externs.|
-|:white_check_mark:|Variable externs.|
+|:x:|Variable externs.<sup>1</sup>|
 |:white_check_mark:|Function prototypes. (a.k.a., function pointers.)|
 |:white_check_mark:|Enums.|
-|:white_check_mark:|Structs.<sup>1</sup>|
-|:white_check_mark:|Unions.<sup>2</sup>|
-|:white_check_mark:|Opaque types.<sup>3</sup>|
+|:white_check_mark:|Structs.<sup>2</sup>|
+|:white_check_mark:|Unions.<sup>3</sup>|
+|:white_check_mark:|Opaque types.<sup>4</sup>|
 |:white_check_mark:|Typedefs. (a.k.a, type aliases.)|
-|:o:|Function-like macros.<sup>4</sup>|
-|:o:|Object-like macros.<sup>5</sup>|
+|:o:|Function-like macros.<sup>5</sup>|
+|:o:|Object-like macros.<sup>6</sup>|
 |:x:|C++.|
 |:x:|Objective-C.|
-|:x:|Implicit types.<sup>6</sup>|
-|:x:|`va_list`.<sup>7</sup>|
+|:x:|Implicit types.<sup>7</sup>|
+|:x:|`va_list`.<sup>8</sup>|
 
-<sup>1</sup>: For structs (and unions within structs), distinguishing between public/private fields is not possible automatically. If the record is transtive to a function extern or variable extern then it will be transpiled as if all the fields were public. In some cases this may not be appropriate to which there is the following options. Either, (1) use proper information hiding with C headers so the private fields are not in transtive property to a public function extern or variable extern, or (2) use pointers to access the struct and manually specify the struct as an opaque type for input to `C2CS`. Option 2 is the approach taken for generating bindings for https://github.com/libuv/libuv because `libuv` makes use of mixing public/private struct fields and struct inheritance.
+<sup>1</sup>: `dlsym` on Unix and `GetProcAddress` on Windows allow getting the address of a variable exported for shared libraries (`.dll`/`.dylib`/`.so`). However, there is no way to do the same for static libraries after they are linked. There is also no alternative for `DllImport` in C# for variables. The recommended way to expose variable externs to C# from C is to instead create "getter" and/or "setter" function externs. Statically linking a library is something that necessary for limited platforms such as iOS and Xbox. Thus, variable externs are not supported for simplicity.
 
-<sup>2</sup>: C# allows for unions using explicit layout of struct fields. Anonymous unions are transpiled to a struct which is nested inside the parent struct.
+<sup>2</sup>: For structs (and unions within structs), distinguishing between public/private fields is not possible automatically. If the record is transtive to a function extern or variable extern then it will be transpiled as if all the fields were public. In some cases this may not be appropriate to which there is the following options. Either, (1) use proper information hiding with C headers so the private fields are not in transtive property to a public function extern or variable extern, or (2) use pointers to access the struct and manually specify the struct as an opaque type for input to `C2CS`. Option 2 is the approach taken for generating bindings for https://github.com/libuv/libuv because `libuv` makes use of mixing public/private struct fields and struct inheritance.
 
-<sup>3</sup>: For opaque types, if the C header file has direct knowledge of the actual implementation, then they will be by default transpiled as if they were not opaque types. To overcome this, the opaque types in question will need to be manually specified for input to `C2CS`. This a common scenario for single file header libraries such as https://github.com/nothings/stb.
+<sup>3</sup>: C# allows for unions using explicit layout of struct fields. Anonymous unions are transpiled to a struct which is nested inside the parent struct.
 
-<sup>4</sup>: Function-like macros are only possible if the parameters' types can be inferred 100% of the time during preprocessor; otherwise, not possible. **Not yet implemented**.
+<sup>4</sup>: For opaque types, if the C header file has direct knowledge of the actual implementation, then they will be by default transpiled as if they were not opaque types. To overcome this, the opaque types in question will need to be manually specified for input to `C2CS`. This a common scenario for single file header libraries such as https://github.com/nothings/stb.
 
-<sup>5</sup>: Object-like macros are only possible if the type can inferred 100% of the time during preprocessor; otherwise, not possible. **Not yet implemented**.
+<sup>5</sup>: Function-like macros are only possible if the parameters' types can be inferred 100% of the time during preprocessor; otherwise, not possible. **Not yet implemented**.
 
-<sup>6</sup>: Types must be explicit so they can be found. E.g., it is not possible to transpile an enum if it is never discovered through transitive property of function extern or variable extern.
+<sup>6</sup>: Object-like macros are only possible if the type can inferred 100% of the time during preprocessor; otherwise, not possible. **Not yet implemented**.
 
-<sup>7</sup>: For support with `va_list` see https://github.com/lithiumtoast/c2cs/issues/15.
+<sup>7</sup>: Types must be explicit so they can be found. E.g., it is not possible to transpile an enum if it is never discovered through transitive property of function extern or variable extern.
+
+<sup>8</sup>: For support with `va_list` see https://github.com/lithiumtoast/c2cs/issues/15.
 
 #### What do I do if I want to generate bindings for a non bindgen-friendly C library?
 

--- a/src/cs/examples/flecs/flecs-02_simple_system/Program.cs
+++ b/src/cs/examples/flecs/flecs-02_simple_system/Program.cs
@@ -63,7 +63,7 @@ internal static unsafe class Program
                 name = Systems.PrintMessage.Name
             }
         };
-        systemDescriptor.entity.add[0] = EcsOnUpdate;
+        // systemDescriptor.entity.add[0] = EcsOnUpdate;
         systemDescriptor.query.filter.terms[0] = new ecs_term_t
         {
             id = component

--- a/src/cs/examples/flecs/flecs-03_move_system/Program.cs
+++ b/src/cs/examples/flecs/flecs-03_move_system/Program.cs
@@ -76,7 +76,7 @@ internal static unsafe class Program
         {
             entity = new ecs_entity_desc_t { name = Systems.Move.Name }
         };
-        systemDescriptor.entity.add[0] = EcsOnUpdate;
+        // systemDescriptor.entity.add[0] = EcsOnUpdate;
         var queryFilterTerms = systemDescriptor.query.filter.terms;
         queryFilterTerms[0].id = positionComponent;
         queryFilterTerms[1].id = velocityComponent;

--- a/src/cs/examples/flecs/flecs-c/ast.json
+++ b/src/cs/examples/flecs/flecs-c/ast.json
@@ -18,9 +18,9 @@
           "name": "t_dst",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -37,9 +37,9 @@
           "name": "t_src",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -248,9 +248,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -258,9 +258,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -277,9 +277,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -316,9 +316,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -326,9 +326,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -345,9 +345,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -384,9 +384,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -394,9 +394,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -413,9 +413,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -443,9 +443,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -453,9 +453,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -550,9 +550,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -743,9 +743,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -782,9 +782,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -988,9 +988,9 @@
           "name": "size",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -1047,9 +1047,9 @@
           "name": "size",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -1204,9 +1204,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -1243,9 +1243,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -1253,9 +1253,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -1292,9 +1292,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -1322,9 +1322,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -1332,9 +1332,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -1371,9 +1371,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -1381,9 +1381,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -1543,9 +1543,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -1935,9 +1935,9 @@
           "name": "rate",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -2186,9 +2186,9 @@
           "name": "threads",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -2477,9 +2477,9 @@
           "name": "column_index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -2516,9 +2516,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -2555,9 +2555,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -2699,9 +2699,9 @@
           "name": "offset",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -2709,9 +2709,9 @@
           "name": "limit",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -2766,9 +2766,9 @@
           "name": "stage_current",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -2776,9 +2776,9 @@
           "name": "stage_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -2965,9 +2965,9 @@
           "name": "handles_size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -3240,9 +3240,9 @@
           "name": "stage_id",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3310,9 +3310,9 @@
           "name": "stages",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3518,9 +3518,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3548,9 +3548,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -3558,9 +3558,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3637,9 +3637,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3667,9 +3667,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3697,9 +3697,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3727,9 +3727,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3757,9 +3757,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3787,9 +3787,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -3797,9 +3797,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -3925,9 +3925,9 @@
           "name": "stage_current",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -3935,9 +3935,9 @@
           "name": "stage_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -4014,9 +4014,9 @@
           "name": "offset",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -4024,9 +4024,9 @@
           "name": "limit",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -5242,9 +5242,9 @@
           "name": "buffer_len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -5580,9 +5580,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -6151,9 +6151,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -6208,9 +6208,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -6697,9 +6697,9 @@
           "name": "entity_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7209,9 +7209,9 @@
           "name": "rate",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -7277,9 +7277,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7307,9 +7307,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7337,9 +7337,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7367,9 +7367,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7397,9 +7397,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7427,9 +7427,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7457,9 +7457,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7487,9 +7487,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7517,9 +7517,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -7527,9 +7527,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -7537,9 +7537,9 @@
           "name": "row",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7596,9 +7596,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -7606,9 +7606,9 @@
           "name": "column",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -7978,9 +7978,9 @@
           "name": "buffer_len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -8064,9 +8064,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -8405,9 +8405,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -8759,9 +8759,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -8827,9 +8827,9 @@
           "name": "entity_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -8857,9 +8857,9 @@
           "name": "start_index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -8990,9 +8990,9 @@
           "name": "min_depth",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9000,9 +9000,9 @@
           "name": "max_depth",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9341,9 +9341,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -9496,9 +9496,9 @@
           "name": "column",
           "type": "int64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 21,
-            "column": 28,
+            "file": "_int64_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9535,9 +9535,9 @@
           "name": "error_code",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9572,9 +9572,9 @@
           "name": "line",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -9593,9 +9593,9 @@
           "name": "error_code",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9621,9 +9621,9 @@
           "name": "line",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -9642,9 +9642,9 @@
           "name": "error_code",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -9692,9 +9692,9 @@
           "name": "line",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9731,9 +9731,9 @@
           "name": "line",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9770,9 +9770,9 @@
           "name": "line",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9818,9 +9818,9 @@
           "name": "line",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9984,9 +9984,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -9994,9 +9994,9 @@
           "name": "alignment",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -10526,9 +10526,9 @@
           "name": "n",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -10681,9 +10681,9 @@
           "name": "args",
           "type": "va_list",
           "location": {
-            "file": "vadefs.h",
-            "line": 72,
-            "column": 23,
+            "file": "_va_list.h",
+            "line": 32,
+            "column": 26,
             "isSystem": true
           }
         }
@@ -10740,9 +10740,9 @@
           "name": "allocd",
           "type": "int32_t*",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -10750,9 +10750,9 @@
           "name": "used",
           "type": "int32_t*",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -10780,9 +10780,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -10810,9 +10810,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11197,9 +11197,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11236,9 +11236,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11275,9 +11275,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11285,9 +11285,9 @@
           "name": "allocd",
           "type": "int32_t*",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11295,9 +11295,9 @@
           "name": "used",
           "type": "int32_t*",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11334,9 +11334,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11382,9 +11382,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11461,9 +11461,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11471,9 +11471,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11510,9 +11510,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11520,9 +11520,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11559,9 +11559,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11569,9 +11569,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11608,9 +11608,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11647,9 +11647,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11657,9 +11657,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11705,9 +11705,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11715,9 +11715,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11754,9 +11754,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11822,9 +11822,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11832,9 +11832,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11871,9 +11871,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11881,9 +11881,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11920,9 +11920,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -11959,9 +11959,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -11969,9 +11969,9 @@
           "name": "index",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -12008,9 +12008,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -12018,9 +12018,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -12057,9 +12057,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -12194,9 +12194,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -12224,9 +12224,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -12234,9 +12234,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -12273,9 +12273,9 @@
           "name": "offset",
           "type": "int16_t",
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -12283,9 +12283,9 @@
           "name": "elem_count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -12580,9 +12580,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -12590,9 +12590,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -12675,9 +12675,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -12685,9 +12685,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -12752,9 +12752,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -12762,9 +12762,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -12931,7 +12931,7 @@
     },
     {
       "name": "ecs_os_api_log_t",
-      "type": "void (char *, va_list)",
+      "type": "void (char *, __va_list_tag *)",
       "returnType": "void",
       "parameters": [
         {
@@ -12947,9 +12947,9 @@
           "name": "args",
           "type": "va_list",
           "location": {
-            "file": "vadefs.h",
-            "line": 72,
-            "column": 23,
+            "file": "_va_list.h",
+            "line": 32,
+            "column": 26,
             "isSystem": true
           }
         }
@@ -12990,9 +12990,9 @@
           "name": "sec",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -13000,9 +13000,9 @@
           "name": "nanosec",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -13179,9 +13179,9 @@
           "name": "value",
           "type": "int32_t*",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -13509,9 +13509,9 @@
           "name": "count",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -13520,9 +13520,9 @@
           "type": "int32_t",
           "offset": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -13531,9 +13531,9 @@
           "type": "int64_t",
           "offset": 8,
           "location": {
-            "file": "stdint.h",
-            "line": 21,
-            "column": 28,
+            "file": "_int64_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -13672,9 +13672,9 @@
           "type": "int32_t",
           "offset": 2160,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -13693,9 +13693,9 @@
           "name": "dummy_",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -13984,9 +13984,9 @@
           "type": "int32_t",
           "offset": 24244,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -14016,9 +14016,9 @@
           "offset": 8,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -14108,9 +14108,9 @@
           "type": "int32_t",
           "offset": 56,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14119,9 +14119,9 @@
           "type": "int32_t",
           "offset": 60,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14131,9 +14131,9 @@
           "offset": 64,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14222,9 +14222,9 @@
           "type": "int32_t",
           "offset": 124,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14233,9 +14233,9 @@
           "type": "int32_t",
           "offset": 128,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14244,9 +14244,9 @@
           "type": "int32_t",
           "offset": 132,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14256,9 +14256,9 @@
           "offset": 136,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14378,9 +14378,9 @@
           "offset": 64,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14419,9 +14419,9 @@
           "type": "int32_t",
           "offset": 8,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14430,9 +14430,9 @@
           "type": "int32_t",
           "offset": 12,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14583,9 +14583,9 @@
           "type": "int32_t",
           "offset": 184,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14677,9 +14677,9 @@
           "offset": 8,
           "padding": 3,
           "location": {
-            "file": "stdint.h",
-            "line": 22,
-            "column": 28,
+            "file": "_uint8_t.h",
+            "line": 31,
+            "column": 23,
             "isSystem": true
           }
         },
@@ -14688,9 +14688,9 @@
           "type": "int32_t",
           "offset": 12,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14700,9 +14700,9 @@
           "offset": 16,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -14731,9 +14731,9 @@
           "type": "int32_t",
           "offset": 12,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14742,9 +14742,9 @@
           "type": "int32_t",
           "offset": 16,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14753,9 +14753,9 @@
           "type": "int32_t",
           "offset": 20,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14764,9 +14764,9 @@
           "type": "int32_t",
           "offset": 24,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -14785,9 +14785,9 @@
           "name": "offset",
           "type": "int32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14796,9 +14796,9 @@
           "type": "int32_t",
           "offset": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14807,9 +14807,9 @@
           "type": "int32_t",
           "offset": 8,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -14849,9 +14849,9 @@
           "offset": 64,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14901,9 +14901,9 @@
           "offset": 88,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14952,9 +14952,9 @@
           "type": "int32_t",
           "offset": 16,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -14963,9 +14963,9 @@
           "type": "int32_t",
           "offset": 20,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15005,9 +15005,9 @@
           "offset": 8,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -15026,9 +15026,9 @@
           "name": "columns",
           "type": "int32_t*",
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15127,9 +15127,9 @@
           "type": "int32_t",
           "offset": 24,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15138,9 +15138,9 @@
           "type": "int32_t",
           "offset": 28,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15262,9 +15262,9 @@
           "type": "int32_t",
           "offset": 24,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15273,9 +15273,9 @@
           "type": "int32_t",
           "offset": 28,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15305,9 +15305,9 @@
           "type": "int32_t",
           "offset": 48,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15316,9 +15316,9 @@
           "type": "int16_t",
           "offset": 52,
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15327,9 +15327,9 @@
           "type": "int16_t",
           "offset": 54,
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15359,9 +15359,9 @@
           "type": "int32_t",
           "offset": 72,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15370,9 +15370,9 @@
           "type": "int32_t",
           "offset": 76,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15411,9 +15411,9 @@
           "type": "int32_t",
           "offset": 8,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15422,9 +15422,9 @@
           "type": "int32_t",
           "offset": 12,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15434,9 +15434,9 @@
           "offset": 16,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -15546,9 +15546,9 @@
           "type": "int32_t",
           "offset": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15608,9 +15608,9 @@
           "type": "int32_t",
           "offset": 48,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15619,9 +15619,9 @@
           "type": "int32_t",
           "offset": 52,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15640,9 +15640,9 @@
           "type": "int16_t",
           "offset": 64,
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15651,9 +15651,9 @@
           "type": "int16_t",
           "offset": 66,
           "location": {
-            "file": "stdint.h",
-            "line": 19,
-            "column": 28,
+            "file": "_int16_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15672,9 +15672,9 @@
           "type": "int32_t",
           "offset": 72,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15683,9 +15683,9 @@
           "type": "int32_t",
           "offset": 76,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15826,9 +15826,9 @@
           "offset": 64,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -15877,9 +15877,9 @@
           "type": "int32_t",
           "offset": 24,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15919,9 +15919,9 @@
           "type": "int32_t",
           "offset": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -15950,9 +15950,9 @@
           "type": "int32_t",
           "offset": 8,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15961,9 +15961,9 @@
           "type": "int32_t",
           "offset": 12,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -15972,9 +15972,9 @@
           "type": "int32_t",
           "offset": 16,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -16124,9 +16124,9 @@
           "type": "int32_t",
           "offset": 3788,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -16255,9 +16255,9 @@
           "type": "int32_t",
           "offset": 3080,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -16568,9 +16568,9 @@
           "type": "size_t",
           "offset": 568,
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -16579,9 +16579,9 @@
           "type": "size_t",
           "offset": 576,
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -16730,9 +16730,9 @@
           "type": "int32_t",
           "offset": 68,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -16741,9 +16741,9 @@
           "type": "int32_t",
           "offset": 72,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -16752,9 +16752,9 @@
           "type": "int32_t",
           "offset": 76,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -16764,9 +16764,9 @@
           "offset": 80,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -16845,9 +16845,9 @@
           "name": "sec",
           "type": "uint32_t",
           "location": {
-            "file": "stdint.h",
-            "line": 24,
-            "column": 28,
+            "file": "_uint32_t.h",
+            "line": 31,
+            "column": 22,
             "isSystem": true
           }
         },
@@ -16856,9 +16856,9 @@
           "type": "uint32_t",
           "offset": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 24,
-            "column": 28,
+            "file": "_uint32_t.h",
+            "line": 31,
+            "column": 22,
             "isSystem": true
           }
         }
@@ -17217,9 +17217,9 @@
           "type": "int32_t",
           "offset": 8,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -17228,9 +17228,9 @@
           "type": "int32_t",
           "offset": 12,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -17240,9 +17240,9 @@
           "offset": 16,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -17282,9 +17282,9 @@
           "offset": 1080,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -17304,9 +17304,9 @@
           "type": "int32_t",
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -17346,9 +17346,9 @@
           "type": "int32_t",
           "offset": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -17415,7 +17415,7 @@
     {
       "name": "ecs_match_kind_t",
       "type": "ecs_match_kind_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "EcsMatchDefault",
@@ -17462,7 +17462,7 @@
     {
       "name": "ecs_oper_kind_t",
       "type": "ecs_oper_kind_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "EcsAnd",
@@ -17536,7 +17536,7 @@
     {
       "name": "ecs_var_kind_t",
       "type": "ecs_var_kind_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "EcsVarDefault",
@@ -17574,7 +17574,7 @@
     {
       "name": "ecs_inout_kind_t",
       "type": "ecs_inout_kind_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "EcsInOutDefault",
@@ -17621,7 +17621,7 @@
     {
       "name": "ecs_query_iter_kind_t",
       "type": "ecs_query_iter_kind_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "EcsQuerySimpleIter",
@@ -17668,7 +17668,7 @@
     {
       "name": "ecs_blob_header_kind_t",
       "type": "ecs_blob_header_kind_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "EcsStreamHeader",
@@ -17814,7 +17814,7 @@
     {
       "name": "EcsMatchFailureReason",
       "type": "EcsMatchFailureReason",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "EcsMatchOk",
@@ -17987,7 +17987,7 @@
     {
       "name": "ecs_system_status_t",
       "type": "ecs_system_status_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "EcsSystemStatusNone",
@@ -18662,9 +18662,9 @@
       "name": "ecs_os_api_free_count",
       "type": "int64_t",
       "location": {
-        "file": "stdint.h",
-        "line": 21,
-        "column": 28,
+        "file": "_int64_t.h",
+        "line": 30,
+        "column": 33,
         "isSystem": true
       }
     },
@@ -18672,9 +18672,9 @@
       "name": "ecs_os_api_calloc_count",
       "type": "int64_t",
       "location": {
-        "file": "stdint.h",
-        "line": 21,
-        "column": 28,
+        "file": "_int64_t.h",
+        "line": 30,
+        "column": 33,
         "isSystem": true
       }
     },
@@ -18682,9 +18682,9 @@
       "name": "ecs_os_api_realloc_count",
       "type": "int64_t",
       "location": {
-        "file": "stdint.h",
-        "line": 21,
-        "column": 28,
+        "file": "_int64_t.h",
+        "line": 30,
+        "column": 33,
         "isSystem": true
       }
     },
@@ -18692,9 +18692,9 @@
       "name": "ecs_os_api_malloc_count",
       "type": "int64_t",
       "location": {
-        "file": "stdint.h",
-        "line": 21,
-        "column": 28,
+        "file": "_int64_t.h",
+        "line": 30,
+        "column": 33,
         "isSystem": true
       }
     }
@@ -19263,7 +19263,7 @@
       }
     },
     {
-      "name": "int",
+      "name": "unsigned int",
       "kind": "primitive",
       "sizeOf": 4,
       "alignOf": 4,
@@ -19531,6 +19531,13 @@
         "line": 121,
         "column": 3
       }
+    },
+    {
+      "name": "int",
+      "kind": "primitive",
+      "sizeOf": 4,
+      "alignOf": 4,
+      "isSystem": true
     },
     {
       "name": "ecs_size_t",
@@ -20460,7 +20467,7 @@
     {
       "name": "va_list",
       "kind": "typedef",
-      "sizeOf": 8,
+      "sizeOf": 24,
       "alignOf": 8,
       "isSystem": true
     },

--- a/src/cs/examples/flecs/flecs-cs/flecs.cs
+++ b/src/cs/examples/flecs/flecs-cs/flecs.cs
@@ -20,2675 +20,1514 @@ using C2CS;
 public static unsafe partial class flecs
 {
     private const string LibraryName = "flecs";
-    private static IntPtr _libraryHandle;
-
-    static flecs()
-    {
-        TryLoadApi();
-    }
-
-    public static bool TryLoadApi(string? libraryName = LibraryName)
-    {
-        UnloadApi();
-        _libraryHandle = Runtime.LibraryLoad(libraryName!);
-        if (_libraryHandle == IntPtr.Zero) return false;
-        _LoadVirtualTable();
-        return true;
-    }
-
-    public static void UnloadApi()
-    {
-        if (_libraryHandle == IntPtr.Zero) return;
-        _UnloadVirtualTable();
-        Runtime.LibraryUnload(_libraryHandle);
-    }
-
-    // Variable @ flecs.h:77:29
-    public static ecs_type_t FLECS__TEcsRateFilter
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_type_t>(_virtualTable.FLECS__TEcsRateFilter);
-    }
-
-    // Variable @ flecs.h:77:29
-    public static ecs_type_t FLECS__TEcsTimer
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_type_t>(_virtualTable.FLECS__TEcsTimer);
-    }
-
-    // Variable @ flecs.h:77:29
-    public static ecs_type_t FLECS__TEcsTickSource
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_type_t>(_virtualTable.FLECS__TEcsTickSource);
-    }
-
-    // Variable @ flecs.h:77:29
-    public static ecs_type_t FLECS__TEcsSystem
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_type_t>(_virtualTable.FLECS__TEcsSystem);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsPostFrame
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsPostFrame);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnStore
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnStore);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsPreStore
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsPreStore);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsPostUpdate
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsPostUpdate);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnValidate
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnValidate);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnUpdate
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnUpdate);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsPreUpdate
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsPreUpdate);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsPostLoad
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsPostLoad);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnLoad
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnLoad);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsPreFrame
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsPreFrame);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsPipeline
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsPipeline);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsInactive
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsInactive);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsDisabledIntern
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsDisabledIntern);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsMonitor
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsMonitor);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnDemand
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnDemand);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsThrow
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsThrow);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsDelete
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsDelete);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsRemove
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsRemove);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnDeleteObject
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnDeleteObject);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnDelete
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnDelete);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsUnSet
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsUnSet);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnSet
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnSet);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnRemove
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnRemove);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsOnAdd
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsOnAdd);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsHidden
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsHidden);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsDisabled
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsDisabled);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsPrefab
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsPrefab);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsModule
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsModule);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsIsA
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsIsA);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsChildOf
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsChildOf);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsFinal
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsFinal);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsTransitive
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsTransitive);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsThis
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsThis);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsWildcard
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsWildcard);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsWorld
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsWorld);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsFlecsCore
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsFlecsCore);
-    }
-
-    // Variable @ flecs.h:74:18
-    public static ecs_entity_t EcsFlecs
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_entity_t>(_virtualTable.EcsFlecs);
-    }
-
-    // Variable @ flecs.h:71:18
-    public static ecs_id_t ECS_DISABLED
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_id_t>(_virtualTable.ECS_DISABLED);
-    }
-
-    // Variable @ flecs.h:71:18
-    public static ecs_id_t ECS_OWNED
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_id_t>(_virtualTable.ECS_OWNED);
-    }
-
-    // Variable @ flecs.h:71:18
-    public static ecs_id_t ECS_PAIR
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_id_t>(_virtualTable.ECS_PAIR);
-    }
-
-    // Variable @ flecs.h:71:18
-    public static ecs_id_t ECS_SWITCH
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_id_t>(_virtualTable.ECS_SWITCH);
-    }
-
-    // Variable @ flecs.h:71:18
-    public static ecs_id_t ECS_CASE
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_id_t>(_virtualTable.ECS_CASE);
-    }
-
-    // Variable @ flecs.h:77:29
-    public static ecs_type_t FLECS__TEcsName
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_type_t>(_virtualTable.FLECS__TEcsName);
-    }
-
-    // Variable @ flecs.h:77:29
-    public static ecs_type_t FLECS__TEcsType
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_type_t>(_virtualTable.FLECS__TEcsType);
-    }
-
-    // Variable @ flecs.h:77:29
-    public static ecs_type_t FLECS__TEcsComponentLifecycle
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_type_t>(_virtualTable.FLECS__TEcsComponentLifecycle);
-    }
-
-    // Variable @ flecs.h:77:29
-    public static ecs_type_t FLECS__TEcsComponent
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_type_t>(_virtualTable.FLECS__TEcsComponent);
-    }
-
-    // Variable @ os_api.h:251:3
-    public static ecs_os_api_t ecs_os_api
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<ecs_os_api_t>(_virtualTable.ecs_os_api);
-    }
-
-    // Variable @ System
-    public static long ecs_os_api_free_count
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<long>(_virtualTable.ecs_os_api_free_count);
-    }
-
-    // Variable @ System
-    public static long ecs_os_api_calloc_count
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<long>(_virtualTable.ecs_os_api_calloc_count);
-    }
-
-    // Variable @ System
-    public static long ecs_os_api_realloc_count
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<long>(_virtualTable.ecs_os_api_realloc_count);
-    }
-
-    // Variable @ System
-    public static long ecs_os_api_malloc_count
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => Runtime.ReadMemory<long>(_virtualTable.ecs_os_api_malloc_count);
-    }
 
     // Function @ stats.h:178:16
-    public static void ecs_gauge_reduce(ecs_gauge_t* dst, int t_dst, ecs_gauge_t* src, int t_src)
-    {
-        _virtualTable.ecs_gauge_reduce(dst, t_dst, src, t_src);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_gauge_reduce(ecs_gauge_t* dst, int t_dst, ecs_gauge_t* src, int t_src);
 
     // Function @ stats.h:172:16
-    public static CBool ecs_get_pipeline_stats(ecs_world_t* world, ecs_entity_t pipeline, ecs_pipeline_stats_t* stats)
-    {
-        return _virtualTable.ecs_get_pipeline_stats(world, pipeline, stats);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_get_pipeline_stats(ecs_world_t* world, ecs_entity_t pipeline, ecs_pipeline_stats_t* stats);
 
     // Function @ stats.h:157:16
-    public static CBool ecs_get_system_stats(ecs_world_t* world, ecs_entity_t system, ecs_system_stats_t* stats)
-    {
-        return _virtualTable.ecs_get_system_stats(world, system, stats);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_get_system_stats(ecs_world_t* world, ecs_entity_t system, ecs_system_stats_t* stats);
 
     // Function @ stats.h:143:16
-    public static void ecs_get_query_stats(ecs_world_t* world, ecs_query_t* query, ecs_query_stats_t* s)
-    {
-        _virtualTable.ecs_get_query_stats(world, query, s);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_get_query_stats(ecs_world_t* world, ecs_query_t* query, ecs_query_stats_t* s);
 
     // Function @ stats.h:132:16
-    public static void ecs_dump_world_stats(ecs_world_t* world, ecs_world_stats_t* stats)
-    {
-        _virtualTable.ecs_dump_world_stats(world, stats);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_dump_world_stats(ecs_world_t* world, ecs_world_stats_t* stats);
 
     // Function @ stats.h:121:16
-    public static void ecs_get_world_stats(ecs_world_t* world, ecs_world_stats_t* stats)
-    {
-        _virtualTable.ecs_get_world_stats(world, stats);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_get_world_stats(ecs_world_t* world, ecs_world_stats_t* stats);
 
     // Function @ direct_access.h:313:6
-    public static void ecs_record_move_to(ecs_world_t* world, ecs_record_t* r, int column, ulong size, void* value, int count)
-    {
-        _virtualTable.ecs_record_move_to(world, r, column, size, value, count);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_record_move_to(ecs_world_t* world, ecs_record_t* r, int column, ulong size, void* value, int count);
 
     // Function @ direct_access.h:292:6
-    public static void ecs_record_copy_pod_to(ecs_world_t* world, ecs_record_t* r, int column, ulong size, void* value, int count)
-    {
-        _virtualTable.ecs_record_copy_pod_to(world, r, column, size, value, count);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_record_copy_pod_to(ecs_world_t* world, ecs_record_t* r, int column, ulong size, void* value, int count);
 
     // Function @ direct_access.h:271:6
-    public static void ecs_record_copy_to(ecs_world_t* world, ecs_record_t* r, int column, ulong size, void* value, int count)
-    {
-        _virtualTable.ecs_record_copy_to(world, r, column, size, value, count);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_record_copy_to(ecs_world_t* world, ecs_record_t* r, int column, ulong size, void* value, int count);
 
     // Function @ direct_access.h:249:7
-    public static void* ecs_record_get_column(ecs_record_t* r, int column, ulong size)
-    {
-        return _virtualTable.ecs_record_get_column(r, column, size);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_record_get_column(ecs_record_t* r, int column, ulong size);
 
     // Function @ direct_access.h:237:15
-    public static ecs_record_t* ecs_record_ensure(ecs_world_t* world, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_record_ensure(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_record_t* ecs_record_ensure(ecs_world_t* world, ecs_entity_t entity);
 
     // Function @ direct_access.h:223:15
-    public static ecs_record_t* ecs_record_find(ecs_world_t* world, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_record_find(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_record_t* ecs_record_find(ecs_world_t* world, ecs_entity_t entity);
 
     // Function @ direct_access.h:197:6
-    public static void ecs_table_delete_column(ecs_world_t* world, ecs_table_t* table, int column, ecs_vector_t* vector)
-    {
-        _virtualTable.ecs_table_delete_column(world, table, column, vector);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_table_delete_column(ecs_world_t* world, ecs_table_t* table, int column, ecs_vector_t* vector);
 
     // Function @ direct_access.h:158:6
-    public static void ecs_table_set_entities(ecs_table_t* table, ecs_vector_t* entities, ecs_vector_t* records)
-    {
-        _virtualTable.ecs_table_set_entities(table, entities, records);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_table_set_entities(ecs_table_t* table, ecs_vector_t* entities, ecs_vector_t* records);
 
     // Function @ direct_access.h:133:6
-    public static void ecs_records_update(ecs_world_t* world, ecs_vector_t* entities, ecs_vector_t* records, ecs_table_t* table)
-    {
-        _virtualTable.ecs_records_update(world, entities, records, table);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_records_update(ecs_world_t* world, ecs_vector_t* entities, ecs_vector_t* records, ecs_table_t* table);
 
     // Function @ direct_access.h:121:6
-    public static void ecs_records_clear(ecs_vector_t* records)
-    {
-        _virtualTable.ecs_records_clear(records);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_records_clear(ecs_vector_t* records);
 
     // Function @ direct_access.h:110:15
-    public static ecs_vector_t* ecs_table_get_records(ecs_table_t* table)
-    {
-        return _virtualTable.ecs_table_get_records(table);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_vector_t* ecs_table_get_records(ecs_table_t* table);
 
     // Function @ direct_access.h:98:15
-    public static ecs_vector_t* ecs_table_get_entities(ecs_table_t* table)
-    {
-        return _virtualTable.ecs_table_get_entities(table);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_vector_t* ecs_table_get_entities(ecs_table_t* table);
 
     // Function @ direct_access.h:83:15
-    public static ecs_vector_t* ecs_table_set_column(ecs_world_t* world, ecs_table_t* table, int column, ecs_vector_t* vector)
-    {
-        return _virtualTable.ecs_table_set_column(world, table, column, vector);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_vector_t* ecs_table_set_column(ecs_world_t* world, ecs_table_t* table, int column, ecs_vector_t* vector);
 
     // Function @ direct_access.h:50:15
-    public static ecs_vector_t* ecs_table_get_column(ecs_table_t* table, int column)
-    {
-        return _virtualTable.ecs_table_get_column(table, column);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_vector_t* ecs_table_get_column(ecs_table_t* table, int column);
 
     // Function @ direct_access.h:34:9
-    public static int ecs_table_find_column(ecs_table_t* table, ecs_entity_t component)
-    {
-        return _virtualTable.ecs_table_find_column(table, component);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_table_find_column(ecs_table_t* table, ecs_entity_t component);
 
     // Function @ snapshot.h:94:6
-    public static void ecs_snapshot_free(ecs_snapshot_t* snapshot)
-    {
-        _virtualTable.ecs_snapshot_free(snapshot);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_snapshot_free(ecs_snapshot_t* snapshot);
 
     // Function @ snapshot.h:83:6
-    public static CBool ecs_snapshot_next(ecs_iter_t* iter)
-    {
-        return _virtualTable.ecs_snapshot_next(iter);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_snapshot_next(ecs_iter_t* iter);
 
     // Function @ snapshot.h:73:12
-    public static ecs_iter_t ecs_snapshot_iter(ecs_snapshot_t* snapshot, ecs_filter_t* filter)
-    {
-        return _virtualTable.ecs_snapshot_iter(snapshot, filter);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_iter_t ecs_snapshot_iter(ecs_snapshot_t* snapshot, ecs_filter_t* filter);
 
     // Function @ snapshot.h:64:6
-    public static void ecs_snapshot_restore(ecs_world_t* world, ecs_snapshot_t* snapshot)
-    {
-        _virtualTable.ecs_snapshot_restore(world, snapshot);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_snapshot_restore(ecs_world_t* world, ecs_snapshot_t* snapshot);
 
     // Function @ snapshot.h:45:17
-    public static ecs_snapshot_t* ecs_snapshot_take_w_iter(ecs_iter_t* iter, ecs_iter_next_action_t action)
-    {
-        return _virtualTable.ecs_snapshot_take_w_iter(iter, action);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_snapshot_t* ecs_snapshot_take_w_iter(ecs_iter_t* iter, ecs_iter_next_action_t action);
 
     // Function @ snapshot.h:33:17
-    public static ecs_snapshot_t* ecs_snapshot_take(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_snapshot_take(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_snapshot_t* ecs_snapshot_take(ecs_world_t* world);
 
     // Function @ reader_writer.h:213:9
-    public static int ecs_writer_write(CString buffer, int size, ecs_writer_t* writer)
-    {
-        return _virtualTable.ecs_writer_write(buffer, size, writer);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_writer_write(CString buffer, int size, ecs_writer_t* writer);
 
     // Function @ reader_writer.h:190:14
-    public static ecs_writer_t ecs_writer_init(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_writer_init(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_writer_t ecs_writer_init(ecs_world_t* world);
 
     // Function @ reader_writer.h:171:9
-    public static int ecs_reader_read(CString buffer, int size, ecs_reader_t* reader)
-    {
-        return _virtualTable.ecs_reader_read(buffer, size, reader);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_reader_read(CString buffer, int size, ecs_reader_t* reader);
 
     // Function @ reader_writer.h:152:14
-    public static ecs_reader_t ecs_reader_init_w_iter(ecs_iter_t* iter, ecs_iter_next_action_t next)
-    {
-        return _virtualTable.ecs_reader_init_w_iter(iter, next);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_reader_t ecs_reader_init_w_iter(ecs_iter_t* iter, ecs_iter_next_action_t next);
 
     // Function @ reader_writer.h:138:14
-    public static ecs_reader_t ecs_reader_init(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_reader_init(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_reader_t ecs_reader_init(ecs_world_t* world);
 
     // Function @ queue.h:79:6
-    public static void ecs_queue_free(ecs_queue_t* queue)
-    {
-        _virtualTable.ecs_queue_free(queue);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_queue_free(ecs_queue_t* queue);
 
     // Function @ queue.h:75:9
-    public static int ecs_queue_count(ecs_queue_t* queue)
-    {
-        return _virtualTable.ecs_queue_count(queue);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_queue_count(ecs_queue_t* queue);
 
     // Function @ queue.h:71:9
-    public static int ecs_queue_index(ecs_queue_t* queue)
-    {
-        return _virtualTable.ecs_queue_index(queue);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_queue_index(ecs_queue_t* queue);
 
     // Function @ queue.h:62:7
-    public static void* _ecs_queue_last(ecs_queue_t* queue, ecs_size_t elem_size, short offset)
-    {
-        return _virtualTable._ecs_queue_last(queue, elem_size, offset);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_queue_last(ecs_queue_t* queue, ecs_size_t elem_size, short offset);
 
     // Function @ queue.h:49:7
-    public static void* _ecs_queue_get(ecs_queue_t* queue, ecs_size_t elem_size, short offset, int index)
-    {
-        return _virtualTable._ecs_queue_get(queue, elem_size, offset, index);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_queue_get(ecs_queue_t* queue, ecs_size_t elem_size, short offset, int index);
 
     // Function @ queue.h:40:7
-    public static void* _ecs_queue_push(ecs_queue_t* queue, ecs_size_t elem_size, short offset)
-    {
-        return _virtualTable._ecs_queue_push(queue, elem_size, offset);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_queue_push(ecs_queue_t* queue, ecs_size_t elem_size, short offset);
 
     // Function @ queue.h:30:14
-    public static ecs_queue_t* _ecs_queue_from_array(ecs_size_t elem_size, short offset, int elem_count, void* array)
-    {
-        return _virtualTable._ecs_queue_from_array(elem_size, offset, elem_count, array);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_queue_t* _ecs_queue_from_array(ecs_size_t elem_size, short offset, int elem_count, void* array);
 
     // Function @ queue.h:21:14
-    public static ecs_queue_t* _ecs_queue_new(ecs_size_t elem_size, short offset, int elem_count)
-    {
-        return _virtualTable._ecs_queue_new(elem_size, offset, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_queue_t* _ecs_queue_new(ecs_size_t elem_size, short offset, int elem_count);
 
     // Function @ parser.h:46:7
-    public static CString ecs_parse_term(ecs_world_t* world, CString name, CString expr, CString ptr, ecs_term_t* term_out)
-    {
-        return _virtualTable.ecs_parse_term(world, name, expr, ptr, term_out);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_parse_term(ecs_world_t* world, CString name, CString expr, CString ptr, ecs_term_t* term_out);
 
     // Function @ dbg.h:60:6
-    public static void ecs_dbg_table(ecs_world_t* world, ecs_table_t* table, ecs_dbg_table_t* dbg_out)
-    {
-        _virtualTable.ecs_dbg_table(world, table, dbg_out);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_dbg_table(ecs_world_t* world, ecs_table_t* table, ecs_dbg_table_t* dbg_out);
 
     // Function @ dbg.h:54:6
-    public static CBool ecs_dbg_filter_table(ecs_world_t* world, ecs_table_t* table, ecs_filter_t* filter)
-    {
-        return _virtualTable.ecs_dbg_filter_table(world, table, filter);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_dbg_filter_table(ecs_world_t* world, ecs_table_t* table, ecs_filter_t* filter);
 
     // Function @ dbg.h:49:14
-    public static ecs_table_t* ecs_dbg_get_table(ecs_world_t* world, int index)
-    {
-        return _virtualTable.ecs_dbg_get_table(world, index);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_table_t* ecs_dbg_get_table(ecs_world_t* world, int index);
 
     // Function @ dbg.h:44:14
-    public static ecs_table_t* ecs_dbg_find_table(ecs_world_t* world, ecs_type_t type)
-    {
-        return _virtualTable.ecs_dbg_find_table(world, type);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_table_t* ecs_dbg_find_table(ecs_world_t* world, ecs_type_t type);
 
     // Function @ dbg.h:38:6
-    public static void ecs_dbg_entity(ecs_world_t* world, ecs_entity_t entity, ecs_dbg_entity_t* dbg_out)
-    {
-        _virtualTable.ecs_dbg_entity(world, entity, dbg_out);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_dbg_entity(ecs_world_t* world, ecs_entity_t entity, ecs_dbg_entity_t* dbg_out);
 
     // Function @ bulk.h:127:6
-    public static void ecs_bulk_delete(ecs_world_t* world, ecs_filter_t* filter)
-    {
-        _virtualTable.ecs_bulk_delete(world, filter);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_bulk_delete(ecs_world_t* world, ecs_filter_t* filter);
 
     // Function @ bulk.h:102:6
-    public static void ecs_bulk_add_remove_type(ecs_world_t* world, ecs_type_t to_add, ecs_type_t to_remove, ecs_filter_t* filter)
-    {
-        _virtualTable.ecs_bulk_add_remove_type(world, to_add, to_remove, filter);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_bulk_add_remove_type(ecs_world_t* world, ecs_type_t to_add, ecs_type_t to_remove, ecs_filter_t* filter);
 
     // Function @ bulk.h:77:6
-    public static void ecs_bulk_remove_type(ecs_world_t* world, ecs_type_t type, ecs_filter_t* filter)
-    {
-        _virtualTable.ecs_bulk_remove_type(world, type, filter);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_bulk_remove_type(ecs_world_t* world, ecs_type_t type, ecs_filter_t* filter);
 
     // Function @ bulk.h:63:6
-    public static void ecs_bulk_remove_entity(ecs_world_t* world, ecs_entity_t entity_remove, ecs_filter_t* filter)
-    {
-        _virtualTable.ecs_bulk_remove_entity(world, entity_remove, filter);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_bulk_remove_entity(ecs_world_t* world, ecs_entity_t entity_remove, ecs_filter_t* filter);
 
     // Function @ bulk.h:38:6
-    public static void ecs_bulk_add_type(ecs_world_t* world, ecs_type_t type, ecs_filter_t* filter)
-    {
-        _virtualTable.ecs_bulk_add_type(world, type, filter);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_bulk_add_type(ecs_world_t* world, ecs_type_t type, ecs_filter_t* filter);
 
     // Function @ bulk.h:24:6
-    public static void ecs_bulk_add_entity(ecs_world_t* world, ecs_entity_t entity_add, ecs_filter_t* filter)
-    {
-        _virtualTable.ecs_bulk_add_entity(world, entity_add, filter);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_bulk_add_entity(ecs_world_t* world, ecs_entity_t entity_add, ecs_filter_t* filter);
 
     // Function @ timer.h:246:6
-    public static void FlecsTimerImport(ecs_world_t* world)
-    {
-        _virtualTable.FlecsTimerImport(world);
-    }
+    [DllImport("flecs")]
+    public static extern void FlecsTimerImport(ecs_world_t* world);
 
     // Function @ timer.h:230:6
-    public static void ecs_set_tick_source(ecs_world_t* world, ecs_entity_t system, ecs_entity_t tick_source)
-    {
-        _virtualTable.ecs_set_tick_source(world, system, tick_source);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_tick_source(ecs_world_t* world, ecs_entity_t system, ecs_entity_t tick_source);
 
     // Function @ timer.h:201:14
-    public static ecs_entity_t ecs_set_rate(ecs_world_t* world, ecs_entity_t tick_source, int rate, ecs_entity_t source)
-    {
-        return _virtualTable.ecs_set_rate(world, tick_source, rate, source);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_set_rate(ecs_world_t* world, ecs_entity_t tick_source, int rate, ecs_entity_t source);
 
     // Function @ timer.h:166:6
-    public static void ecs_stop_timer(ecs_world_t* world, ecs_entity_t tick_source)
-    {
-        _virtualTable.ecs_stop_timer(world, tick_source);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_stop_timer(ecs_world_t* world, ecs_entity_t tick_source);
 
     // Function @ timer.h:154:6
-    public static void ecs_start_timer(ecs_world_t* world, ecs_entity_t tick_source)
-    {
-        _virtualTable.ecs_start_timer(world, tick_source);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_start_timer(ecs_world_t* world, ecs_entity_t tick_source);
 
     // Function @ timer.h:140:13
-    public static float ecs_get_interval(ecs_world_t* world, ecs_entity_t tick_source)
-    {
-        return _virtualTable.ecs_get_interval(world, tick_source);
-    }
+    [DllImport("flecs")]
+    public static extern float ecs_get_interval(ecs_world_t* world, ecs_entity_t tick_source);
 
     // Function @ timer.h:126:14
-    public static ecs_entity_t ecs_set_interval(ecs_world_t* world, ecs_entity_t tick_source, float interval)
-    {
-        return _virtualTable.ecs_set_interval(world, tick_source, interval);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_set_interval(ecs_world_t* world, ecs_entity_t tick_source, float interval);
 
     // Function @ timer.h:104:13
-    public static float ecs_get_timeout(ecs_world_t* world, ecs_entity_t tick_source)
-    {
-        return _virtualTable.ecs_get_timeout(world, tick_source);
-    }
+    [DllImport("flecs")]
+    public static extern float ecs_get_timeout(ecs_world_t* world, ecs_entity_t tick_source);
 
     // Function @ timer.h:79:14
-    public static ecs_entity_t ecs_set_timeout(ecs_world_t* world, ecs_entity_t tick_source, float timeout)
-    {
-        return _virtualTable.ecs_set_timeout(world, tick_source, timeout);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_set_timeout(ecs_world_t* world, ecs_entity_t tick_source, float timeout);
 
     // Function @ pipeline.h:169:6
-    public static void FlecsPipelineImport(ecs_world_t* world)
-    {
-        _virtualTable.FlecsPipelineImport(world);
-    }
+    [DllImport("flecs")]
+    public static extern void FlecsPipelineImport(ecs_world_t* world);
 
     // Function @ pipeline.h:155:6
-    public static void ecs_set_threads(ecs_world_t* world, int threads)
-    {
-        _virtualTable.ecs_set_threads(world, threads);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_threads(ecs_world_t* world, int threads);
 
     // Function @ pipeline.h:141:6
-    public static void ecs_deactivate_systems(ecs_world_t* world)
-    {
-        _virtualTable.ecs_deactivate_systems(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_deactivate_systems(ecs_world_t* world);
 
     // Function @ pipeline.h:125:6
-    public static void ecs_pipeline_run(ecs_world_t* world, ecs_entity_t pipeline, float delta_time)
-    {
-        _virtualTable.ecs_pipeline_run(world, pipeline, delta_time);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_pipeline_run(ecs_world_t* world, ecs_entity_t pipeline, float delta_time);
 
     // Function @ pipeline.h:103:6
-    public static void ecs_reset_clock(ecs_world_t* world)
-    {
-        _virtualTable.ecs_reset_clock(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_reset_clock(ecs_world_t* world);
 
     // Function @ pipeline.h:93:6
-    public static void ecs_set_time_scale(ecs_world_t* world, float scale)
-    {
-        _virtualTable.ecs_set_time_scale(world, scale);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_time_scale(ecs_world_t* world, float scale);
 
     // Function @ pipeline.h:82:6
-    public static CBool ecs_progress(ecs_world_t* world, float delta_time)
-    {
-        return _virtualTable.ecs_progress(world, delta_time);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_progress(ecs_world_t* world, float delta_time);
 
     // Function @ pipeline.h:60:14
-    public static ecs_entity_t ecs_get_pipeline(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_get_pipeline(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_get_pipeline(ecs_world_t* world);
 
     // Function @ pipeline.h:49:6
-    public static void ecs_set_pipeline(ecs_world_t* world, ecs_entity_t pipeline)
-    {
-        _virtualTable.ecs_set_pipeline(world, pipeline);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_pipeline(ecs_world_t* world, ecs_entity_t pipeline);
 
     // Function @ system.h:321:6
-    public static void FlecsSystemImport(ecs_world_t* world)
-    {
-        _virtualTable.FlecsSystemImport(world);
-    }
+    [DllImport("flecs")]
+    public static extern void FlecsSystemImport(ecs_world_t* world);
 
     // Function @ system.h:304:6
-    public static CBool ecs_dbg_match_entity(ecs_world_t* world, ecs_entity_t entity, ecs_entity_t system, ecs_match_failure_t* failure_info_out)
-    {
-        return _virtualTable.ecs_dbg_match_entity(world, entity, system, failure_info_out);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_dbg_match_entity(ecs_world_t* world, ecs_entity_t entity, ecs_entity_t system, ecs_match_failure_t* failure_info_out);
 
     // Function @ system.h:298:12
-    public static ecs_type_t ecs_dbg_get_column_type(ecs_world_t* world, ecs_entity_t system, int column_index)
-    {
-        return _virtualTable.ecs_dbg_get_column_type(world, system, column_index);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_dbg_get_column_type(ecs_world_t* world, ecs_entity_t system, int column_index);
 
     // Function @ system.h:292:14
-    public static ecs_table_t* ecs_dbg_get_inactive_table(ecs_world_t* world, ecs_dbg_system_t* dbg, int index)
-    {
-        return _virtualTable.ecs_dbg_get_inactive_table(world, dbg, index);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_table_t* ecs_dbg_get_inactive_table(ecs_world_t* world, ecs_dbg_system_t* dbg, int index);
 
     // Function @ system.h:286:14
-    public static ecs_table_t* ecs_dbg_get_active_table(ecs_world_t* world, ecs_dbg_system_t* dbg, int index)
-    {
-        return _virtualTable.ecs_dbg_get_active_table(world, dbg, index);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_table_t* ecs_dbg_get_active_table(ecs_world_t* world, ecs_dbg_system_t* dbg, int index);
 
     // Function @ system.h:280:5
-    public static int ecs_dbg_system(ecs_world_t* world, ecs_entity_t system, ecs_dbg_system_t* dbg_out)
-    {
-        return _virtualTable.ecs_dbg_system(world, system, dbg_out);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_dbg_system(ecs_world_t* world, ecs_entity_t system, ecs_dbg_system_t* dbg_out);
 
     // Function @ system.h:262:7
-    public static void* ecs_get_system_ctx(ecs_world_t* world, ecs_entity_t system)
-    {
-        return _virtualTable.ecs_get_system_ctx(world, system);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_system_ctx(ecs_world_t* world, ecs_entity_t system);
 
     // Function @ system.h:249:14
-    public static ecs_query_t* ecs_get_query(ecs_world_t* world, ecs_entity_t system)
-    {
-        return _virtualTable.ecs_get_query(world, system);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_query_t* ecs_get_query(ecs_world_t* world, ecs_entity_t system);
 
     // Function @ system.h:230:14
-    public static ecs_entity_t ecs_run_w_filter(ecs_world_t* world, ecs_entity_t system, float delta_time, int offset, int limit, ecs_filter_t* filter, void* param)
-    {
-        return _virtualTable.ecs_run_w_filter(world, system, delta_time, offset, limit, filter, param);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_run_w_filter(ecs_world_t* world, ecs_entity_t system, float delta_time, int offset, int limit, ecs_filter_t* filter, void* param);
 
     // Function @ system.h:200:14
-    public static ecs_entity_t ecs_run_worker(ecs_world_t* world, ecs_entity_t system, int stage_current, int stage_count, float delta_time, void* param)
-    {
-        return _virtualTable.ecs_run_worker(world, system, stage_current, stage_count, delta_time, param);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_run_worker(ecs_world_t* world, ecs_entity_t system, int stage_current, int stage_count, float delta_time, void* param);
 
     // Function @ system.h:183:14
-    public static ecs_entity_t ecs_run(ecs_world_t* world, ecs_entity_t system, float delta_time, void* param)
-    {
-        return _virtualTable.ecs_run(world, system, delta_time, param);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_run(ecs_world_t* world, ecs_entity_t system, float delta_time, void* param);
 
     // Function @ system.h:125:14
-    public static ecs_entity_t ecs_system_init(ecs_world_t* world, ecs_system_desc_t* desc)
-    {
-        return _virtualTable.ecs_system_init(world, desc);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_system_init(ecs_world_t* world, ecs_system_desc_t* desc);
 
     // Function @ module.h:69:14
-    public static ecs_entity_t ecs_import_from_library(ecs_world_t* world, CString library_name, CString module_name)
-    {
-        return _virtualTable.ecs_import_from_library(world, library_name, module_name);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_import_from_library(ecs_world_t* world, CString library_name, CString module_name);
 
     // Function @ module.h:42:14
-    public static ecs_entity_t ecs_import(ecs_world_t* world, ecs_module_action_t module, CString module_name, void* handles_out, ulong handles_size)
-    {
-        return _virtualTable.ecs_import(world, module, module_name, handles_out, handles_size);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_import(ecs_world_t* world, ecs_module_action_t module, CString module_name, void* handles_out, ulong handles_size);
 
     // Function @ flecs.h:3609:9
-    public static int ecs_table_count(ecs_table_t* table)
-    {
-        return _virtualTable.ecs_table_count(table);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_table_count(ecs_table_t* table);
 
     // Function @ flecs.h:3593:14
-    public static ecs_record_t ecs_table_insert(ecs_world_t* world, ecs_table_t* table, ecs_entity_t entity, ecs_record_t* @record)
-    {
-        return _virtualTable.ecs_table_insert(world, table, entity, @record);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_record_t ecs_table_insert(ecs_world_t* world, ecs_table_t* table, ecs_entity_t entity, ecs_record_t* @record);
 
     // Function @ flecs.h:3567:12
-    public static ecs_type_t ecs_table_get_type(ecs_table_t* table)
-    {
-        return _virtualTable.ecs_table_get_type(table);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_table_get_type(ecs_table_t* table);
 
     // Function @ flecs.h:3557:14
-    public static ecs_table_t* ecs_table_from_type(ecs_world_t* world, ecs_type_t type)
-    {
-        return _virtualTable.ecs_table_from_type(world, type);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_table_t* ecs_table_from_type(ecs_world_t* world, ecs_type_t type);
 
     // Function @ flecs.h:3545:14
-    public static ecs_table_t* ecs_table_from_str(ecs_world_t* world, CString type)
-    {
-        return _virtualTable.ecs_table_from_str(world, type);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_table_t* ecs_table_from_str(ecs_world_t* world, CString type);
 
     // Function @ flecs.h:3523:6
-    public static CBool ecs_stage_is_async(ecs_world_t* stage)
-    {
-        return _virtualTable.ecs_stage_is_async(stage);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_stage_is_async(ecs_world_t* stage);
 
     // Function @ flecs.h:3513:6
-    public static void ecs_async_stage_free(ecs_world_t* stage)
-    {
-        _virtualTable.ecs_async_stage_free(stage);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_async_stage_free(ecs_world_t* stage);
 
     // Function @ flecs.h:3503:14
-    public static ecs_world_t* ecs_async_stage_new(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_async_stage_new(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_world_t* ecs_async_stage_new(ecs_world_t* world);
 
     // Function @ flecs.h:3481:6
-    public static CBool ecs_stage_is_readonly(ecs_world_t* stage)
-    {
-        return _virtualTable.ecs_stage_is_readonly(stage);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_stage_is_readonly(ecs_world_t* stage);
 
     // Function @ flecs.h:3470:20
-    public static ecs_world_t* ecs_get_world(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_get_world(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_world_t* ecs_get_world(ecs_world_t* world);
 
     // Function @ flecs.h:3461:14
-    public static ecs_world_t* ecs_get_stage(ecs_world_t* world, int stage_id)
-    {
-        return _virtualTable.ecs_get_stage(world, stage_id);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_world_t* ecs_get_stage(ecs_world_t* world, int stage_id);
 
     // Function @ flecs.h:3442:9
-    public static int ecs_get_stage_id(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_get_stage_id(world);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_get_stage_id(ecs_world_t* world);
 
     // Function @ flecs.h:3431:9
-    public static int ecs_get_stage_count(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_get_stage_count(world);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_get_stage_count(ecs_world_t* world);
 
     // Function @ flecs.h:3420:6
-    public static void ecs_set_stages(ecs_world_t* world, int stages)
-    {
-        _virtualTable.ecs_set_stages(world, stages);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_stages(ecs_world_t* world, int stages);
 
     // Function @ flecs.h:3402:6
-    public static void ecs_set_automerge(ecs_world_t* world, CBool automerge)
-    {
-        _virtualTable.ecs_set_automerge(world, automerge);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_automerge(ecs_world_t* world, CBool automerge);
 
     // Function @ flecs.h:3382:6
-    public static CBool ecs_defer_end(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_defer_end(world);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_defer_end(ecs_world_t* world);
 
     // Function @ flecs.h:3370:6
-    public static CBool ecs_defer_begin(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_defer_begin(world);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_defer_begin(ecs_world_t* world);
 
     // Function @ flecs.h:3357:6
-    public static void ecs_merge(ecs_world_t* world)
-    {
-        _virtualTable.ecs_merge(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_merge(ecs_world_t* world);
 
     // Function @ flecs.h:3343:6
-    public static void ecs_staging_end(ecs_world_t* world)
-    {
-        _virtualTable.ecs_staging_end(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_staging_end(ecs_world_t* world);
 
     // Function @ flecs.h:3330:6
-    public static CBool ecs_staging_begin(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_staging_begin(world);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_staging_begin(ecs_world_t* world);
 
     // Function @ flecs.h:3307:6
-    public static void ecs_frame_end(ecs_world_t* world)
-    {
-        _virtualTable.ecs_frame_end(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_frame_end(ecs_world_t* world);
 
     // Function @ flecs.h:3296:13
-    public static float ecs_frame_begin(ecs_world_t* world, float delta_time)
-    {
-        return _virtualTable.ecs_frame_begin(world, delta_time);
-    }
+    [DllImport("flecs")]
+    public static extern float ecs_frame_begin(ecs_world_t* world, float delta_time);
 
     // Function @ flecs.h:3265:8
-    public static ulong ecs_iter_column_size(ecs_iter_t* it, int index)
-    {
-        return _virtualTable.ecs_iter_column_size(it, index);
-    }
+    [DllImport("flecs")]
+    public static extern ulong ecs_iter_column_size(ecs_iter_t* it, int index);
 
     // Function @ flecs.h:3247:7
-    public static void* ecs_iter_column_w_size(ecs_iter_t* it, ulong size, int index)
-    {
-        return _virtualTable.ecs_iter_column_w_size(it, size, index);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_iter_column_w_size(ecs_iter_t* it, ulong size, int index);
 
     // Function @ flecs.h:3215:9
-    public static int ecs_iter_find_column(ecs_iter_t* it, ecs_id_t id)
-    {
-        return _virtualTable.ecs_iter_find_column(it, id);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_iter_find_column(ecs_iter_t* it, ecs_id_t id);
 
     // Function @ flecs.h:3192:12
-    public static ecs_type_t ecs_iter_type(ecs_iter_t* it)
-    {
-        return _virtualTable.ecs_iter_type(it);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_iter_type(ecs_iter_t* it);
 
     // Function @ flecs.h:3180:6
-    public static CBool ecs_term_is_owned(ecs_iter_t* it, int index)
-    {
-        return _virtualTable.ecs_term_is_owned(it, index);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_term_is_owned(ecs_iter_t* it, int index);
 
     // Function @ flecs.h:3166:6
-    public static CBool ecs_term_is_readonly(ecs_iter_t* it, int index)
-    {
-        return _virtualTable.ecs_term_is_readonly(it, index);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_term_is_readonly(ecs_iter_t* it, int index);
 
     // Function @ flecs.h:3153:8
-    public static ulong ecs_term_size(ecs_iter_t* it, int index)
-    {
-        return _virtualTable.ecs_term_size(it, index);
-    }
+    [DllImport("flecs")]
+    public static extern ulong ecs_term_size(ecs_iter_t* it, int index);
 
     // Function @ flecs.h:3141:14
-    public static ecs_entity_t ecs_term_source(ecs_iter_t* it, int index)
-    {
-        return _virtualTable.ecs_term_source(it, index);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_term_source(ecs_iter_t* it, int index);
 
     // Function @ flecs.h:3123:10
-    public static ecs_id_t ecs_term_id(ecs_iter_t* it, int index)
-    {
-        return _virtualTable.ecs_term_id(it, index);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_id_t ecs_term_id(ecs_iter_t* it, int index);
 
     // Function @ flecs.h:3104:7
-    public static void* ecs_term_w_size(ecs_iter_t* it, ulong size, int index)
-    {
-        return _virtualTable.ecs_term_w_size(it, size, index);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_term_w_size(ecs_iter_t* it, ulong size, int index);
 
     // Function @ flecs.h:3068:7
-    public static void* ecs_get_trigger_ctx(ecs_world_t* world, ecs_entity_t trigger)
-    {
-        return _virtualTable.ecs_get_trigger_ctx(world, trigger);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_trigger_ctx(ecs_world_t* world, ecs_entity_t trigger);
 
     // Function @ flecs.h:3055:14
-    public static ecs_entity_t ecs_trigger_init(ecs_world_t* world, ecs_trigger_desc_t* desc)
-    {
-        return _virtualTable.ecs_trigger_init(world, desc);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_trigger_init(ecs_world_t* world, ecs_trigger_desc_t* desc);
 
     // Function @ flecs.h:3030:6
-    public static CBool ecs_query_orphaned(ecs_query_t* query)
-    {
-        return _virtualTable.ecs_query_orphaned(query);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_query_orphaned(ecs_query_t* query);
 
     // Function @ flecs.h:3018:6
-    public static CBool ecs_query_changed(ecs_query_t* query)
-    {
-        return _virtualTable.ecs_query_changed(query);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_query_changed(ecs_query_t* query);
 
     // Function @ flecs.h:3002:6
-    public static CBool ecs_query_next_worker(ecs_iter_t* it, int stage_current, int stage_count)
-    {
-        return _virtualTable.ecs_query_next_worker(it, stage_current, stage_count);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_query_next_worker(ecs_iter_t* it, int stage_current, int stage_count);
 
     // Function @ flecs.h:2982:6
-    public static CBool ecs_query_next_w_filter(ecs_iter_t* iter, ecs_filter_t* filter)
-    {
-        return _virtualTable.ecs_query_next_w_filter(iter, filter);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_query_next_w_filter(ecs_iter_t* iter, ecs_filter_t* filter);
 
     // Function @ flecs.h:2970:6
-    public static CBool ecs_query_next(ecs_iter_t* iter)
-    {
-        return _virtualTable.ecs_query_next(iter);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_query_next(ecs_iter_t* iter);
 
     // Function @ flecs.h:2955:12
-    public static ecs_iter_t ecs_query_iter_page(ecs_query_t* query, int offset, int limit)
-    {
-        return _virtualTable.ecs_query_iter_page(query, offset, limit);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_iter_t ecs_query_iter_page(ecs_query_t* query, int offset, int limit);
 
     // Function @ flecs.h:2942:12
-    public static ecs_iter_t ecs_query_iter(ecs_query_t* query)
-    {
-        return _virtualTable.ecs_query_iter(query);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_iter_t ecs_query_iter(ecs_query_t* query);
 
     // Function @ flecs.h:2912:6
-    public static void ecs_query_fini(ecs_query_t* query)
-    {
-        _virtualTable.ecs_query_fini(query);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_query_fini(ecs_query_t* query);
 
     // Function @ flecs.h:2900:14
-    public static ecs_query_t* ecs_query_init(ecs_world_t* world, ecs_query_desc_t* desc)
-    {
-        return _virtualTable.ecs_query_init(world, desc);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_query_t* ecs_query_init(ecs_world_t* world, ecs_query_desc_t* desc);
 
     // Function @ flecs.h:2854:6
-    public static CBool ecs_filter_next(ecs_iter_t* iter)
-    {
-        return _virtualTable.ecs_filter_next(iter);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_filter_next(ecs_iter_t* iter);
 
     // Function @ flecs.h:2840:12
-    public static ecs_iter_t ecs_filter_iter(ecs_world_t* world, ecs_filter_t* filter)
-    {
-        return _virtualTable.ecs_filter_iter(world, filter);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_iter_t ecs_filter_iter(ecs_world_t* world, ecs_filter_t* filter);
 
     // Function @ flecs.h:2825:6
-    public static CBool ecs_filter_match_entity(ecs_world_t* world, ecs_filter_t* filter, ecs_entity_t e)
-    {
-        return _virtualTable.ecs_filter_match_entity(world, filter, e);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_filter_match_entity(ecs_world_t* world, ecs_filter_t* filter, ecs_entity_t e);
 
     // Function @ flecs.h:2805:7
-    public static CString ecs_filter_str(ecs_world_t* world, ecs_filter_t* filter)
-    {
-        return _virtualTable.ecs_filter_str(world, filter);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_filter_str(ecs_world_t* world, ecs_filter_t* filter);
 
     // Function @ flecs.h:2796:5
-    public static int ecs_filter_finalize(ecs_world_t* world, ecs_filter_t* filter)
-    {
-        return _virtualTable.ecs_filter_finalize(world, filter);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_filter_finalize(ecs_world_t* world, ecs_filter_t* filter);
 
     // Function @ flecs.h:2779:6
-    public static void ecs_filter_fini(ecs_filter_t* filter)
-    {
-        _virtualTable.ecs_filter_fini(filter);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_filter_fini(ecs_filter_t* filter);
 
     // Function @ flecs.h:2768:5
-    public static int ecs_filter_init(ecs_world_t* world, ecs_filter_t* filter_out, ecs_filter_desc_t* desc)
-    {
-        return _virtualTable.ecs_filter_init(world, filter_out, desc);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_filter_init(ecs_world_t* world, ecs_filter_t* filter_out, ecs_filter_desc_t* desc);
 
     // Function @ flecs.h:2735:6
-    public static CBool ecs_id_match(ecs_id_t id, ecs_id_t pattern)
-    {
-        return _virtualTable.ecs_id_match(id, pattern);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_id_match(ecs_id_t id, ecs_id_t pattern);
 
     // Function @ flecs.h:2724:6
-    public static void ecs_term_fini(ecs_term_t* term)
-    {
-        _virtualTable.ecs_term_fini(term);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_term_fini(ecs_term_t* term);
 
     // Function @ flecs.h:2714:12
-    public static ecs_term_t ecs_term_move(ecs_term_t* src)
-    {
-        return _virtualTable.ecs_term_move(src);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_term_t ecs_term_move(ecs_term_t* src);
 
     // Function @ flecs.h:2700:12
-    public static ecs_term_t ecs_term_copy(ecs_term_t* src)
-    {
-        return _virtualTable.ecs_term_copy(src);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_term_t ecs_term_copy(ecs_term_t* src);
 
     // Function @ flecs.h:2685:5
-    public static int ecs_term_finalize(ecs_world_t* world, CString name, CString expr, ecs_term_t* term)
-    {
-        return _virtualTable.ecs_term_finalize(world, name, expr, term);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_term_finalize(ecs_world_t* world, CString name, CString expr, ecs_term_t* term);
 
     // Function @ flecs.h:2661:6
-    public static CBool ecs_term_is_trivial(ecs_term_t* term)
-    {
-        return _virtualTable.ecs_term_is_trivial(term);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_term_is_trivial(ecs_term_t* term);
 
     // Function @ flecs.h:2634:6
-    public static CBool ecs_term_is_set(ecs_term_t* term)
-    {
-        return _virtualTable.ecs_term_is_set(term);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_term_is_set(ecs_term_t* term);
 
     // Function @ flecs.h:2610:13
-    public static CString ecs_set_name_prefix(ecs_world_t* world, CString prefix)
-    {
-        return _virtualTable.ecs_set_name_prefix(world, prefix);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_set_name_prefix(ecs_world_t* world, CString prefix);
 
     // Function @ flecs.h:2597:14
-    public static ecs_entity_t ecs_get_scope(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_get_scope(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_get_scope(ecs_world_t* world);
 
     // Function @ flecs.h:2585:14
-    public static ecs_entity_t ecs_set_scope(ecs_world_t* world, ecs_entity_t scope)
-    {
-        return _virtualTable.ecs_set_scope(world, scope);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_set_scope(ecs_world_t* world, ecs_entity_t scope);
 
     // Function @ flecs.h:2570:6
-    public static CBool ecs_scope_next(ecs_iter_t* it)
-    {
-        return _virtualTable.ecs_scope_next(it);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_scope_next(ecs_iter_t* it);
 
     // Function @ flecs.h:2556:12
-    public static ecs_iter_t ecs_scope_iter_w_filter(ecs_world_t* world, ecs_entity_t parent, ecs_filter_t* filter)
-    {
-        return _virtualTable.ecs_scope_iter_w_filter(world, parent, filter);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_iter_t ecs_scope_iter_w_filter(ecs_world_t* world, ecs_entity_t parent, ecs_filter_t* filter);
 
     // Function @ flecs.h:2544:12
-    public static ecs_iter_t ecs_scope_iter(ecs_world_t* world, ecs_entity_t parent)
-    {
-        return _virtualTable.ecs_scope_iter(world, parent);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_iter_t ecs_scope_iter(ecs_world_t* world, ecs_entity_t parent);
 
     // Function @ flecs.h:2531:9
-    public static int ecs_get_child_count(ecs_world_t* world, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_get_child_count(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_get_child_count(ecs_world_t* world, ecs_entity_t entity);
 
     // Function @ flecs.h:2484:14
-    public static ecs_entity_t ecs_add_path_w_sep(ecs_world_t* world, ecs_entity_t entity, ecs_entity_t parent, CString path, CString sep, CString prefix)
-    {
-        return _virtualTable.ecs_add_path_w_sep(world, entity, parent, path, sep, prefix);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_add_path_w_sep(ecs_world_t* world, ecs_entity_t entity, ecs_entity_t parent, CString path, CString sep, CString prefix);
 
     // Function @ flecs.h:2440:14
-    public static ecs_entity_t ecs_new_from_path_w_sep(ecs_world_t* world, ecs_entity_t parent, CString path, CString sep, CString prefix)
-    {
-        return _virtualTable.ecs_new_from_path_w_sep(world, parent, path, sep, prefix);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_new_from_path_w_sep(ecs_world_t* world, ecs_entity_t parent, CString path, CString sep, CString prefix);
 
     // Function @ flecs.h:2391:7
-    public static CString ecs_get_path_w_sep(ecs_world_t* world, ecs_entity_t parent, ecs_entity_t child, ecs_entity_t component, CString sep, CString prefix)
-    {
-        return _virtualTable.ecs_get_path_w_sep(world, parent, child, component, sep, prefix);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_get_path_w_sep(ecs_world_t* world, ecs_entity_t parent, ecs_entity_t child, ecs_entity_t component, CString sep, CString prefix);
 
     // Function @ flecs.h:2359:6
-    public static void ecs_use(ecs_world_t* world, ecs_entity_t entity, CString name)
-    {
-        _virtualTable.ecs_use(world, entity, name);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_use(ecs_world_t* world, ecs_entity_t entity, CString name);
 
     // Function @ flecs.h:2353:14
-    public static ecs_entity_t ecs_lookup_symbol(ecs_world_t* world, CString name)
-    {
-        return _virtualTable.ecs_lookup_symbol(world, name);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_lookup_symbol(ecs_world_t* world, CString name);
 
     // Function @ flecs.h:2312:14
-    public static ecs_entity_t ecs_lookup_path_w_sep(ecs_world_t* world, ecs_entity_t parent, CString path, CString sep, CString prefix, CBool recursive)
-    {
-        return _virtualTable.ecs_lookup_path_w_sep(world, parent, path, sep, prefix, recursive);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_lookup_path_w_sep(ecs_world_t* world, ecs_entity_t parent, CString path, CString sep, CString prefix, CBool recursive);
 
     // Function @ flecs.h:2288:14
-    public static ecs_entity_t ecs_lookup_child(ecs_world_t* world, ecs_entity_t parent, CString name)
-    {
-        return _virtualTable.ecs_lookup_child(world, parent, name);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_lookup_child(ecs_world_t* world, ecs_entity_t parent, CString name);
 
     // Function @ flecs.h:2274:14
-    public static ecs_entity_t ecs_lookup(ecs_world_t* world, CString name)
-    {
-        return _virtualTable.ecs_lookup(world, name);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_lookup(ecs_world_t* world, CString name);
 
     // Function @ flecs.h:2253:9
-    public static int ecs_count_filter(ecs_world_t* world, ecs_filter_t* filter)
-    {
-        return _virtualTable.ecs_count_filter(world, filter);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_count_filter(ecs_world_t* world, ecs_filter_t* filter);
 
     // Function @ flecs.h:2231:9
-    public static int ecs_count_id(ecs_world_t* world, ecs_id_t entity)
-    {
-        return _virtualTable.ecs_count_id(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_count_id(ecs_world_t* world, ecs_id_t entity);
 
     // Function @ flecs.h:2218:6
-    public static void ecs_enable(ecs_world_t* world, ecs_entity_t entity, CBool enabled)
-    {
-        _virtualTable.ecs_enable(world, entity, enabled);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_enable(ecs_world_t* world, ecs_entity_t entity, CBool enabled);
 
     // Function @ flecs.h:2189:14
-    public static ecs_entity_t ecs_get_object_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_entity_t rel, ecs_id_t id)
-    {
-        return _virtualTable.ecs_get_object_w_id(world, entity, rel, id);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_get_object_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_entity_t rel, ecs_id_t id);
 
     // Function @ flecs.h:2171:8
-    public static ulong ecs_id_str(ecs_world_t* world, ecs_id_t entity, CString buffer, ulong buffer_len)
-    {
-        return _virtualTable.ecs_id_str(world, entity, buffer, buffer_len);
-    }
+    [DllImport("flecs")]
+    public static extern ulong ecs_id_str(ecs_world_t* world, ecs_id_t entity, CString buffer, ulong buffer_len);
 
     // Function @ flecs.h:2158:13
-    public static CString ecs_role_str(ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_role_str(entity);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_role_str(ecs_entity_t entity);
 
     // Function @ flecs.h:2146:13
-    public static CString ecs_get_name(ecs_world_t* world, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_get_name(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_get_name(ecs_world_t* world, ecs_entity_t entity);
 
     // Function @ flecs.h:2134:14
-    public static ecs_entity_t ecs_get_typeid(ecs_world_t* world, ecs_entity_t e)
-    {
-        return _virtualTable.ecs_get_typeid(world, e);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_get_typeid(ecs_world_t* world, ecs_entity_t e);
 
     // Function @ flecs.h:2123:12
-    public static ecs_type_t ecs_get_type(ecs_world_t* world, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_get_type(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_get_type(ecs_world_t* world, ecs_entity_t entity);
 
     // Function @ flecs.h:2112:6
-    public static CBool ecs_exists(ecs_world_t* world, ecs_entity_t e)
-    {
-        return _virtualTable.ecs_exists(world, e);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_exists(ecs_world_t* world, ecs_entity_t e);
 
     // Function @ flecs.h:2100:6
-    public static void ecs_ensure(ecs_world_t* world, ecs_entity_t e)
-    {
-        _virtualTable.ecs_ensure(world, e);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_ensure(ecs_world_t* world, ecs_entity_t e);
 
     // Function @ flecs.h:2072:14
-    public static ecs_entity_t ecs_get_alive(ecs_world_t* world, ecs_entity_t e)
-    {
-        return _virtualTable.ecs_get_alive(world, e);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_get_alive(ecs_world_t* world, ecs_entity_t e);
 
     // Function @ flecs.h:2051:6
-    public static CBool ecs_is_alive(ecs_world_t* world, ecs_entity_t e)
-    {
-        return _virtualTable.ecs_is_alive(world, e);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_is_alive(ecs_world_t* world, ecs_entity_t e);
 
     // Function @ flecs.h:2040:6
-    public static CBool ecs_is_valid(ecs_world_t* world, ecs_entity_t e)
-    {
-        return _virtualTable.ecs_is_valid(world, e);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_is_valid(ecs_world_t* world, ecs_entity_t e);
 
     // Function @ flecs.h:1989:6
-    public static CBool ecs_has_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_has_id(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_has_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ flecs.h:1914:14
-    public static ecs_entity_t ecs_set_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, ulong size, void* ptr)
-    {
-        return _virtualTable.ecs_set_id(world, entity, id, size, ptr);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_set_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, ulong size, void* ptr);
 
     // Function @ flecs.h:1885:6
-    public static void ecs_modified_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        _virtualTable.ecs_modified_w_id(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_modified_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ flecs.h:1856:7
-    public static void* ecs_get_mut_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, CBool* is_added)
-    {
-        return _virtualTable.ecs_get_mut_w_id(world, entity, id, is_added);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_mut_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, CBool* is_added);
 
     // Function @ flecs.h:1828:14
-    public static ecs_entity_t ecs_get_case(ecs_world_t* world, ecs_entity_t e, ecs_entity_t sw)
-    {
-        return _virtualTable.ecs_get_case(world, e, sw);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_get_case(ecs_world_t* world, ecs_entity_t e, ecs_entity_t sw);
 
     // Function @ flecs.h:1800:13
-    public static void* ecs_get_ref_w_id(ecs_world_t* world, ecs_ref_t* @ref, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_get_ref_w_id(world, @ref, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_ref_w_id(ecs_world_t* world, ecs_ref_t* @ref, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ flecs.h:1770:13
-    public static void* ecs_get_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_get_id(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ flecs.h:1748:6
-    public static void ecs_delete_children(ecs_world_t* world, ecs_entity_t parent)
-    {
-        _virtualTable.ecs_delete_children(world, parent);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_delete_children(ecs_world_t* world, ecs_entity_t parent);
 
     // Function @ flecs.h:1735:6
-    public static void ecs_delete(ecs_world_t* world, ecs_entity_t entity)
-    {
-        _virtualTable.ecs_delete(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_delete(ecs_world_t* world, ecs_entity_t entity);
 
     // Function @ flecs.h:1721:6
-    public static void ecs_clear(ecs_world_t* world, ecs_entity_t entity)
-    {
-        _virtualTable.ecs_clear(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_clear(ecs_world_t* world, ecs_entity_t entity);
 
     // Function @ flecs.h:1522:10
-    public static ecs_id_t ecs_make_pair(ecs_entity_t relation, ecs_entity_t @object)
-    {
-        return _virtualTable.ecs_make_pair(relation, @object);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_id_t ecs_make_pair(ecs_entity_t relation, ecs_entity_t @object);
 
     // Function @ flecs.h:1498:6
-    public static CBool ecs_is_component_enabled_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_is_component_enabled_w_id(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_is_component_enabled_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ flecs.h:1478:6
-    public static void ecs_enable_component_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, CBool enable)
-    {
-        _virtualTable.ecs_enable_component_w_id(world, entity, id, enable);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_enable_component_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, CBool enable);
 
     // Function @ flecs.h:1434:6
-    public static void ecs_remove_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        _virtualTable.ecs_remove_id(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_remove_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ flecs.h:1402:6
-    public static void ecs_add_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        _virtualTable.ecs_add_id(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_add_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ flecs.h:1379:14
-    public static ecs_entity_t ecs_clone(ecs_world_t* world, ecs_entity_t dst, ecs_entity_t src, CBool copy_value)
-    {
-        return _virtualTable.ecs_clone(world, dst, src, copy_value);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_clone(ecs_world_t* world, ecs_entity_t dst, ecs_entity_t src, CBool copy_value);
 
     // Function @ flecs.h:1347:21
-    public static ecs_entity_t* ecs_bulk_new_w_data(ecs_world_t* world, int count, ecs_entities_t* component_ids, void* data)
-    {
-        return _virtualTable.ecs_bulk_new_w_data(world, count, component_ids, data);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t* ecs_bulk_new_w_data(ecs_world_t* world, int count, ecs_entities_t* component_ids, void* data);
 
     // Function @ flecs.h:1329:21
-    public static ecs_entity_t* ecs_bulk_new_w_id(ecs_world_t* world, ecs_id_t id, int count)
-    {
-        return _virtualTable.ecs_bulk_new_w_id(world, id, count);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t* ecs_bulk_new_w_id(ecs_world_t* world, ecs_id_t id, int count);
 
     // Function @ flecs.h:1315:14
-    public static ecs_entity_t ecs_type_init(ecs_world_t* world, ecs_type_desc_t* desc)
-    {
-        return _virtualTable.ecs_type_init(world, desc);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_type_init(ecs_world_t* world, ecs_type_desc_t* desc);
 
     // Function @ flecs.h:1292:14
-    public static ecs_entity_t ecs_component_init(ecs_world_t* world, ecs_component_desc_t* desc)
-    {
-        return _virtualTable.ecs_component_init(world, desc);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_component_init(ecs_world_t* world, ecs_component_desc_t* desc);
 
     // Function @ flecs.h:1274:14
-    public static ecs_entity_t ecs_entity_init(ecs_world_t* world, ecs_entity_desc_t* desc)
-    {
-        return _virtualTable.ecs_entity_init(world, desc);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_entity_init(ecs_world_t* world, ecs_entity_desc_t* desc);
 
     // Function @ flecs.h:1238:14
-    public static ecs_entity_t ecs_new_w_id(ecs_world_t* world, ecs_id_t id)
-    {
-        return _virtualTable.ecs_new_w_id(world, id);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_new_w_id(ecs_world_t* world, ecs_id_t id);
 
     // Function @ flecs.h:1226:14
-    public static ecs_entity_t ecs_new_component_id(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_new_component_id(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_new_component_id(ecs_world_t* world);
 
     // Function @ flecs.h:1213:14
-    public static ecs_entity_t ecs_new_id(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_new_id(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_new_id(ecs_world_t* world);
 
     // Function @ flecs.h:1196:9
-    public static int ecs_get_threads(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_get_threads(world);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_get_threads(ecs_world_t* world);
 
     // Function @ flecs.h:1190:6
-    public static void ecs_set_target_fps(ecs_world_t* world, float fps)
-    {
-        _virtualTable.ecs_set_target_fps(world, fps);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_target_fps(ecs_world_t* world, float fps);
 
     // Function @ flecs.h:1170:16
-    public static void ecs_measure_system_time(ecs_world_t* world, CBool enable)
-    {
-        _virtualTable.ecs_measure_system_time(world, enable);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_measure_system_time(ecs_world_t* world, CBool enable);
 
     // Function @ flecs.h:1156:16
-    public static void ecs_measure_frame_time(ecs_world_t* world, CBool enable)
-    {
-        _virtualTable.ecs_measure_frame_time(world, enable);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_measure_frame_time(ecs_world_t* world, CBool enable);
 
     // Function @ flecs.h:1142:6
-    public static void ecs_tracing_enable(int level)
-    {
-        _virtualTable.ecs_tracing_enable(level);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_tracing_enable(int level);
 
     // Function @ flecs.h:1121:6
-    public static void ecs_end_wait(ecs_world_t* world)
-    {
-        _virtualTable.ecs_end_wait(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_end_wait(ecs_world_t* world);
 
     // Function @ flecs.h:1111:6
-    public static void ecs_begin_wait(ecs_world_t* world)
-    {
-        _virtualTable.ecs_begin_wait(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_begin_wait(ecs_world_t* world);
 
     // Function @ flecs.h:1097:6
-    public static void ecs_unlock(ecs_world_t* world)
-    {
-        _virtualTable.ecs_unlock(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_unlock(ecs_world_t* world);
 
     // Function @ flecs.h:1088:6
-    public static void ecs_lock(ecs_world_t* world)
-    {
-        _virtualTable.ecs_lock(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_lock(ecs_world_t* world);
 
     // Function @ flecs.h:1078:6
-    public static CBool ecs_enable_locking(ecs_world_t* world, CBool enable)
-    {
-        return _virtualTable.ecs_enable_locking(world, enable);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_enable_locking(ecs_world_t* world, CBool enable);
 
     // Function @ flecs.h:1057:6
-    public static CBool ecs_enable_range_check(ecs_world_t* world, CBool enable)
-    {
-        return _virtualTable.ecs_enable_range_check(world, enable);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_enable_range_check(ecs_world_t* world, CBool enable);
 
     // Function @ flecs.h:1041:6
-    public static void ecs_set_entity_range(ecs_world_t* world, ecs_entity_t id_start, ecs_entity_t id_end)
-    {
-        _virtualTable.ecs_set_entity_range(world, id_start, id_end);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_entity_range(ecs_world_t* world, ecs_entity_t id_start, ecs_entity_t id_end);
 
     // Function @ flecs.h:1021:6
-    public static void ecs_dim(ecs_world_t* world, int entity_count)
-    {
-        _virtualTable.ecs_dim(world, entity_count);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_dim(ecs_world_t* world, int entity_count);
 
     // Function @ flecs.h:1008:25
-    public static ecs_world_info_t* ecs_get_world_info(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_get_world_info(world);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_world_info_t* ecs_get_world_info(ecs_world_t* world);
 
     // Function @ flecs.h:998:7
-    public static void* ecs_get_context(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_get_context(world);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_context(ecs_world_t* world);
 
     // Function @ flecs.h:986:6
-    public static void ecs_set_context(ecs_world_t* world, void* ctx)
-    {
-        _virtualTable.ecs_set_context(world, ctx);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_context(ecs_world_t* world, void* ctx);
 
     // Function @ flecs.h:968:6
-    public static void ecs_set_component_actions_w_id(ecs_world_t* world, ecs_id_t id, EcsComponentLifecycle* actions)
-    {
-        _virtualTable.ecs_set_component_actions_w_id(world, id, actions);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_component_actions_w_id(ecs_world_t* world, ecs_id_t id, EcsComponentLifecycle* actions);
 
     // Function @ flecs.h:958:6
-    public static CBool ecs_should_quit(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_should_quit(world);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_should_quit(ecs_world_t* world);
 
     // Function @ flecs.h:950:6
-    public static void ecs_quit(ecs_world_t* world)
-    {
-        _virtualTable.ecs_quit(world);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_quit(ecs_world_t* world);
 
     // Function @ flecs.h:938:6
-    public static void ecs_run_post_frame(ecs_world_t* world, ecs_fini_action_t action, void* ctx)
-    {
-        _virtualTable.ecs_run_post_frame(world, action, ctx);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_run_post_frame(ecs_world_t* world, ecs_fini_action_t action, void* ctx);
 
     // Function @ flecs.h:925:6
-    public static void ecs_atfini(ecs_world_t* world, ecs_fini_action_t action, void* ctx)
-    {
-        _virtualTable.ecs_atfini(world, action, ctx);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_atfini(ecs_world_t* world, ecs_fini_action_t action, void* ctx);
 
     // Function @ flecs.h:914:5
-    public static int ecs_fini(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_fini(world);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_fini(ecs_world_t* world);
 
     // Function @ flecs.h:903:14
-    public static ecs_world_t* ecs_init_w_args(int argc, CString* argv)
-    {
-        return _virtualTable.ecs_init_w_args(argc, argv);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_world_t* ecs_init_w_args(int argc, CString* argv);
 
     // Function @ flecs.h:893:14
-    public static ecs_world_t* ecs_mini()
-    {
-        return _virtualTable.ecs_mini();
-    }
+    [DllImport("flecs")]
+    public static extern ecs_world_t* ecs_mini();
 
     // Function @ flecs.h:886:14
-    public static ecs_world_t* ecs_init()
-    {
-        return _virtualTable.ecs_init();
-    }
+    [DllImport("flecs")]
+    public static extern ecs_world_t* ecs_init();
 
     // Function @ deprecated.h:550:6
-    public static void ecs_query_group_by(ecs_world_t* world, ecs_query_t* query, ecs_entity_t component, ecs_rank_type_action_t rank_action)
-    {
-        _virtualTable.ecs_query_group_by(world, query, component, rank_action);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_query_group_by(ecs_world_t* world, ecs_query_t* query, ecs_entity_t component, ecs_rank_type_action_t rank_action);
 
     // Function @ deprecated.h:542:6
-    public static void ecs_query_order_by(ecs_world_t* world, ecs_query_t* query, ecs_entity_t component, ecs_compare_action_t compare)
-    {
-        _virtualTable.ecs_query_order_by(world, query, component, compare);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_query_order_by(ecs_world_t* world, ecs_query_t* query, ecs_entity_t component, ecs_compare_action_t compare);
 
     // Function @ deprecated.h:537:6
-    public static void ecs_query_free(ecs_query_t* query)
-    {
-        _virtualTable.ecs_query_free(query);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_query_free(ecs_query_t* query);
 
     // Function @ deprecated.h:530:14
-    public static ecs_query_t* ecs_subquery_new(ecs_world_t* world, ecs_query_t* parent, CString sig)
-    {
-        return _virtualTable.ecs_subquery_new(world, parent, sig);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_query_t* ecs_subquery_new(ecs_world_t* world, ecs_query_t* parent, CString sig);
 
     // Function @ deprecated.h:524:14
-    public static ecs_query_t* ecs_query_new(ecs_world_t* world, CString sig)
-    {
-        return _virtualTable.ecs_query_new(world, sig);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_query_t* ecs_query_new(ecs_world_t* world, CString sig);
 
     // Function @ deprecated.h:516:14
-    public static ecs_entity_t ecs_set_rate_filter(ecs_world_t* world, ecs_entity_t filter, int rate, ecs_entity_t source)
-    {
-        return _virtualTable.ecs_set_rate_filter(world, filter, rate, source);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_set_rate_filter(ecs_world_t* world, ecs_entity_t filter, int rate, ecs_entity_t source);
 
     // Function @ deprecated.h:510:9
-    public static int ecs_table_component_index(ecs_iter_t* it, ecs_entity_t component)
-    {
-        return _virtualTable.ecs_table_component_index(it, component);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_table_component_index(ecs_iter_t* it, ecs_entity_t component);
 
     // Function @ deprecated.h:504:8
-    public static ulong ecs_table_column_size(ecs_iter_t* it, int column)
-    {
-        return _virtualTable.ecs_table_column_size(it, column);
-    }
+    [DllImport("flecs")]
+    public static extern ulong ecs_table_column_size(ecs_iter_t* it, int column);
 
     // Function @ deprecated.h:498:7
-    public static void* ecs_table_column(ecs_iter_t* it, int column)
-    {
-        return _virtualTable.ecs_table_column(it, column);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_table_column(ecs_iter_t* it, int column);
 
     // Function @ deprecated.h:492:6
-    public static CBool ecs_is_owned(ecs_iter_t* it, int column)
-    {
-        return _virtualTable.ecs_is_owned(it, column);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_is_owned(ecs_iter_t* it, int column);
 
     // Function @ deprecated.h:486:6
-    public static CBool ecs_is_readonly(ecs_iter_t* it, int column)
-    {
-        return _virtualTable.ecs_is_readonly(it, column);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_is_readonly(ecs_iter_t* it, int column);
 
     // Function @ deprecated.h:480:8
-    public static ulong ecs_column_size(ecs_iter_t* it, int column)
-    {
-        return _virtualTable.ecs_column_size(it, column);
-    }
+    [DllImport("flecs")]
+    public static extern ulong ecs_column_size(ecs_iter_t* it, int column);
 
     // Function @ deprecated.h:474:12
-    public static ecs_type_t ecs_column_type(ecs_iter_t* it, int column)
-    {
-        return _virtualTable.ecs_column_type(it, column);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_column_type(ecs_iter_t* it, int column);
 
     // Function @ deprecated.h:468:14
-    public static ecs_entity_t ecs_column_entity(ecs_iter_t* it, int column)
-    {
-        return _virtualTable.ecs_column_entity(it, column);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_column_entity(ecs_iter_t* it, int column);
 
     // Function @ deprecated.h:462:14
-    public static ecs_entity_t ecs_column_source(ecs_iter_t* it, int column)
-    {
-        return _virtualTable.ecs_column_source(it, column);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_column_source(ecs_iter_t* it, int column);
 
     // Function @ deprecated.h:451:7
-    public static void* ecs_element_w_size(ecs_iter_t* it, ulong size, int column, int row)
-    {
-        return _virtualTable.ecs_element_w_size(it, size, column, row);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_element_w_size(ecs_iter_t* it, ulong size, int column, int row);
 
     // Function @ deprecated.h:445:9
-    public static int ecs_column_index_from_name(ecs_iter_t* it, CString name)
-    {
-        return _virtualTable.ecs_column_index_from_name(it, name);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_column_index_from_name(ecs_iter_t* it, CString name);
 
     // Function @ deprecated.h:435:7
-    public static void* ecs_column_w_size(ecs_iter_t* it, ulong size, int column)
-    {
-        return _virtualTable.ecs_column_w_size(it, size, column);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_column_w_size(ecs_iter_t* it, ulong size, int column);
 
     // Function @ deprecated.h:427:6
-    public static CBool ecs_type_owns_entity(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity, CBool owned)
-    {
-        return _virtualTable.ecs_type_owns_entity(world, type, entity, owned);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_type_owns_entity(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity, CBool owned);
 
     // Function @ deprecated.h:420:6
-    public static CBool ecs_type_has_entity(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_type_has_entity(world, type, entity);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_type_has_entity(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity);
 
     // Function @ deprecated.h:414:14
-    public static ecs_entity_t ecs_type_to_entity(ecs_world_t* world, ecs_type_t type)
-    {
-        return _virtualTable.ecs_type_to_entity(world, type);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_type_to_entity(ecs_world_t* world, ecs_type_t type);
 
     // Function @ deprecated.h:408:12
-    public static ecs_type_t ecs_type_from_entity(ecs_world_t* world, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_type_from_entity(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_type_from_entity(ecs_world_t* world, ecs_entity_t entity);
 
     // Function @ deprecated.h:400:6
-    public static void ecs_add_remove_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id_add, ecs_id_t id_remove)
-    {
-        _virtualTable.ecs_add_remove_entity(world, entity, id_add, id_remove);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_add_remove_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id_add, ecs_id_t id_remove);
 
     // Function @ deprecated.h:393:6
-    public static void ecs_remove_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        _virtualTable.ecs_remove_entity(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_remove_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ deprecated.h:386:6
-    public static void ecs_add_entity(ecs_world_t* world, ecs_entity_t entity, ecs_entity_t entity_add)
-    {
-        _virtualTable.ecs_add_entity(world, entity, entity_add);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_add_entity(ecs_world_t* world, ecs_entity_t entity, ecs_entity_t entity_add);
 
     // Function @ deprecated.h:381:9
-    public static int ecs_get_thread_index(ecs_world_t* world)
-    {
-        return _virtualTable.ecs_get_thread_index(world);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_get_thread_index(ecs_world_t* world);
 
     // Function @ deprecated.h:371:14
-    public static ecs_entity_t ecs_get_parent_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_get_parent_w_entity(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_get_parent_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ deprecated.h:363:8
-    public static ulong ecs_entity_str(ecs_world_t* world, ecs_id_t entity, CString buffer, ulong buffer_len)
-    {
-        return _virtualTable.ecs_entity_str(world, entity, buffer, buffer_len);
-    }
+    [DllImport("flecs")]
+    public static extern ulong ecs_entity_str(ecs_world_t* world, ecs_id_t entity, CString buffer, ulong buffer_len);
 
     // Function @ deprecated.h:356:6
-    public static CBool ecs_has_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_has_entity(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_has_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ deprecated.h:347:14
-    public static ecs_entity_t ecs_set_ptr_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, ulong size, void* ptr)
-    {
-        return _virtualTable.ecs_set_ptr_w_entity(world, entity, id, size, ptr);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_set_ptr_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, ulong size, void* ptr);
 
     // Function @ deprecated.h:340:6
-    public static void ecs_modified_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        _virtualTable.ecs_modified_w_entity(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_modified_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ deprecated.h:332:7
-    public static void* ecs_get_mut_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, CBool* is_added)
-    {
-        return _virtualTable.ecs_get_mut_w_entity(world, entity, id, is_added);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_mut_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, CBool* is_added);
 
     // Function @ deprecated.h:324:13
-    public static void* ecs_get_ref_w_entity(ecs_world_t* world, ecs_ref_t* @ref, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_get_ref_w_entity(world, @ref, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_ref_w_entity(ecs_world_t* world, ecs_ref_t* @ref, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ deprecated.h:317:13
-    public static void* ecs_get_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_get_w_entity(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ deprecated.h:310:13
-    public static void* ecs_get_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_get_w_id(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_get_w_id(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ deprecated.h:303:6
-    public static CBool ecs_is_component_enabled_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id)
-    {
-        return _virtualTable.ecs_is_component_enabled_w_entity(world, entity, id);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_is_component_enabled_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id);
 
     // Function @ deprecated.h:295:6
-    public static void ecs_enable_component_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, CBool enable)
-    {
-        _virtualTable.ecs_enable_component_w_entity(world, entity, id, enable);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_enable_component_w_entity(ecs_world_t* world, ecs_entity_t entity, ecs_id_t id, CBool enable);
 
     // Function @ deprecated.h:288:21
-    public static ecs_entity_t* ecs_bulk_new_w_entity(ecs_world_t* world, ecs_id_t id, int count)
-    {
-        return _virtualTable.ecs_bulk_new_w_entity(world, id, count);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t* ecs_bulk_new_w_entity(ecs_world_t* world, ecs_id_t id, int count);
 
     // Function @ deprecated.h:282:14
-    public static ecs_entity_t ecs_new_w_entity(ecs_world_t* world, ecs_id_t id)
-    {
-        return _virtualTable.ecs_new_w_entity(world, id);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_new_w_entity(ecs_world_t* world, ecs_id_t id);
 
     // Function @ deprecated.h:275:6
-    public static void ecs_set_component_actions_w_entity(ecs_world_t* world, ecs_id_t id, EcsComponentLifecycle* actions)
-    {
-        _virtualTable.ecs_set_component_actions_w_entity(world, id, actions);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_set_component_actions_w_entity(ecs_world_t* world, ecs_id_t id, EcsComponentLifecycle* actions);
 
     // Function @ deprecated.h:269:9
-    public static int ecs_count_w_filter(ecs_world_t* world, ecs_filter_t* filter)
-    {
-        return _virtualTable.ecs_count_w_filter(world, filter);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_count_w_filter(ecs_world_t* world, ecs_filter_t* filter);
 
     // Function @ deprecated.h:263:9
-    public static int ecs_count_entity(ecs_world_t* world, ecs_id_t entity)
-    {
-        return _virtualTable.ecs_count_entity(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_count_entity(ecs_world_t* world, ecs_id_t entity);
 
     // Function @ deprecated.h:257:9
-    public static int ecs_count_type(ecs_world_t* world, ecs_type_t type)
-    {
-        return _virtualTable.ecs_count_type(world, type);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_count_type(ecs_world_t* world, ecs_type_t type);
 
     // Function @ deprecated.h:250:6
-    public static CBool ecs_has_type(ecs_world_t* world, ecs_entity_t entity, ecs_type_t type)
-    {
-        return _virtualTable.ecs_has_type(world, entity, type);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_has_type(ecs_world_t* world, ecs_entity_t entity, ecs_type_t type);
 
     // Function @ deprecated.h:242:6
-    public static void ecs_add_remove_type(ecs_world_t* world, ecs_entity_t entity, ecs_type_t to_add, ecs_type_t to_remove)
-    {
-        _virtualTable.ecs_add_remove_type(world, entity, to_add, to_remove);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_add_remove_type(ecs_world_t* world, ecs_entity_t entity, ecs_type_t to_add, ecs_type_t to_remove);
 
     // Function @ deprecated.h:235:6
-    public static void ecs_remove_type(ecs_world_t* world, ecs_entity_t entity, ecs_type_t type)
-    {
-        _virtualTable.ecs_remove_type(world, entity, type);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_remove_type(ecs_world_t* world, ecs_entity_t entity, ecs_type_t type);
 
     // Function @ deprecated.h:228:6
-    public static void ecs_add_type(ecs_world_t* world, ecs_entity_t entity, ecs_type_t type)
-    {
-        _virtualTable.ecs_add_type(world, entity, type);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_add_type(ecs_world_t* world, ecs_entity_t entity, ecs_type_t type);
 
     // Function @ deprecated.h:221:21
-    public static ecs_entity_t* ecs_bulk_new_w_type(ecs_world_t* world, ecs_type_t type, int count)
-    {
-        return _virtualTable.ecs_bulk_new_w_type(world, type, count);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t* ecs_bulk_new_w_type(ecs_world_t* world, ecs_type_t type, int count);
 
     // Function @ deprecated.h:215:14
-    public static ecs_entity_t ecs_new_w_type(ecs_world_t* world, ecs_type_t type)
-    {
-        return _virtualTable.ecs_new_w_type(world, type);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_new_w_type(ecs_world_t* world, ecs_type_t type);
 
     // Function @ deprecated.h:208:6
-    public static void ecs_dim_type(ecs_world_t* world, ecs_type_t type, int entity_count)
-    {
-        _virtualTable.ecs_dim_type(world, type, entity_count);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_dim_type(ecs_world_t* world, ecs_type_t type, int entity_count);
 
     // Function @ type.h:109:9
-    public static int ecs_type_match(ecs_type_t type, int start_index, ecs_entity_t pair)
-    {
-        return _virtualTable.ecs_type_match(type, start_index, pair);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_type_match(ecs_type_t type, int start_index, ecs_entity_t pair);
 
     // Function @ type.h:104:9
-    public static int ecs_type_index_of(ecs_type_t type, ecs_entity_t component)
-    {
-        return _virtualTable.ecs_type_index_of(type, component);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_type_index_of(ecs_type_t type, ecs_entity_t component);
 
     // Function @ type.h:98:14
-    public static ecs_entity_t ecs_type_get_entity_for_xor(ecs_world_t* world, ecs_type_t type, ecs_entity_t xor_tag)
-    {
-        return _virtualTable.ecs_type_get_entity_for_xor(world, type, xor_tag);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_type_get_entity_for_xor(ecs_world_t* world, ecs_type_t type, ecs_entity_t xor_tag);
 
     // Function @ type.h:88:6
-    public static CBool ecs_type_find_id(ecs_world_t* world, ecs_type_t type, ecs_entity_t id, ecs_entity_t rel, int min_depth, int max_depth, ecs_entity_t* @out)
-    {
-        return _virtualTable.ecs_type_find_id(world, type, id, rel, min_depth, max_depth, @out);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_type_find_id(ecs_world_t* world, ecs_type_t type, ecs_entity_t id, ecs_entity_t rel, int min_depth, int max_depth, ecs_entity_t* @out);
 
     // Function @ type.h:81:6
-    public static CBool ecs_type_owns_type(ecs_world_t* world, ecs_type_t type, ecs_type_t has, CBool owned)
-    {
-        return _virtualTable.ecs_type_owns_type(world, type, has, owned);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_type_owns_type(ecs_world_t* world, ecs_type_t type, ecs_type_t has, CBool owned);
 
     // Function @ type.h:74:6
-    public static CBool ecs_type_owns_id(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity, CBool owned)
-    {
-        return _virtualTable.ecs_type_owns_id(world, type, entity, owned);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_type_owns_id(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity, CBool owned);
 
     // Function @ type.h:68:6
-    public static CBool ecs_type_has_type(ecs_world_t* world, ecs_type_t type, ecs_type_t has)
-    {
-        return _virtualTable.ecs_type_has_type(world, type, has);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_type_has_type(ecs_world_t* world, ecs_type_t type, ecs_type_t has);
 
     // Function @ type.h:62:6
-    public static CBool ecs_type_has_id(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_type_has_id(world, type, entity);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_type_has_id(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity);
 
     // Function @ type.h:56:12
-    public static ecs_type_t ecs_type_remove(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_type_remove(world, type, entity);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_type_remove(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity);
 
     // Function @ type.h:50:12
-    public static ecs_type_t ecs_type_add(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_type_add(world, type, entity);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_type_add(ecs_world_t* world, ecs_type_t type, ecs_entity_t entity);
 
     // Function @ type.h:43:12
-    public static ecs_type_t ecs_type_merge(ecs_world_t* world, ecs_type_t type, ecs_type_t type_add, ecs_type_t type_remove)
-    {
-        return _virtualTable.ecs_type_merge(world, type, type_add, type_remove);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_type_merge(ecs_world_t* world, ecs_type_t type, ecs_type_t type_add, ecs_type_t type_remove);
 
     // Function @ type.h:37:12
-    public static ecs_type_t ecs_type_find(ecs_world_t* world, ecs_entity_t* array, int count)
-    {
-        return _virtualTable.ecs_type_find(world, array, count);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_type_find(ecs_world_t* world, ecs_entity_t* array, int count);
 
     // Function @ type.h:32:12
-    public static ecs_type_t ecs_type_from_str(ecs_world_t* world, CString expr)
-    {
-        return _virtualTable.ecs_type_from_str(world, expr);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_type_from_str(ecs_world_t* world, CString expr);
 
     // Function @ type.h:27:7
-    public static CString ecs_type_str(ecs_world_t* world, ecs_type_t type)
-    {
-        return _virtualTable.ecs_type_str(world, type);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_type_str(ecs_world_t* world, ecs_type_t type);
 
     // Function @ type.h:22:14
-    public static ecs_entity_t ecs_type_to_id(ecs_world_t* world, ecs_type_t type)
-    {
-        return _virtualTable.ecs_type_to_id(world, type);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_type_to_id(ecs_world_t* world, ecs_type_t type);
 
     // Function @ type.h:17:12
-    public static ecs_type_t ecs_type_from_id(ecs_world_t* world, ecs_entity_t entity)
-    {
-        return _virtualTable.ecs_type_from_id(world, entity);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_type_t ecs_type_from_id(ecs_world_t* world, ecs_entity_t entity);
 
     // Function @ log.h:158:6
-    public static void _ecs_parser_error(CString name, CString expr, long column, CString fmt)
-    {
-        _virtualTable._ecs_parser_error(name, expr, column, fmt);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_parser_error(CString name, CString expr, long column, CString fmt);
 
     // Function @ log.h:141:6
-    public static void _ecs_assert(CBool condition, int error_code, CString param, CString condition_str, CString file, int line)
-    {
-        _virtualTable._ecs_assert(condition, error_code, param, condition_str, file, line);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_assert(CBool condition, int error_code, CString param, CString condition_str, CString file, int line);
 
     // Function @ log.h:130:6
-    public static void _ecs_abort(int error_code, CString param, CString file, int line)
-    {
-        _virtualTable._ecs_abort(error_code, param, file, line);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_abort(int error_code, CString param, CString file, int line);
 
     // Function @ log.h:125:13
-    public static CString ecs_strerror(int error_code)
-    {
-        return _virtualTable.ecs_strerror(error_code);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_strerror(int error_code);
 
     // Function @ log.h:71:6
-    public static void ecs_log_pop()
-    {
-        _virtualTable.ecs_log_pop();
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_log_pop();
 
     // Function @ log.h:68:6
-    public static void ecs_log_push()
-    {
-        _virtualTable.ecs_log_push();
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_log_push();
 
     // Function @ log.h:62:6
-    public static void _ecs_deprecated(CString file, int line, CString msg)
-    {
-        _virtualTable._ecs_deprecated(file, line, msg);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_deprecated(CString file, int line, CString msg);
 
     // Function @ log.h:55:6
-    public static void _ecs_err(CString file, int line, CString fmt)
-    {
-        _virtualTable._ecs_err(file, line, fmt);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_err(CString file, int line, CString fmt);
 
     // Function @ log.h:48:6
-    public static void _ecs_warn(CString file, int line, CString fmt)
-    {
-        _virtualTable._ecs_warn(file, line, fmt);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_warn(CString file, int line, CString fmt);
 
     // Function @ log.h:40:6
-    public static void _ecs_trace(int level, CString file, int line, CString fmt)
-    {
-        _virtualTable._ecs_trace(level, file, line, fmt);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_trace(int level, CString file, int line, CString fmt);
 
     // Function @ api_support.h:80:15
-    public static ecs_filter_t* ecs_query_get_filter(ecs_query_t* query)
-    {
-        return _virtualTable.ecs_query_get_filter(query);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_filter_t* ecs_query_get_filter(ecs_query_t* query);
 
     // Function @ api_support.h:75:6
-    public static CBool ecs_identifier_is_var(CString id)
-    {
-        return _virtualTable.ecs_identifier_is_var(id);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_identifier_is_var(CString id);
 
     // Function @ api_support.h:72:6
-    public static CBool ecs_identifier_is_0(CString id)
-    {
-        return _virtualTable.ecs_identifier_is_0(id);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_identifier_is_0(CString id);
 
     // Function @ api_support.h:64:6
-    public static CBool ecs_component_has_actions(ecs_world_t* world, ecs_entity_t component)
-    {
-        return _virtualTable.ecs_component_has_actions(world, component);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_component_has_actions(ecs_world_t* world, ecs_entity_t component);
 
     // Function @ api_support.h:60:7
-    public static CString ecs_module_path_from_c(CString c_name)
-    {
-        return _virtualTable.ecs_module_path_from_c(c_name);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_module_path_from_c(CString c_name);
 
     // Function @ api_support.h:52:14
-    public static ecs_entity_t ecs_new_module(ecs_world_t* world, ecs_entity_t e, CString name, ulong size, ulong alignment)
-    {
-        return _virtualTable.ecs_new_module(world, e, name, size, alignment);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_entity_t ecs_new_module(ecs_world_t* world, ecs_entity_t e, CString name, ulong size, ulong alignment);
 
     // Function @ os_api.h:431:6
-    public static CBool ecs_os_has_modules()
-    {
-        return _virtualTable.ecs_os_has_modules();
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_os_has_modules();
 
     // Function @ os_api.h:427:6
-    public static CBool ecs_os_has_dl()
-    {
-        return _virtualTable.ecs_os_has_dl();
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_os_has_dl();
 
     // Function @ os_api.h:423:6
-    public static CBool ecs_os_has_logging()
-    {
-        return _virtualTable.ecs_os_has_logging();
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_os_has_logging();
 
     // Function @ os_api.h:419:6
-    public static CBool ecs_os_has_time()
-    {
-        return _virtualTable.ecs_os_has_time();
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_os_has_time();
 
     // Function @ os_api.h:415:6
-    public static CBool ecs_os_has_threading()
-    {
-        return _virtualTable.ecs_os_has_threading();
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_os_has_threading();
 
     // Function @ os_api.h:411:6
-    public static CBool ecs_os_has_heap()
-    {
-        return _virtualTable.ecs_os_has_heap();
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_os_has_heap();
 
     // Function @ os_api.h:405:7
-    public static void* ecs_os_memdup(void* src, ecs_size_t size)
-    {
-        return _virtualTable.ecs_os_memdup(src, size);
-    }
+    [DllImport("flecs")]
+    public static extern void* ecs_os_memdup(void* src, ecs_size_t size);
 
     // Function @ os_api.h:401:8
-    public static double ecs_time_to_double(ecs_time_t t)
-    {
-        return _virtualTable.ecs_time_to_double(t);
-    }
+    [DllImport("flecs")]
+    public static extern double ecs_time_to_double(ecs_time_t t);
 
     // Function @ os_api.h:395:12
-    public static ecs_time_t ecs_time_sub(ecs_time_t t1, ecs_time_t t2)
-    {
-        return _virtualTable.ecs_time_sub(t1, t2);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_time_t ecs_time_sub(ecs_time_t t1, ecs_time_t t2);
 
     // Function @ os_api.h:390:8
-    public static double ecs_time_measure(ecs_time_t* start)
-    {
-        return _virtualTable.ecs_time_measure(start);
-    }
+    [DllImport("flecs")]
+    public static extern double ecs_time_measure(ecs_time_t* start);
 
     // Function @ os_api.h:385:6
-    public static void ecs_sleepf(double t)
-    {
-        _virtualTable.ecs_sleepf(t);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_sleepf(double t);
 
     // Function @ os_api.h:369:6
-    public static void ecs_os_dbg(CString fmt)
-    {
-        _virtualTable.ecs_os_dbg(fmt);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_os_dbg(CString fmt);
 
     // Function @ os_api.h:366:6
-    public static void ecs_os_err(CString fmt)
-    {
-        _virtualTable.ecs_os_err(fmt);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_os_err(CString fmt);
 
     // Function @ os_api.h:363:6
-    public static void ecs_os_warn(CString fmt)
-    {
-        _virtualTable.ecs_os_warn(fmt);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_os_warn(CString fmt);
 
     // Function @ os_api.h:360:6
-    public static void ecs_os_log(CString fmt)
-    {
-        _virtualTable.ecs_os_log(fmt);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_os_log(CString fmt);
 
     // Function @ os_api.h:267:6
-    public static void ecs_os_set_api_defaults()
-    {
-        _virtualTable.ecs_os_set_api_defaults();
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_os_set_api_defaults();
 
     // Function @ os_api.h:263:6
-    public static void ecs_os_set_api(ecs_os_api_t* os_api)
-    {
-        _virtualTable.ecs_os_set_api(os_api);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_os_set_api(ecs_os_api_t* os_api);
 
     // Function @ os_api.h:260:6
-    public static void ecs_os_fini()
-    {
-        _virtualTable.ecs_os_fini();
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_os_fini();
 
     // Function @ os_api.h:257:6
-    public static void ecs_os_init()
-    {
-        _virtualTable.ecs_os_init();
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_os_init();
 
     // Function @ strbuf.h:166:6
-    public static CBool ecs_strbuf_list_appendstr(ecs_strbuf_t* buffer, CString str)
-    {
-        return _virtualTable.ecs_strbuf_list_appendstr(buffer, str);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_strbuf_list_appendstr(ecs_strbuf_t* buffer, CString str);
 
     // Function @ strbuf.h:159:6
-    public static CBool ecs_strbuf_list_append(ecs_strbuf_t* buffer, CString fmt)
-    {
-        return _virtualTable.ecs_strbuf_list_append(buffer, fmt);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_strbuf_list_append(ecs_strbuf_t* buffer, CString fmt);
 
     // Function @ strbuf.h:154:6
-    public static void ecs_strbuf_list_next(ecs_strbuf_t* buffer)
-    {
-        _virtualTable.ecs_strbuf_list_next(buffer);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_strbuf_list_next(ecs_strbuf_t* buffer);
 
     // Function @ strbuf.h:148:6
-    public static void ecs_strbuf_list_pop(ecs_strbuf_t* buffer, CString list_close)
-    {
-        _virtualTable.ecs_strbuf_list_pop(buffer, list_close);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_strbuf_list_pop(ecs_strbuf_t* buffer, CString list_close);
 
     // Function @ strbuf.h:141:6
-    public static void ecs_strbuf_list_push(ecs_strbuf_t* buffer, CString list_open, CString separator)
-    {
-        _virtualTable.ecs_strbuf_list_push(buffer, list_open, separator);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_strbuf_list_push(ecs_strbuf_t* buffer, CString list_open, CString separator);
 
     // Function @ strbuf.h:136:6
-    public static void ecs_strbuf_reset(ecs_strbuf_t* buffer)
-    {
-        _virtualTable.ecs_strbuf_reset(buffer);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_strbuf_reset(ecs_strbuf_t* buffer);
 
     // Function @ strbuf.h:131:7
-    public static CString ecs_strbuf_get(ecs_strbuf_t* buffer)
-    {
-        return _virtualTable.ecs_strbuf_get(buffer);
-    }
+    [DllImport("flecs")]
+    public static extern CString ecs_strbuf_get(ecs_strbuf_t* buffer);
 
     // Function @ strbuf.h:124:6
-    public static CBool ecs_strbuf_appendstrn(ecs_strbuf_t* buffer, CString str, int n)
-    {
-        return _virtualTable.ecs_strbuf_appendstrn(buffer, str, n);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_strbuf_appendstrn(ecs_strbuf_t* buffer, CString str, int n);
 
     // Function @ strbuf.h:117:6
-    public static CBool ecs_strbuf_appendstr_zerocpy_const(ecs_strbuf_t* buffer, CString str)
-    {
-        return _virtualTable.ecs_strbuf_appendstr_zerocpy_const(buffer, str);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_strbuf_appendstr_zerocpy_const(ecs_strbuf_t* buffer, CString str);
 
     // Function @ strbuf.h:110:6
-    public static CBool ecs_strbuf_appendstr_zerocpy(ecs_strbuf_t* buffer, CString str)
-    {
-        return _virtualTable.ecs_strbuf_appendstr_zerocpy(buffer, str);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_strbuf_appendstr_zerocpy(ecs_strbuf_t* buffer, CString str);
 
     // Function @ strbuf.h:103:6
-    public static CBool ecs_strbuf_mergebuff(ecs_strbuf_t* dst_buffer, ecs_strbuf_t* src_buffer)
-    {
-        return _virtualTable.ecs_strbuf_mergebuff(dst_buffer, src_buffer);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_strbuf_mergebuff(ecs_strbuf_t* dst_buffer, ecs_strbuf_t* src_buffer);
 
     // Function @ strbuf.h:96:6
-    public static CBool ecs_strbuf_appendstr(ecs_strbuf_t* buffer, CString str)
-    {
-        return _virtualTable.ecs_strbuf_appendstr(buffer, str);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_strbuf_appendstr(ecs_strbuf_t* buffer, CString str);
 
     // Function @ strbuf.h:88:6
-    public static CBool ecs_strbuf_vappend(ecs_strbuf_t* buffer, CString fmt, IntPtr args)
-    {
-        return _virtualTable.ecs_strbuf_vappend(buffer, fmt, args);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_strbuf_vappend(ecs_strbuf_t* buffer, CString fmt, IntPtr args);
 
     // Function @ strbuf.h:80:6
-    public static CBool ecs_strbuf_append(ecs_strbuf_t* buffer, CString fmt)
-    {
-        return _virtualTable.ecs_strbuf_append(buffer, fmt);
-    }
+    [DllImport("flecs")]
+    public static extern CBool ecs_strbuf_append(ecs_strbuf_t* buffer, CString fmt);
 
     // Function @ map.h:165:6
-    public static void ecs_map_memory(ecs_map_t* map, int* allocd, int* used)
-    {
-        _virtualTable.ecs_map_memory(map, allocd, used);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_map_memory(ecs_map_t* map, int* allocd, int* used);
 
     // Function @ map.h:159:6
-    public static void ecs_map_set_size(ecs_map_t* map, int elem_count)
-    {
-        _virtualTable.ecs_map_set_size(map, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_map_set_size(ecs_map_t* map, int elem_count);
 
     // Function @ map.h:153:6
-    public static void ecs_map_grow(ecs_map_t* map, int elem_count)
-    {
-        _virtualTable.ecs_map_grow(map, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_map_grow(ecs_map_t* map, int elem_count);
 
     // Function @ map.h:144:7
-    public static void* _ecs_map_next_ptr(ecs_map_iter_t* iter, ecs_map_key_t* key)
-    {
-        return _virtualTable._ecs_map_next_ptr(iter, key);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_map_next_ptr(ecs_map_iter_t* iter, ecs_map_key_t* key);
 
     // Function @ map.h:134:7
-    public static void* _ecs_map_next(ecs_map_iter_t* iter, ecs_size_t elem_size, ecs_map_key_t* key)
-    {
-        return _virtualTable._ecs_map_next(iter, elem_size, key);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_map_next(ecs_map_iter_t* iter, ecs_size_t elem_size, ecs_map_key_t* key);
 
     // Function @ map.h:129:16
-    public static ecs_map_iter_t ecs_map_iter(ecs_map_t* map)
-    {
-        return _virtualTable.ecs_map_iter(map);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_map_iter_t ecs_map_iter(ecs_map_t* map);
 
     // Function @ map.h:124:9
-    public static int ecs_map_bucket_count(ecs_map_t* map)
-    {
-        return _virtualTable.ecs_map_bucket_count(map);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_map_bucket_count(ecs_map_t* map);
 
     // Function @ map.h:119:9
-    public static int ecs_map_count(ecs_map_t* map)
-    {
-        return _virtualTable.ecs_map_count(map);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_map_count(ecs_map_t* map);
 
     // Function @ map.h:114:6
-    public static void ecs_map_clear(ecs_map_t* map)
-    {
-        _virtualTable.ecs_map_clear(map);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_map_clear(ecs_map_t* map);
 
     // Function @ map.h:108:6
-    public static void ecs_map_remove(ecs_map_t* map, ecs_map_key_t key)
-    {
-        _virtualTable.ecs_map_remove(map, key);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_map_remove(ecs_map_t* map, ecs_map_key_t key);
 
     // Function @ map.h:103:6
-    public static void ecs_map_free(ecs_map_t* map)
-    {
-        _virtualTable.ecs_map_free(map);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_map_free(ecs_map_t* map);
 
     // Function @ map.h:92:7
-    public static void* _ecs_map_set(ecs_map_t* map, ecs_size_t elem_size, ecs_map_key_t key, void* payload)
-    {
-        return _virtualTable._ecs_map_set(map, elem_size, key, payload);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_map_set(ecs_map_t* map, ecs_size_t elem_size, ecs_map_key_t key, void* payload);
 
     // Function @ map.h:82:8
-    public static void* _ecs_map_ensure(ecs_map_t* map, ecs_size_t elem_size, ecs_map_key_t key)
-    {
-        return _virtualTable._ecs_map_ensure(map, elem_size, key);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_map_ensure(ecs_map_t* map, ecs_size_t elem_size, ecs_map_key_t key);
 
     // Function @ map.h:73:8
-    public static void* _ecs_map_get_ptr(ecs_map_t* map, ecs_map_key_t key)
-    {
-        return _virtualTable._ecs_map_get_ptr(map, key);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_map_get_ptr(ecs_map_t* map, ecs_map_key_t key);
 
     // Function @ map.h:60:8
-    public static void* _ecs_map_get(ecs_map_t* map, ecs_size_t elem_size, ecs_map_key_t key)
-    {
-        return _virtualTable._ecs_map_get(map, elem_size, key);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_map_get(ecs_map_t* map, ecs_size_t elem_size, ecs_map_key_t key);
 
     // Function @ map.h:50:13
-    public static ecs_map_t* _ecs_map_new(ecs_size_t elem_size, ecs_size_t alignment, int elem_count)
-    {
-        return _virtualTable._ecs_map_new(elem_size, alignment, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_map_t* _ecs_map_new(ecs_size_t elem_size, ecs_size_t alignment, int elem_count);
 
     // Function @ vector.h:370:15
-    public static ecs_vector_t* _ecs_vector_copy(ecs_vector_t* src, ecs_size_t elem_size, short offset)
-    {
-        return _virtualTable._ecs_vector_copy(src, elem_size, offset);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_vector_t* _ecs_vector_copy(ecs_vector_t* src, ecs_size_t elem_size, short offset);
 
     // Function @ vector.h:355:6
-    public static void _ecs_vector_memory(ecs_vector_t* vector, ecs_size_t elem_size, short offset, int* allocd, int* used)
-    {
-        _virtualTable._ecs_vector_memory(vector, elem_size, offset, allocd, used);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_vector_memory(ecs_vector_t* vector, ecs_size_t elem_size, short offset, int* allocd, int* used);
 
     // Function @ vector.h:344:6
-    public static void _ecs_vector_sort(ecs_vector_t* vector, ecs_size_t elem_size, short offset, ecs_comparator_t compare_action)
-    {
-        _virtualTable._ecs_vector_sort(vector, elem_size, offset, compare_action);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_vector_sort(ecs_vector_t* vector, ecs_size_t elem_size, short offset, ecs_comparator_t compare_action);
 
     // Function @ vector.h:331:7
-    public static void* _ecs_vector_first(ecs_vector_t* vector, ecs_size_t elem_size, short offset)
-    {
-        return _virtualTable._ecs_vector_first(vector, elem_size, offset);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_vector_first(ecs_vector_t* vector, ecs_size_t elem_size, short offset);
 
     // Function @ vector.h:326:9
-    public static int ecs_vector_size(ecs_vector_t* vector)
-    {
-        return _virtualTable.ecs_vector_size(vector);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_vector_size(ecs_vector_t* vector);
 
     // Function @ vector.h:321:9
-    public static int ecs_vector_count(ecs_vector_t* vector)
-    {
-        return _virtualTable.ecs_vector_count(vector);
-    }
+    [DllImport("flecs")]
+    public static extern int ecs_vector_count(ecs_vector_t* vector);
 
     // Function @ vector.h:307:9
-    public static int _ecs_vector_set_count(ecs_vector_t** vector, ecs_size_t elem_size, short offset, int elem_count)
-    {
-        return _virtualTable._ecs_vector_set_count(vector, elem_size, offset, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern int _ecs_vector_set_count(ecs_vector_t** vector, ecs_size_t elem_size, short offset, int elem_count);
 
     // Function @ vector.h:292:9
-    public static int _ecs_vector_set_size(ecs_vector_t** vector, ecs_size_t elem_size, short offset, int elem_count)
-    {
-        return _virtualTable._ecs_vector_set_size(vector, elem_size, offset, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern int _ecs_vector_set_size(ecs_vector_t** vector, ecs_size_t elem_size, short offset, int elem_count);
 
     // Function @ vector.h:281:9
-    public static int _ecs_vector_grow(ecs_vector_t** vector, ecs_size_t elem_size, short offset, int elem_count)
-    {
-        return _virtualTable._ecs_vector_grow(vector, elem_size, offset, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern int _ecs_vector_grow(ecs_vector_t** vector, ecs_size_t elem_size, short offset, int elem_count);
 
     // Function @ vector.h:271:6
-    public static void _ecs_vector_reclaim(ecs_vector_t** vector, ecs_size_t elem_size, short offset)
-    {
-        _virtualTable._ecs_vector_reclaim(vector, elem_size, offset);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_vector_reclaim(ecs_vector_t** vector, ecs_size_t elem_size, short offset);
 
     // Function @ vector.h:257:9
-    public static int _ecs_vector_remove_index(ecs_vector_t* vector, ecs_size_t elem_size, short offset, int index)
-    {
-        return _virtualTable._ecs_vector_remove_index(vector, elem_size, offset, index);
-    }
+    [DllImport("flecs")]
+    public static extern int _ecs_vector_remove_index(ecs_vector_t* vector, ecs_size_t elem_size, short offset, int index);
 
     // Function @ vector.h:245:9
-    public static int _ecs_vector_move_index(ecs_vector_t** dst, ecs_vector_t* src, ecs_size_t elem_size, short offset, int index)
-    {
-        return _virtualTable._ecs_vector_move_index(dst, src, elem_size, offset, index);
-    }
+    [DllImport("flecs")]
+    public static extern int _ecs_vector_move_index(ecs_vector_t** dst, ecs_vector_t* src, ecs_size_t elem_size, short offset, int index);
 
     // Function @ vector.h:234:6
-    public static CBool _ecs_vector_pop(ecs_vector_t* vector, ecs_size_t elem_size, short offset, void* value)
-    {
-        return _virtualTable._ecs_vector_pop(vector, elem_size, offset, value);
-    }
+    [DllImport("flecs")]
+    public static extern CBool _ecs_vector_pop(ecs_vector_t* vector, ecs_size_t elem_size, short offset, void* value);
 
     // Function @ vector.h:229:6
-    public static void ecs_vector_remove_last(ecs_vector_t* vector)
-    {
-        _virtualTable.ecs_vector_remove_last(vector);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_vector_remove_last(ecs_vector_t* vector);
 
     // Function @ vector.h:218:9
-    public static int _ecs_vector_set_min_count(ecs_vector_t** vector_inout, ecs_size_t elem_size, short offset, int elem_count)
-    {
-        return _virtualTable._ecs_vector_set_min_count(vector_inout, elem_size, offset, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern int _ecs_vector_set_min_count(ecs_vector_t** vector_inout, ecs_size_t elem_size, short offset, int elem_count);
 
     // Function @ vector.h:206:9
-    public static int _ecs_vector_set_min_size(ecs_vector_t** array_inout, ecs_size_t elem_size, short offset, int elem_count)
-    {
-        return _virtualTable._ecs_vector_set_min_size(array_inout, elem_size, offset, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern int _ecs_vector_set_min_size(ecs_vector_t** array_inout, ecs_size_t elem_size, short offset, int elem_count);
 
     // Function @ vector.h:195:7
-    public static void* _ecs_vector_last(ecs_vector_t* vector, ecs_size_t elem_size, short offset)
-    {
-        return _virtualTable._ecs_vector_last(vector, elem_size, offset);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_vector_last(ecs_vector_t* vector, ecs_size_t elem_size, short offset);
 
     // Function @ vector.h:181:7
-    public static void* _ecs_vector_get(ecs_vector_t* vector, ecs_size_t elem_size, short offset, int index)
-    {
-        return _virtualTable._ecs_vector_get(vector, elem_size, offset, index);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_vector_get(ecs_vector_t* vector, ecs_size_t elem_size, short offset, int index);
 
     // Function @ vector.h:167:7
-    public static void* _ecs_vector_addn(ecs_vector_t** array_inout, ecs_size_t elem_size, short offset, int elem_count)
-    {
-        return _virtualTable._ecs_vector_addn(array_inout, elem_size, offset, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_vector_addn(ecs_vector_t** array_inout, ecs_size_t elem_size, short offset, int elem_count);
 
     // Function @ vector.h:154:7
-    public static void* _ecs_vector_add(ecs_vector_t** array_inout, ecs_size_t elem_size, short offset)
-    {
-        return _virtualTable._ecs_vector_add(array_inout, elem_size, offset);
-    }
+    [DllImport("flecs")]
+    public static extern void* _ecs_vector_add(ecs_vector_t** array_inout, ecs_size_t elem_size, short offset);
 
     // Function @ vector.h:148:6
-    public static void ecs_vector_assert_alignment(ecs_vector_t* vector, ecs_size_t elem_alignment)
-    {
-        _virtualTable.ecs_vector_assert_alignment(vector, elem_alignment);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_vector_assert_alignment(ecs_vector_t* vector, ecs_size_t elem_alignment);
 
     // Function @ vector.h:142:6
-    public static void ecs_vector_assert_size(ecs_vector_t* vector_inout, ecs_size_t elem_size)
-    {
-        _virtualTable.ecs_vector_assert_size(vector_inout, elem_size);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_vector_assert_size(ecs_vector_t* vector_inout, ecs_size_t elem_size);
 
     // Function @ vector.h:137:6
-    public static void ecs_vector_clear(ecs_vector_t* vector)
-    {
-        _virtualTable.ecs_vector_clear(vector);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_vector_clear(ecs_vector_t* vector);
 
     // Function @ vector.h:132:6
-    public static void ecs_vector_free(ecs_vector_t* vector)
-    {
-        _virtualTable.ecs_vector_free(vector);
-    }
+    [DllImport("flecs")]
+    public static extern void ecs_vector_free(ecs_vector_t* vector);
 
     // Function @ vector.h:122:6
-    public static void _ecs_vector_zero(ecs_vector_t* vector, ecs_size_t elem_size, short offset)
-    {
-        _virtualTable._ecs_vector_zero(vector, elem_size, offset);
-    }
+    [DllImport("flecs")]
+    public static extern void _ecs_vector_zero(ecs_vector_t* vector, ecs_size_t elem_size, short offset);
 
     // Function @ vector.h:111:15
-    public static ecs_vector_t* _ecs_vector_from_array(ecs_size_t elem_size, short offset, int elem_count, void* array)
-    {
-        return _virtualTable._ecs_vector_from_array(elem_size, offset, elem_count, array);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_vector_t* _ecs_vector_from_array(ecs_size_t elem_size, short offset, int elem_count, void* array);
 
     // Function @ vector.h:98:15
-    public static ecs_vector_t* _ecs_vector_new(ecs_size_t elem_size, short offset, int elem_count)
-    {
-        return _virtualTable._ecs_vector_new(elem_size, offset, elem_count);
-    }
+    [DllImport("flecs")]
+    public static extern ecs_vector_t* _ecs_vector_new(ecs_size_t elem_size, short offset, int elem_count);
 
     // FunctionPointer @ flecs.h:124:16
     [StructLayout(LayoutKind.Sequential)]
@@ -4535,1442 +3374,102 @@ public static unsafe partial class flecs
     }
 
     // Enum @ flecs.h:244:3
-    public enum ecs_match_kind_t : int
+    public enum ecs_match_kind_t : uint
     {
-        EcsMatchDefault = 0,
-        EcsMatchAll = 1,
-        EcsMatchAny = 2,
-        EcsMatchExact = 3
+        EcsMatchDefault = 0U,
+        EcsMatchAll = 1U,
+        EcsMatchAny = 2U,
+        EcsMatchExact = 3U
     }
 
     // Enum @ flecs.h:194:3
-    public enum ecs_oper_kind_t : int
+    public enum ecs_oper_kind_t : uint
     {
-        EcsAnd = 0,
-        EcsOr = 1,
-        EcsNot = 2,
-        EcsOptional = 3,
-        EcsAndFrom = 4,
-        EcsOrFrom = 5,
-        EcsNotFrom = 6
+        EcsAnd = 0U,
+        EcsOr = 1U,
+        EcsNot = 2U,
+        EcsOptional = 3U,
+        EcsAndFrom = 4U,
+        EcsOrFrom = 5U,
+        EcsNotFrom = 6U
     }
 
     // Enum @ flecs.h:183:3
-    public enum ecs_var_kind_t : int
+    public enum ecs_var_kind_t : uint
     {
-        EcsVarDefault = 0,
-        EcsVarIsEntity = 1,
-        EcsVarIsVariable = 2
+        EcsVarDefault = 0U,
+        EcsVarIsEntity = 1U,
+        EcsVarIsVariable = 2U
     }
 
     // Enum @ flecs.h:176:3
-    public enum ecs_inout_kind_t : int
+    public enum ecs_inout_kind_t : uint
     {
-        EcsInOutDefault = 0,
-        EcsInOut = 1,
-        EcsIn = 2,
-        EcsOut = 3
+        EcsInOutDefault = 0U,
+        EcsInOut = 1U,
+        EcsIn = 2U,
+        EcsOut = 3U
     }
 
     // Enum @ api_types.h:114:3
-    public enum ecs_query_iter_kind_t : int
+    public enum ecs_query_iter_kind_t : uint
     {
-        EcsQuerySimpleIter = 0,
-        EcsQueryPagedIter = 1,
-        EcsQuerySortedIter = 2,
-        EcsQuerySwitchIter = 3
+        EcsQuerySimpleIter = 0U,
+        EcsQueryPagedIter = 1U,
+        EcsQuerySortedIter = 2U,
+        EcsQuerySwitchIter = 3U
     }
 
     // Enum @ reader_writer.h:47:3
-    public enum ecs_blob_header_kind_t : int
+    public enum ecs_blob_header_kind_t : uint
     {
-        EcsStreamHeader = 0,
-        EcsTableSegment = 1,
-        EcsFooterSegment = 2,
-        EcsTableHeader = 3,
-        EcsTableTypeSize = 4,
-        EcsTableType = 5,
-        EcsTableSize = 6,
-        EcsTableColumn = 7,
-        EcsTableColumnHeader = 8,
-        EcsTableColumnSize = 9,
-        EcsTableColumnData = 10,
-        EcsTableColumnNameHeader = 11,
-        EcsTableColumnNameLength = 12,
-        EcsTableColumnName = 13,
-        EcsStreamFooter = 14
+        EcsStreamHeader = 0U,
+        EcsTableSegment = 1U,
+        EcsFooterSegment = 2U,
+        EcsTableHeader = 3U,
+        EcsTableTypeSize = 4U,
+        EcsTableType = 5U,
+        EcsTableSize = 6U,
+        EcsTableColumn = 7U,
+        EcsTableColumnHeader = 8U,
+        EcsTableColumnSize = 9U,
+        EcsTableColumnData = 10U,
+        EcsTableColumnNameHeader = 11U,
+        EcsTableColumnNameLength = 12U,
+        EcsTableColumnName = 13U,
+        EcsStreamFooter = 14U
     }
 
     // Enum @ api_types.h:197:3
-    public enum EcsMatchFailureReason : int
+    public enum EcsMatchFailureReason : uint
     {
-        EcsMatchOk = 0,
-        EcsMatchNotASystem = 1,
-        EcsMatchSystemIsATask = 2,
-        EcsMatchEntityIsDisabled = 3,
-        EcsMatchEntityIsPrefab = 4,
-        EcsMatchFromSelf = 5,
-        EcsMatchFromOwned = 6,
-        EcsMatchFromShared = 7,
-        EcsMatchFromContainer = 8,
-        EcsMatchFromEntity = 9,
-        EcsMatchOrFromSelf = 10,
-        EcsMatchOrFromOwned = 11,
-        EcsMatchOrFromShared = 12,
-        EcsMatchOrFromContainer = 13,
-        EcsMatchNotFromSelf = 14,
-        EcsMatchNotFromOwned = 15,
-        EcsMatchNotFromShared = 16,
-        EcsMatchNotFromContainer = 17
+        EcsMatchOk = 0U,
+        EcsMatchNotASystem = 1U,
+        EcsMatchSystemIsATask = 2U,
+        EcsMatchEntityIsDisabled = 3U,
+        EcsMatchEntityIsPrefab = 4U,
+        EcsMatchFromSelf = 5U,
+        EcsMatchFromOwned = 6U,
+        EcsMatchFromShared = 7U,
+        EcsMatchFromContainer = 8U,
+        EcsMatchFromEntity = 9U,
+        EcsMatchOrFromSelf = 10U,
+        EcsMatchOrFromOwned = 11U,
+        EcsMatchOrFromShared = 12U,
+        EcsMatchOrFromContainer = 13U,
+        EcsMatchNotFromSelf = 14U,
+        EcsMatchNotFromOwned = 15U,
+        EcsMatchNotFromShared = 16U,
+        EcsMatchNotFromContainer = 17U
     }
 
     // Enum @ system.h:52:3
-    public enum ecs_system_status_t : int
+    public enum ecs_system_status_t : uint
     {
-        EcsSystemStatusNone = 0,
-        EcsSystemEnabled = 1,
-        EcsSystemDisabled = 2,
-        EcsSystemActivated = 3,
-        EcsSystemDeactivated = 4
+        EcsSystemStatusNone = 0U,
+        EcsSystemEnabled = 1U,
+        EcsSystemDisabled = 2U,
+        EcsSystemActivated = 3U,
+        EcsSystemDeactivated = 4U
     }
-
-    private static void _LoadVirtualTable()
-    {
-        #region "Functions"
-        _virtualTable.ecs_gauge_reduce = (delegate* unmanaged[Cdecl]<ecs_gauge_t*, int, ecs_gauge_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_gauge_reduce");
-        _virtualTable.ecs_get_pipeline_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_pipeline_stats_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_pipeline_stats");
-        _virtualTable.ecs_get_system_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_system_stats_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_system_stats");
-        _virtualTable.ecs_get_query_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, ecs_query_stats_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_query_stats");
-        _virtualTable.ecs_dump_world_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_stats_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dump_world_stats");
-        _virtualTable.ecs_get_world_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_stats_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_world_stats");
-        _virtualTable.ecs_record_move_to = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_record_t*, int, ulong, void*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_record_move_to");
-        _virtualTable.ecs_record_copy_pod_to = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_record_t*, int, ulong, void*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_record_copy_pod_to");
-        _virtualTable.ecs_record_copy_to = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_record_t*, int, ulong, void*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_record_copy_to");
-        _virtualTable.ecs_record_get_column = (delegate* unmanaged[Cdecl]<ecs_record_t*, int, ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_record_get_column");
-        _virtualTable.ecs_record_ensure = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_record_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_record_ensure");
-        _virtualTable.ecs_record_find = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_record_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_record_find");
-        _virtualTable.ecs_table_delete_column = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, int, ecs_vector_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_delete_column");
-        _virtualTable.ecs_table_set_entities = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_vector_t*, ecs_vector_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_set_entities");
-        _virtualTable.ecs_records_update = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_vector_t*, ecs_vector_t*, ecs_table_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_records_update");
-        _virtualTable.ecs_records_clear = (delegate* unmanaged[Cdecl]<ecs_vector_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_records_clear");
-        _virtualTable.ecs_table_get_records = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_vector_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_get_records");
-        _virtualTable.ecs_table_get_entities = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_vector_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_get_entities");
-        _virtualTable.ecs_table_set_column = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, int, ecs_vector_t*, ecs_vector_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_set_column");
-        _virtualTable.ecs_table_get_column = (delegate* unmanaged[Cdecl]<ecs_table_t*, int, ecs_vector_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_get_column");
-        _virtualTable.ecs_table_find_column = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_entity_t, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_find_column");
-        _virtualTable.ecs_snapshot_free = (delegate* unmanaged[Cdecl]<ecs_snapshot_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_snapshot_free");
-        _virtualTable.ecs_snapshot_next = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_snapshot_next");
-        _virtualTable.ecs_snapshot_iter = (delegate* unmanaged[Cdecl]<ecs_snapshot_t*, ecs_filter_t*, ecs_iter_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_snapshot_iter");
-        _virtualTable.ecs_snapshot_restore = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_snapshot_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_snapshot_restore");
-        _virtualTable.ecs_snapshot_take_w_iter = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_iter_next_action_t, ecs_snapshot_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_snapshot_take_w_iter");
-        _virtualTable.ecs_snapshot_take = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_snapshot_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_snapshot_take");
-        _virtualTable.ecs_writer_write = (delegate* unmanaged[Cdecl]<CString, int, ecs_writer_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_writer_write");
-        _virtualTable.ecs_writer_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_writer_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_writer_init");
-        _virtualTable.ecs_reader_read = (delegate* unmanaged[Cdecl]<CString, int, ecs_reader_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_reader_read");
-        _virtualTable.ecs_reader_init_w_iter = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_iter_next_action_t, ecs_reader_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_reader_init_w_iter");
-        _virtualTable.ecs_reader_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_reader_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_reader_init");
-        _virtualTable.ecs_queue_free = (delegate* unmanaged[Cdecl]<ecs_queue_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_queue_free");
-        _virtualTable.ecs_queue_count = (delegate* unmanaged[Cdecl]<ecs_queue_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_queue_count");
-        _virtualTable.ecs_queue_index = (delegate* unmanaged[Cdecl]<ecs_queue_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_queue_index");
-        _virtualTable._ecs_queue_last = (delegate* unmanaged[Cdecl]<ecs_queue_t*, ecs_size_t, short, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_queue_last");
-        _virtualTable._ecs_queue_get = (delegate* unmanaged[Cdecl]<ecs_queue_t*, ecs_size_t, short, int, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_queue_get");
-        _virtualTable._ecs_queue_push = (delegate* unmanaged[Cdecl]<ecs_queue_t*, ecs_size_t, short, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_queue_push");
-        _virtualTable._ecs_queue_from_array = (delegate* unmanaged[Cdecl]<ecs_size_t, short, int, void*, ecs_queue_t*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_queue_from_array");
-        _virtualTable._ecs_queue_new = (delegate* unmanaged[Cdecl]<ecs_size_t, short, int, ecs_queue_t*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_queue_new");
-        _virtualTable.ecs_parse_term = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString, CString, ecs_term_t*, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_parse_term");
-        _virtualTable.ecs_dbg_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, ecs_dbg_table_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_table");
-        _virtualTable.ecs_dbg_filter_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, ecs_filter_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_filter_table");
-        _virtualTable.ecs_dbg_get_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, ecs_table_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_get_table");
-        _virtualTable.ecs_dbg_find_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_table_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_find_table");
-        _virtualTable.ecs_dbg_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_dbg_entity_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_entity");
-        _virtualTable.ecs_bulk_delete = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_delete");
-        _virtualTable.ecs_bulk_add_remove_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, ecs_filter_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_add_remove_type");
-        _virtualTable.ecs_bulk_remove_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_filter_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_remove_type");
-        _virtualTable.ecs_bulk_remove_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_filter_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_remove_entity");
-        _virtualTable.ecs_bulk_add_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_filter_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_add_type");
-        _virtualTable.ecs_bulk_add_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_filter_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_add_entity");
-        _virtualTable.FlecsTimerImport = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "FlecsTimerImport");
-        _virtualTable.ecs_set_tick_source = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_tick_source");
-        _virtualTable.ecs_set_rate = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, ecs_entity_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_rate");
-        _virtualTable.ecs_stop_timer = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_stop_timer");
-        _virtualTable.ecs_start_timer = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_start_timer");
-        _virtualTable.ecs_get_interval = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_interval");
-        _virtualTable.ecs_set_interval = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_interval");
-        _virtualTable.ecs_get_timeout = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_timeout");
-        _virtualTable.ecs_set_timeout = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_timeout");
-        _virtualTable.FlecsPipelineImport = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "FlecsPipelineImport");
-        _virtualTable.ecs_set_threads = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_threads");
-        _virtualTable.ecs_deactivate_systems = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_deactivate_systems");
-        _virtualTable.ecs_pipeline_run = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_pipeline_run");
-        _virtualTable.ecs_reset_clock = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_reset_clock");
-        _virtualTable.ecs_set_time_scale = (delegate* unmanaged[Cdecl]<ecs_world_t*, float, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_time_scale");
-        _virtualTable.ecs_progress = (delegate* unmanaged[Cdecl]<ecs_world_t*, float, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_progress");
-        _virtualTable.ecs_get_pipeline = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_pipeline");
-        _virtualTable.ecs_set_pipeline = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_pipeline");
-        _virtualTable.FlecsSystemImport = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "FlecsSystemImport");
-        _virtualTable.ecs_dbg_match_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_match_failure_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_match_entity");
-        _virtualTable.ecs_dbg_get_column_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_get_column_type");
-        _virtualTable.ecs_dbg_get_inactive_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_dbg_system_t*, int, ecs_table_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_get_inactive_table");
-        _virtualTable.ecs_dbg_get_active_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_dbg_system_t*, int, ecs_table_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_get_active_table");
-        _virtualTable.ecs_dbg_system = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_dbg_system_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dbg_system");
-        _virtualTable.ecs_get_system_ctx = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_system_ctx");
-        _virtualTable.ecs_get_query = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_query_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_query");
-        _virtualTable.ecs_run_w_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, int, int, ecs_filter_t*, void*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_run_w_filter");
-        _virtualTable.ecs_run_worker = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, int, float, void*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_run_worker");
-        _virtualTable.ecs_run = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, void*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_run");
-        _virtualTable.ecs_system_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_system_desc_t*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_system_init");
-        _virtualTable.ecs_import_from_library = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_import_from_library");
-        _virtualTable.ecs_import = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_module_action_t, CString, void*, ulong, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_import");
-        _virtualTable.ecs_table_count = (delegate* unmanaged[Cdecl]<ecs_table_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_count");
-        _virtualTable.ecs_table_insert = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, ecs_entity_t, ecs_record_t*, ecs_record_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_insert");
-        _virtualTable.ecs_table_get_type = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_get_type");
-        _virtualTable.ecs_table_from_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_table_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_from_type");
-        _virtualTable.ecs_table_from_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_table_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_from_str");
-        _virtualTable.ecs_stage_is_async = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_stage_is_async");
-        _virtualTable.ecs_async_stage_free = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_async_stage_free");
-        _virtualTable.ecs_async_stage_new = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_async_stage_new");
-        _virtualTable.ecs_stage_is_readonly = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_stage_is_readonly");
-        _virtualTable.ecs_get_world = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_world");
-        _virtualTable.ecs_get_stage = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, ecs_world_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_stage");
-        _virtualTable.ecs_get_stage_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_stage_id");
-        _virtualTable.ecs_get_stage_count = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_stage_count");
-        _virtualTable.ecs_set_stages = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_stages");
-        _virtualTable.ecs_set_automerge = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_automerge");
-        _virtualTable.ecs_defer_end = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_defer_end");
-        _virtualTable.ecs_defer_begin = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_defer_begin");
-        _virtualTable.ecs_merge = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_merge");
-        _virtualTable.ecs_staging_end = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_staging_end");
-        _virtualTable.ecs_staging_begin = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_staging_begin");
-        _virtualTable.ecs_frame_end = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_frame_end");
-        _virtualTable.ecs_frame_begin = (delegate* unmanaged[Cdecl]<ecs_world_t*, float, float>)Runtime.LibraryGetExport(_libraryHandle, "ecs_frame_begin");
-        _virtualTable.ecs_iter_column_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong>)Runtime.LibraryGetExport(_libraryHandle, "ecs_iter_column_size");
-        _virtualTable.ecs_iter_column_w_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_iter_column_w_size");
-        _virtualTable.ecs_iter_find_column = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_id_t, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_iter_find_column");
-        _virtualTable.ecs_iter_type = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_iter_type");
-        _virtualTable.ecs_term_is_owned = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_is_owned");
-        _virtualTable.ecs_term_is_readonly = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_is_readonly");
-        _virtualTable.ecs_term_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_size");
-        _virtualTable.ecs_term_source = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_source");
-        _virtualTable.ecs_term_id = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_id_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_id");
-        _virtualTable.ecs_term_w_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_w_size");
-        _virtualTable.ecs_get_trigger_ctx = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_trigger_ctx");
-        _virtualTable.ecs_trigger_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_trigger_desc_t*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_trigger_init");
-        _virtualTable.ecs_query_orphaned = (delegate* unmanaged[Cdecl]<ecs_query_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_orphaned");
-        _virtualTable.ecs_query_changed = (delegate* unmanaged[Cdecl]<ecs_query_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_changed");
-        _virtualTable.ecs_query_next_worker = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, int, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_next_worker");
-        _virtualTable.ecs_query_next_w_filter = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_filter_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_next_w_filter");
-        _virtualTable.ecs_query_next = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_next");
-        _virtualTable.ecs_query_iter_page = (delegate* unmanaged[Cdecl]<ecs_query_t*, int, int, ecs_iter_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_iter_page");
-        _virtualTable.ecs_query_iter = (delegate* unmanaged[Cdecl]<ecs_query_t*, ecs_iter_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_iter");
-        _virtualTable.ecs_query_fini = (delegate* unmanaged[Cdecl]<ecs_query_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_fini");
-        _virtualTable.ecs_query_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_desc_t*, ecs_query_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_init");
-        _virtualTable.ecs_filter_next = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_filter_next");
-        _virtualTable.ecs_filter_iter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, ecs_iter_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_filter_iter");
-        _virtualTable.ecs_filter_match_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, ecs_entity_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_filter_match_entity");
-        _virtualTable.ecs_filter_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_filter_str");
-        _virtualTable.ecs_filter_finalize = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_filter_finalize");
-        _virtualTable.ecs_filter_fini = (delegate* unmanaged[Cdecl]<ecs_filter_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_filter_fini");
-        _virtualTable.ecs_filter_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, ecs_filter_desc_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_filter_init");
-        _virtualTable.ecs_id_match = (delegate* unmanaged[Cdecl]<ecs_id_t, ecs_id_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_id_match");
-        _virtualTable.ecs_term_fini = (delegate* unmanaged[Cdecl]<ecs_term_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_fini");
-        _virtualTable.ecs_term_move = (delegate* unmanaged[Cdecl]<ecs_term_t*, ecs_term_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_move");
-        _virtualTable.ecs_term_copy = (delegate* unmanaged[Cdecl]<ecs_term_t*, ecs_term_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_copy");
-        _virtualTable.ecs_term_finalize = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString, ecs_term_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_finalize");
-        _virtualTable.ecs_term_is_trivial = (delegate* unmanaged[Cdecl]<ecs_term_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_is_trivial");
-        _virtualTable.ecs_term_is_set = (delegate* unmanaged[Cdecl]<ecs_term_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_term_is_set");
-        _virtualTable.ecs_set_name_prefix = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_name_prefix");
-        _virtualTable.ecs_get_scope = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_scope");
-        _virtualTable.ecs_set_scope = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_scope");
-        _virtualTable.ecs_scope_next = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_scope_next");
-        _virtualTable.ecs_scope_iter_w_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_filter_t*, ecs_iter_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_scope_iter_w_filter");
-        _virtualTable.ecs_scope_iter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_iter_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_scope_iter");
-        _virtualTable.ecs_get_child_count = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_child_count");
-        _virtualTable.ecs_add_path_w_sep = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, CString, CString, CString, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_add_path_w_sep");
-        _virtualTable.ecs_new_from_path_w_sep = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, CString, CString, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_new_from_path_w_sep");
-        _virtualTable.ecs_get_path_w_sep = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_entity_t, CString, CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_path_w_sep");
-        _virtualTable.ecs_use = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_use");
-        _virtualTable.ecs_lookup_symbol = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_lookup_symbol");
-        _virtualTable.ecs_lookup_path_w_sep = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, CString, CString, CBool, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_lookup_path_w_sep");
-        _virtualTable.ecs_lookup_child = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_lookup_child");
-        _virtualTable.ecs_lookup = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_lookup");
-        _virtualTable.ecs_count_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_count_filter");
-        _virtualTable.ecs_count_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_count_id");
-        _virtualTable.ecs_enable = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_enable");
-        _virtualTable.ecs_get_object_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_id_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_object_w_id");
-        _virtualTable.ecs_id_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, CString, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "ecs_id_str");
-        _virtualTable.ecs_role_str = (delegate* unmanaged[Cdecl]<ecs_entity_t, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_role_str");
-        _virtualTable.ecs_get_name = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_name");
-        _virtualTable.ecs_get_typeid = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_typeid");
-        _virtualTable.ecs_get_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_type");
-        _virtualTable.ecs_exists = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_exists");
-        _virtualTable.ecs_ensure = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_ensure");
-        _virtualTable.ecs_get_alive = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_alive");
-        _virtualTable.ecs_is_alive = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_is_alive");
-        _virtualTable.ecs_is_valid = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_is_valid");
-        _virtualTable.ecs_has_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_has_id");
-        _virtualTable.ecs_set_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ulong, void*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_id");
-        _virtualTable.ecs_modified_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_modified_w_id");
-        _virtualTable.ecs_get_mut_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool*, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_mut_w_id");
-        _virtualTable.ecs_get_case = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_case");
-        _virtualTable.ecs_get_ref_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_ref_t*, ecs_entity_t, ecs_id_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_ref_w_id");
-        _virtualTable.ecs_get_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_id");
-        _virtualTable.ecs_delete_children = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_delete_children");
-        _virtualTable.ecs_delete = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_delete");
-        _virtualTable.ecs_clear = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_clear");
-        _virtualTable.ecs_make_pair = (delegate* unmanaged[Cdecl]<ecs_entity_t, ecs_entity_t, ecs_id_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_make_pair");
-        _virtualTable.ecs_is_component_enabled_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_is_component_enabled_w_id");
-        _virtualTable.ecs_enable_component_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_enable_component_w_id");
-        _virtualTable.ecs_remove_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_remove_id");
-        _virtualTable.ecs_add_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_add_id");
-        _virtualTable.ecs_clone = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, CBool, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_clone");
-        _virtualTable.ecs_bulk_new_w_data = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, ecs_entities_t*, void*, ecs_entity_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_new_w_data");
-        _virtualTable.ecs_bulk_new_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int, ecs_entity_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_new_w_id");
-        _virtualTable.ecs_type_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_desc_t*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_init");
-        _virtualTable.ecs_component_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_component_desc_t*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_component_init");
-        _virtualTable.ecs_entity_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_desc_t*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_entity_init");
-        _virtualTable.ecs_new_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_new_w_id");
-        _virtualTable.ecs_new_component_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_new_component_id");
-        _virtualTable.ecs_new_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_new_id");
-        _virtualTable.ecs_get_threads = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_threads");
-        _virtualTable.ecs_set_target_fps = (delegate* unmanaged[Cdecl]<ecs_world_t*, float, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_target_fps");
-        _virtualTable.ecs_measure_system_time = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_measure_system_time");
-        _virtualTable.ecs_measure_frame_time = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_measure_frame_time");
-        _virtualTable.ecs_tracing_enable = (delegate* unmanaged[Cdecl]<int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_tracing_enable");
-        _virtualTable.ecs_end_wait = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_end_wait");
-        _virtualTable.ecs_begin_wait = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_begin_wait");
-        _virtualTable.ecs_unlock = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_unlock");
-        _virtualTable.ecs_lock = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_lock");
-        _virtualTable.ecs_enable_locking = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_enable_locking");
-        _virtualTable.ecs_enable_range_check = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_enable_range_check");
-        _virtualTable.ecs_set_entity_range = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_entity_range");
-        _virtualTable.ecs_dim = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dim");
-        _virtualTable.ecs_get_world_info = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_info_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_world_info");
-        _virtualTable.ecs_get_context = (delegate* unmanaged[Cdecl]<ecs_world_t*, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_context");
-        _virtualTable.ecs_set_context = (delegate* unmanaged[Cdecl]<ecs_world_t*, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_context");
-        _virtualTable.ecs_set_component_actions_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, EcsComponentLifecycle*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_component_actions_w_id");
-        _virtualTable.ecs_should_quit = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_should_quit");
-        _virtualTable.ecs_quit = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_quit");
-        _virtualTable.ecs_run_post_frame = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_fini_action_t, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_run_post_frame");
-        _virtualTable.ecs_atfini = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_fini_action_t, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_atfini");
-        _virtualTable.ecs_fini = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_fini");
-        _virtualTable.ecs_init_w_args = (delegate* unmanaged[Cdecl]<int, CString*, ecs_world_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_init_w_args");
-        _virtualTable.ecs_mini = (delegate* unmanaged[Cdecl]<ecs_world_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_mini");
-        _virtualTable.ecs_init = (delegate* unmanaged[Cdecl]<ecs_world_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_init");
-        _virtualTable.ecs_query_group_by = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, ecs_entity_t, ecs_rank_type_action_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_group_by");
-        _virtualTable.ecs_query_order_by = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, ecs_entity_t, ecs_compare_action_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_order_by");
-        _virtualTable.ecs_query_free = (delegate* unmanaged[Cdecl]<ecs_query_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_free");
-        _virtualTable.ecs_subquery_new = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, CString, ecs_query_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_subquery_new");
-        _virtualTable.ecs_query_new = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_query_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_new");
-        _virtualTable.ecs_set_rate_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, ecs_entity_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_rate_filter");
-        _virtualTable.ecs_table_component_index = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_entity_t, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_component_index");
-        _virtualTable.ecs_table_column_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_column_size");
-        _virtualTable.ecs_table_column = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_table_column");
-        _virtualTable.ecs_is_owned = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_is_owned");
-        _virtualTable.ecs_is_readonly = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_is_readonly");
-        _virtualTable.ecs_column_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong>)Runtime.LibraryGetExport(_libraryHandle, "ecs_column_size");
-        _virtualTable.ecs_column_type = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_column_type");
-        _virtualTable.ecs_column_entity = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_column_entity");
-        _virtualTable.ecs_column_source = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_column_source");
-        _virtualTable.ecs_element_w_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, int, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_element_w_size");
-        _virtualTable.ecs_column_index_from_name = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CString, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_column_index_from_name");
-        _virtualTable.ecs_column_w_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_column_w_size");
-        _virtualTable.ecs_type_owns_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_owns_entity");
-        _virtualTable.ecs_type_has_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_has_entity");
-        _virtualTable.ecs_type_to_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_to_entity");
-        _virtualTable.ecs_type_from_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_from_entity");
-        _virtualTable.ecs_add_remove_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ecs_id_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_add_remove_entity");
-        _virtualTable.ecs_remove_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_remove_entity");
-        _virtualTable.ecs_add_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_add_entity");
-        _virtualTable.ecs_get_thread_index = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_thread_index");
-        _virtualTable.ecs_get_parent_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_parent_w_entity");
-        _virtualTable.ecs_entity_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, CString, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "ecs_entity_str");
-        _virtualTable.ecs_has_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_has_entity");
-        _virtualTable.ecs_set_ptr_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ulong, void*, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_ptr_w_entity");
-        _virtualTable.ecs_modified_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_modified_w_entity");
-        _virtualTable.ecs_get_mut_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool*, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_mut_w_entity");
-        _virtualTable.ecs_get_ref_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_ref_t*, ecs_entity_t, ecs_id_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_ref_w_entity");
-        _virtualTable.ecs_get_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_w_entity");
-        _virtualTable.ecs_get_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_get_w_id");
-        _virtualTable.ecs_is_component_enabled_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_is_component_enabled_w_entity");
-        _virtualTable.ecs_enable_component_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_enable_component_w_entity");
-        _virtualTable.ecs_bulk_new_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int, ecs_entity_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_new_w_entity");
-        _virtualTable.ecs_new_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_new_w_entity");
-        _virtualTable.ecs_set_component_actions_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, EcsComponentLifecycle*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_set_component_actions_w_entity");
-        _virtualTable.ecs_count_w_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_count_w_filter");
-        _virtualTable.ecs_count_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_count_entity");
-        _virtualTable.ecs_count_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_count_type");
-        _virtualTable.ecs_has_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_has_type");
-        _virtualTable.ecs_add_remove_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, ecs_type_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_add_remove_type");
-        _virtualTable.ecs_remove_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_remove_type");
-        _virtualTable.ecs_add_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_add_type");
-        _virtualTable.ecs_bulk_new_w_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, int, ecs_entity_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_bulk_new_w_type");
-        _virtualTable.ecs_new_w_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_new_w_type");
-        _virtualTable.ecs_dim_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_dim_type");
-        _virtualTable.ecs_type_match = (delegate* unmanaged[Cdecl]<ecs_type_t, int, ecs_entity_t, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_match");
-        _virtualTable.ecs_type_index_of = (delegate* unmanaged[Cdecl]<ecs_type_t, ecs_entity_t, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_index_of");
-        _virtualTable.ecs_type_get_entity_for_xor = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_get_entity_for_xor");
-        _virtualTable.ecs_type_find_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_entity_t, int, int, ecs_entity_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_find_id");
-        _virtualTable.ecs_type_owns_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, CBool, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_owns_type");
-        _virtualTable.ecs_type_owns_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_owns_id");
-        _virtualTable.ecs_type_has_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_has_type");
-        _virtualTable.ecs_type_has_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_has_id");
-        _virtualTable.ecs_type_remove = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_remove");
-        _virtualTable.ecs_type_add = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_add");
-        _virtualTable.ecs_type_merge = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, ecs_type_t, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_merge");
-        _virtualTable.ecs_type_find = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t*, int, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_find");
-        _virtualTable.ecs_type_from_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_from_str");
-        _virtualTable.ecs_type_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_str");
-        _virtualTable.ecs_type_to_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_to_id");
-        _virtualTable.ecs_type_from_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_type_from_id");
-        _virtualTable._ecs_parser_error = (delegate* unmanaged[Cdecl]<CString, CString, long, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_parser_error");
-        _virtualTable._ecs_assert = (delegate* unmanaged[Cdecl]<CBool, int, CString, CString, CString, int, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_assert");
-        _virtualTable._ecs_abort = (delegate* unmanaged[Cdecl]<int, CString, CString, int, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_abort");
-        _virtualTable.ecs_strerror = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strerror");
-        _virtualTable.ecs_log_pop = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_log_pop");
-        _virtualTable.ecs_log_push = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_log_push");
-        _virtualTable._ecs_deprecated = (delegate* unmanaged[Cdecl]<CString, int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_deprecated");
-        _virtualTable._ecs_err = (delegate* unmanaged[Cdecl]<CString, int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_err");
-        _virtualTable._ecs_warn = (delegate* unmanaged[Cdecl]<CString, int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_warn");
-        _virtualTable._ecs_trace = (delegate* unmanaged[Cdecl]<int, CString, int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_trace");
-        _virtualTable.ecs_query_get_filter = (delegate* unmanaged[Cdecl]<ecs_query_t*, ecs_filter_t*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_query_get_filter");
-        _virtualTable.ecs_identifier_is_var = (delegate* unmanaged[Cdecl]<CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_identifier_is_var");
-        _virtualTable.ecs_identifier_is_0 = (delegate* unmanaged[Cdecl]<CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_identifier_is_0");
-        _virtualTable.ecs_component_has_actions = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_component_has_actions");
-        _virtualTable.ecs_module_path_from_c = (delegate* unmanaged[Cdecl]<CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_module_path_from_c");
-        _virtualTable.ecs_new_module = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, ulong, ulong, ecs_entity_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_new_module");
-        _virtualTable.ecs_os_has_modules = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_has_modules");
-        _virtualTable.ecs_os_has_dl = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_has_dl");
-        _virtualTable.ecs_os_has_logging = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_has_logging");
-        _virtualTable.ecs_os_has_time = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_has_time");
-        _virtualTable.ecs_os_has_threading = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_has_threading");
-        _virtualTable.ecs_os_has_heap = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_has_heap");
-        _virtualTable.ecs_os_memdup = (delegate* unmanaged[Cdecl]<void*, ecs_size_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_memdup");
-        _virtualTable.ecs_time_to_double = (delegate* unmanaged[Cdecl]<ecs_time_t, double>)Runtime.LibraryGetExport(_libraryHandle, "ecs_time_to_double");
-        _virtualTable.ecs_time_sub = (delegate* unmanaged[Cdecl]<ecs_time_t, ecs_time_t, ecs_time_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_time_sub");
-        _virtualTable.ecs_time_measure = (delegate* unmanaged[Cdecl]<ecs_time_t*, double>)Runtime.LibraryGetExport(_libraryHandle, "ecs_time_measure");
-        _virtualTable.ecs_sleepf = (delegate* unmanaged[Cdecl]<double, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_sleepf");
-        _virtualTable.ecs_os_dbg = (delegate* unmanaged[Cdecl]<CString, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_dbg");
-        _virtualTable.ecs_os_err = (delegate* unmanaged[Cdecl]<CString, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_err");
-        _virtualTable.ecs_os_warn = (delegate* unmanaged[Cdecl]<CString, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_warn");
-        _virtualTable.ecs_os_log = (delegate* unmanaged[Cdecl]<CString, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_log");
-        _virtualTable.ecs_os_set_api_defaults = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_set_api_defaults");
-        _virtualTable.ecs_os_set_api = (delegate* unmanaged[Cdecl]<ecs_os_api_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_set_api");
-        _virtualTable.ecs_os_fini = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_fini");
-        _virtualTable.ecs_os_init = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_os_init");
-        _virtualTable.ecs_strbuf_list_appendstr = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_list_appendstr");
-        _virtualTable.ecs_strbuf_list_append = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_list_append");
-        _virtualTable.ecs_strbuf_list_next = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_list_next");
-        _virtualTable.ecs_strbuf_list_pop = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_list_pop");
-        _virtualTable.ecs_strbuf_list_push = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_list_push");
-        _virtualTable.ecs_strbuf_reset = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_reset");
-        _virtualTable.ecs_strbuf_get = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_get");
-        _virtualTable.ecs_strbuf_appendstrn = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, int, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_appendstrn");
-        _virtualTable.ecs_strbuf_appendstr_zerocpy_const = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_appendstr_zerocpy_const");
-        _virtualTable.ecs_strbuf_appendstr_zerocpy = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_appendstr_zerocpy");
-        _virtualTable.ecs_strbuf_mergebuff = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, ecs_strbuf_t*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_mergebuff");
-        _virtualTable.ecs_strbuf_appendstr = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_appendstr");
-        _virtualTable.ecs_strbuf_vappend = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, IntPtr, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_vappend");
-        _virtualTable.ecs_strbuf_append = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "ecs_strbuf_append");
-        _virtualTable.ecs_map_memory = (delegate* unmanaged[Cdecl]<ecs_map_t*, int*, int*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_map_memory");
-        _virtualTable.ecs_map_set_size = (delegate* unmanaged[Cdecl]<ecs_map_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_map_set_size");
-        _virtualTable.ecs_map_grow = (delegate* unmanaged[Cdecl]<ecs_map_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_map_grow");
-        _virtualTable._ecs_map_next_ptr = (delegate* unmanaged[Cdecl]<ecs_map_iter_t*, ecs_map_key_t*, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_map_next_ptr");
-        _virtualTable._ecs_map_next = (delegate* unmanaged[Cdecl]<ecs_map_iter_t*, ecs_size_t, ecs_map_key_t*, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_map_next");
-        _virtualTable.ecs_map_iter = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_map_iter_t>)Runtime.LibraryGetExport(_libraryHandle, "ecs_map_iter");
-        _virtualTable.ecs_map_bucket_count = (delegate* unmanaged[Cdecl]<ecs_map_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_map_bucket_count");
-        _virtualTable.ecs_map_count = (delegate* unmanaged[Cdecl]<ecs_map_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_map_count");
-        _virtualTable.ecs_map_clear = (delegate* unmanaged[Cdecl]<ecs_map_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_map_clear");
-        _virtualTable.ecs_map_remove = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_map_key_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_map_remove");
-        _virtualTable.ecs_map_free = (delegate* unmanaged[Cdecl]<ecs_map_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_map_free");
-        _virtualTable._ecs_map_set = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_size_t, ecs_map_key_t, void*, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_map_set");
-        _virtualTable._ecs_map_ensure = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_size_t, ecs_map_key_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_map_ensure");
-        _virtualTable._ecs_map_get_ptr = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_map_key_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_map_get_ptr");
-        _virtualTable._ecs_map_get = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_size_t, ecs_map_key_t, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_map_get");
-        _virtualTable._ecs_map_new = (delegate* unmanaged[Cdecl]<ecs_size_t, ecs_size_t, int, ecs_map_t*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_map_new");
-        _virtualTable._ecs_vector_copy = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, ecs_vector_t*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_copy");
-        _virtualTable._ecs_vector_memory = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, int*, int*, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_memory");
-        _virtualTable._ecs_vector_sort = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, ecs_comparator_t, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_sort");
-        _virtualTable._ecs_vector_first = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_first");
-        _virtualTable.ecs_vector_size = (delegate* unmanaged[Cdecl]<ecs_vector_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_vector_size");
-        _virtualTable.ecs_vector_count = (delegate* unmanaged[Cdecl]<ecs_vector_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "ecs_vector_count");
-        _virtualTable._ecs_vector_set_count = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_set_count");
-        _virtualTable._ecs_vector_set_size = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_set_size");
-        _virtualTable._ecs_vector_grow = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_grow");
-        _virtualTable._ecs_vector_reclaim = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_reclaim");
-        _virtualTable._ecs_vector_remove_index = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, int, int>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_remove_index");
-        _virtualTable._ecs_vector_move_index = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_vector_t*, ecs_size_t, short, int, int>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_move_index");
-        _virtualTable._ecs_vector_pop = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_pop");
-        _virtualTable.ecs_vector_remove_last = (delegate* unmanaged[Cdecl]<ecs_vector_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_vector_remove_last");
-        _virtualTable._ecs_vector_set_min_count = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_set_min_count");
-        _virtualTable._ecs_vector_set_min_size = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_set_min_size");
-        _virtualTable._ecs_vector_last = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_last");
-        _virtualTable._ecs_vector_get = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, int, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_get");
-        _virtualTable._ecs_vector_addn = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_addn");
-        _virtualTable._ecs_vector_add = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, void*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_add");
-        _virtualTable.ecs_vector_assert_alignment = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_vector_assert_alignment");
-        _virtualTable.ecs_vector_assert_size = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_vector_assert_size");
-        _virtualTable.ecs_vector_clear = (delegate* unmanaged[Cdecl]<ecs_vector_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_vector_clear");
-        _virtualTable.ecs_vector_free = (delegate* unmanaged[Cdecl]<ecs_vector_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "ecs_vector_free");
-        _virtualTable._ecs_vector_zero = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_zero");
-        _virtualTable._ecs_vector_from_array = (delegate* unmanaged[Cdecl]<ecs_size_t, short, int, void*, ecs_vector_t*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_from_array");
-        _virtualTable._ecs_vector_new = (delegate* unmanaged[Cdecl]<ecs_size_t, short, int, ecs_vector_t*>)Runtime.LibraryGetExport(_libraryHandle, "_ecs_vector_new");
-        #endregion
-
-        #region "Variables"
-        _virtualTable.FLECS__TEcsRateFilter = Runtime.LibraryGetExport(_libraryHandle, "FLECS__TEcsRateFilter");
-        _virtualTable.FLECS__TEcsTimer = Runtime.LibraryGetExport(_libraryHandle, "FLECS__TEcsTimer");
-        _virtualTable.FLECS__TEcsTickSource = Runtime.LibraryGetExport(_libraryHandle, "FLECS__TEcsTickSource");
-        _virtualTable.FLECS__TEcsSystem = Runtime.LibraryGetExport(_libraryHandle, "FLECS__TEcsSystem");
-        _virtualTable.EcsPostFrame = Runtime.LibraryGetExport(_libraryHandle, "EcsPostFrame");
-        _virtualTable.EcsOnStore = Runtime.LibraryGetExport(_libraryHandle, "EcsOnStore");
-        _virtualTable.EcsPreStore = Runtime.LibraryGetExport(_libraryHandle, "EcsPreStore");
-        _virtualTable.EcsPostUpdate = Runtime.LibraryGetExport(_libraryHandle, "EcsPostUpdate");
-        _virtualTable.EcsOnValidate = Runtime.LibraryGetExport(_libraryHandle, "EcsOnValidate");
-        _virtualTable.EcsOnUpdate = Runtime.LibraryGetExport(_libraryHandle, "EcsOnUpdate");
-        _virtualTable.EcsPreUpdate = Runtime.LibraryGetExport(_libraryHandle, "EcsPreUpdate");
-        _virtualTable.EcsPostLoad = Runtime.LibraryGetExport(_libraryHandle, "EcsPostLoad");
-        _virtualTable.EcsOnLoad = Runtime.LibraryGetExport(_libraryHandle, "EcsOnLoad");
-        _virtualTable.EcsPreFrame = Runtime.LibraryGetExport(_libraryHandle, "EcsPreFrame");
-        _virtualTable.EcsPipeline = Runtime.LibraryGetExport(_libraryHandle, "EcsPipeline");
-        _virtualTable.EcsInactive = Runtime.LibraryGetExport(_libraryHandle, "EcsInactive");
-        _virtualTable.EcsDisabledIntern = Runtime.LibraryGetExport(_libraryHandle, "EcsDisabledIntern");
-        _virtualTable.EcsMonitor = Runtime.LibraryGetExport(_libraryHandle, "EcsMonitor");
-        _virtualTable.EcsOnDemand = Runtime.LibraryGetExport(_libraryHandle, "EcsOnDemand");
-        _virtualTable.EcsThrow = Runtime.LibraryGetExport(_libraryHandle, "EcsThrow");
-        _virtualTable.EcsDelete = Runtime.LibraryGetExport(_libraryHandle, "EcsDelete");
-        _virtualTable.EcsRemove = Runtime.LibraryGetExport(_libraryHandle, "EcsRemove");
-        _virtualTable.EcsOnDeleteObject = Runtime.LibraryGetExport(_libraryHandle, "EcsOnDeleteObject");
-        _virtualTable.EcsOnDelete = Runtime.LibraryGetExport(_libraryHandle, "EcsOnDelete");
-        _virtualTable.EcsUnSet = Runtime.LibraryGetExport(_libraryHandle, "EcsUnSet");
-        _virtualTable.EcsOnSet = Runtime.LibraryGetExport(_libraryHandle, "EcsOnSet");
-        _virtualTable.EcsOnRemove = Runtime.LibraryGetExport(_libraryHandle, "EcsOnRemove");
-        _virtualTable.EcsOnAdd = Runtime.LibraryGetExport(_libraryHandle, "EcsOnAdd");
-        _virtualTable.EcsHidden = Runtime.LibraryGetExport(_libraryHandle, "EcsHidden");
-        _virtualTable.EcsDisabled = Runtime.LibraryGetExport(_libraryHandle, "EcsDisabled");
-        _virtualTable.EcsPrefab = Runtime.LibraryGetExport(_libraryHandle, "EcsPrefab");
-        _virtualTable.EcsModule = Runtime.LibraryGetExport(_libraryHandle, "EcsModule");
-        _virtualTable.EcsIsA = Runtime.LibraryGetExport(_libraryHandle, "EcsIsA");
-        _virtualTable.EcsChildOf = Runtime.LibraryGetExport(_libraryHandle, "EcsChildOf");
-        _virtualTable.EcsFinal = Runtime.LibraryGetExport(_libraryHandle, "EcsFinal");
-        _virtualTable.EcsTransitive = Runtime.LibraryGetExport(_libraryHandle, "EcsTransitive");
-        _virtualTable.EcsThis = Runtime.LibraryGetExport(_libraryHandle, "EcsThis");
-        _virtualTable.EcsWildcard = Runtime.LibraryGetExport(_libraryHandle, "EcsWildcard");
-        _virtualTable.EcsWorld = Runtime.LibraryGetExport(_libraryHandle, "EcsWorld");
-        _virtualTable.EcsFlecsCore = Runtime.LibraryGetExport(_libraryHandle, "EcsFlecsCore");
-        _virtualTable.EcsFlecs = Runtime.LibraryGetExport(_libraryHandle, "EcsFlecs");
-        _virtualTable.ECS_DISABLED = Runtime.LibraryGetExport(_libraryHandle, "ECS_DISABLED");
-        _virtualTable.ECS_OWNED = Runtime.LibraryGetExport(_libraryHandle, "ECS_OWNED");
-        _virtualTable.ECS_PAIR = Runtime.LibraryGetExport(_libraryHandle, "ECS_PAIR");
-        _virtualTable.ECS_SWITCH = Runtime.LibraryGetExport(_libraryHandle, "ECS_SWITCH");
-        _virtualTable.ECS_CASE = Runtime.LibraryGetExport(_libraryHandle, "ECS_CASE");
-        _virtualTable.FLECS__TEcsName = Runtime.LibraryGetExport(_libraryHandle, "FLECS__TEcsName");
-        _virtualTable.FLECS__TEcsType = Runtime.LibraryGetExport(_libraryHandle, "FLECS__TEcsType");
-        _virtualTable.FLECS__TEcsComponentLifecycle = Runtime.LibraryGetExport(_libraryHandle, "FLECS__TEcsComponentLifecycle");
-        _virtualTable.FLECS__TEcsComponent = Runtime.LibraryGetExport(_libraryHandle, "FLECS__TEcsComponent");
-        _virtualTable.ecs_os_api = Runtime.LibraryGetExport(_libraryHandle, "ecs_os_api");
-        _virtualTable.ecs_os_api_free_count = Runtime.LibraryGetExport(_libraryHandle, "ecs_os_api_free_count");
-        _virtualTable.ecs_os_api_calloc_count = Runtime.LibraryGetExport(_libraryHandle, "ecs_os_api_calloc_count");
-        _virtualTable.ecs_os_api_realloc_count = Runtime.LibraryGetExport(_libraryHandle, "ecs_os_api_realloc_count");
-        _virtualTable.ecs_os_api_malloc_count = Runtime.LibraryGetExport(_libraryHandle, "ecs_os_api_malloc_count");
-        #endregion
-    }
-
-    private static void _UnloadVirtualTable()
-    {
-        #region "Functions"
-
-        _virtualTable.ecs_gauge_reduce = (delegate* unmanaged[Cdecl]<ecs_gauge_t*, int, ecs_gauge_t*, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_get_pipeline_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_pipeline_stats_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_get_system_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_system_stats_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_get_query_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, ecs_query_stats_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_dump_world_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_stats_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_get_world_stats = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_stats_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_record_move_to = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_record_t*, int, ulong, void*, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_record_copy_pod_to = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_record_t*, int, ulong, void*, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_record_copy_to = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_record_t*, int, ulong, void*, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_record_get_column = (delegate* unmanaged[Cdecl]<ecs_record_t*, int, ulong, void*>)IntPtr.Zero;
-        _virtualTable.ecs_record_ensure = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_record_t*>)IntPtr.Zero;
-        _virtualTable.ecs_record_find = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_record_t*>)IntPtr.Zero;
-        _virtualTable.ecs_table_delete_column = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, int, ecs_vector_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_table_set_entities = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_vector_t*, ecs_vector_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_records_update = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_vector_t*, ecs_vector_t*, ecs_table_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_records_clear = (delegate* unmanaged[Cdecl]<ecs_vector_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_table_get_records = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_vector_t*>)IntPtr.Zero;
-        _virtualTable.ecs_table_get_entities = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_vector_t*>)IntPtr.Zero;
-        _virtualTable.ecs_table_set_column = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, int, ecs_vector_t*, ecs_vector_t*>)IntPtr.Zero;
-        _virtualTable.ecs_table_get_column = (delegate* unmanaged[Cdecl]<ecs_table_t*, int, ecs_vector_t*>)IntPtr.Zero;
-        _virtualTable.ecs_table_find_column = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_entity_t, int>)IntPtr.Zero;
-        _virtualTable.ecs_snapshot_free = (delegate* unmanaged[Cdecl]<ecs_snapshot_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_snapshot_next = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_snapshot_iter = (delegate* unmanaged[Cdecl]<ecs_snapshot_t*, ecs_filter_t*, ecs_iter_t>)IntPtr.Zero;
-        _virtualTable.ecs_snapshot_restore = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_snapshot_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_snapshot_take_w_iter = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_iter_next_action_t, ecs_snapshot_t*>)IntPtr.Zero;
-        _virtualTable.ecs_snapshot_take = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_snapshot_t*>)IntPtr.Zero;
-        _virtualTable.ecs_writer_write = (delegate* unmanaged[Cdecl]<CString, int, ecs_writer_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_writer_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_writer_t>)IntPtr.Zero;
-        _virtualTable.ecs_reader_read = (delegate* unmanaged[Cdecl]<CString, int, ecs_reader_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_reader_init_w_iter = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_iter_next_action_t, ecs_reader_t>)IntPtr.Zero;
-        _virtualTable.ecs_reader_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_reader_t>)IntPtr.Zero;
-        _virtualTable.ecs_queue_free = (delegate* unmanaged[Cdecl]<ecs_queue_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_queue_count = (delegate* unmanaged[Cdecl]<ecs_queue_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_queue_index = (delegate* unmanaged[Cdecl]<ecs_queue_t*, int>)IntPtr.Zero;
-        _virtualTable._ecs_queue_last = (delegate* unmanaged[Cdecl]<ecs_queue_t*, ecs_size_t, short, void*>)IntPtr.Zero;
-        _virtualTable._ecs_queue_get = (delegate* unmanaged[Cdecl]<ecs_queue_t*, ecs_size_t, short, int, void*>)IntPtr.Zero;
-        _virtualTable._ecs_queue_push = (delegate* unmanaged[Cdecl]<ecs_queue_t*, ecs_size_t, short, void*>)IntPtr.Zero;
-        _virtualTable._ecs_queue_from_array = (delegate* unmanaged[Cdecl]<ecs_size_t, short, int, void*, ecs_queue_t*>)IntPtr.Zero;
-        _virtualTable._ecs_queue_new = (delegate* unmanaged[Cdecl]<ecs_size_t, short, int, ecs_queue_t*>)IntPtr.Zero;
-        _virtualTable.ecs_parse_term = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString, CString, ecs_term_t*, CString>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, ecs_dbg_table_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_filter_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, ecs_filter_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_get_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, ecs_table_t*>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_find_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_table_t*>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_dbg_entity_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_delete = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_add_remove_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, ecs_filter_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_remove_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_filter_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_remove_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_filter_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_add_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_filter_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_add_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_filter_t*, void>)IntPtr.Zero;
-        _virtualTable.FlecsTimerImport = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_set_tick_source = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_set_rate = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, ecs_entity_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_stop_timer = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_start_timer = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_get_interval = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float>)IntPtr.Zero;
-        _virtualTable.ecs_set_interval = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_get_timeout = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float>)IntPtr.Zero;
-        _virtualTable.ecs_set_timeout = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.FlecsPipelineImport = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_set_threads = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_deactivate_systems = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_pipeline_run = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, void>)IntPtr.Zero;
-        _virtualTable.ecs_reset_clock = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_set_time_scale = (delegate* unmanaged[Cdecl]<ecs_world_t*, float, void>)IntPtr.Zero;
-        _virtualTable.ecs_progress = (delegate* unmanaged[Cdecl]<ecs_world_t*, float, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_get_pipeline = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_set_pipeline = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.FlecsSystemImport = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_match_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_match_failure_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_get_column_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_get_inactive_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_dbg_system_t*, int, ecs_table_t*>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_get_active_table = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_dbg_system_t*, int, ecs_table_t*>)IntPtr.Zero;
-        _virtualTable.ecs_dbg_system = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_dbg_system_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_get_system_ctx = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void*>)IntPtr.Zero;
-        _virtualTable.ecs_get_query = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_query_t*>)IntPtr.Zero;
-        _virtualTable.ecs_run_w_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, int, int, ecs_filter_t*, void*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_run_worker = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, int, float, void*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_run = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, void*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_system_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_system_desc_t*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_import_from_library = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_import = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_module_action_t, CString, void*, ulong, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_table_count = (delegate* unmanaged[Cdecl]<ecs_table_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_table_insert = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, ecs_entity_t, ecs_record_t*, ecs_record_t>)IntPtr.Zero;
-        _virtualTable.ecs_table_get_type = (delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_table_from_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_table_t*>)IntPtr.Zero;
-        _virtualTable.ecs_table_from_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_table_t*>)IntPtr.Zero;
-        _virtualTable.ecs_stage_is_async = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_async_stage_free = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_async_stage_new = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_t*>)IntPtr.Zero;
-        _virtualTable.ecs_stage_is_readonly = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_get_world = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_t*>)IntPtr.Zero;
-        _virtualTable.ecs_get_stage = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, ecs_world_t*>)IntPtr.Zero;
-        _virtualTable.ecs_get_stage_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_get_stage_count = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_set_stages = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_set_automerge = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, void>)IntPtr.Zero;
-        _virtualTable.ecs_defer_end = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_defer_begin = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_merge = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_staging_end = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_staging_begin = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_frame_end = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_frame_begin = (delegate* unmanaged[Cdecl]<ecs_world_t*, float, float>)IntPtr.Zero;
-        _virtualTable.ecs_iter_column_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong>)IntPtr.Zero;
-        _virtualTable.ecs_iter_column_w_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, void*>)IntPtr.Zero;
-        _virtualTable.ecs_iter_find_column = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_id_t, int>)IntPtr.Zero;
-        _virtualTable.ecs_iter_type = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_term_is_owned = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_term_is_readonly = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_term_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong>)IntPtr.Zero;
-        _virtualTable.ecs_term_source = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_term_id = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_id_t>)IntPtr.Zero;
-        _virtualTable.ecs_term_w_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, void*>)IntPtr.Zero;
-        _virtualTable.ecs_get_trigger_ctx = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void*>)IntPtr.Zero;
-        _virtualTable.ecs_trigger_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_trigger_desc_t*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_query_orphaned = (delegate* unmanaged[Cdecl]<ecs_query_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_query_changed = (delegate* unmanaged[Cdecl]<ecs_query_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_query_next_worker = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, int, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_query_next_w_filter = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_filter_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_query_next = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_query_iter_page = (delegate* unmanaged[Cdecl]<ecs_query_t*, int, int, ecs_iter_t>)IntPtr.Zero;
-        _virtualTable.ecs_query_iter = (delegate* unmanaged[Cdecl]<ecs_query_t*, ecs_iter_t>)IntPtr.Zero;
-        _virtualTable.ecs_query_fini = (delegate* unmanaged[Cdecl]<ecs_query_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_query_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_desc_t*, ecs_query_t*>)IntPtr.Zero;
-        _virtualTable.ecs_filter_next = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_filter_iter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, ecs_iter_t>)IntPtr.Zero;
-        _virtualTable.ecs_filter_match_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, ecs_entity_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_filter_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, CString>)IntPtr.Zero;
-        _virtualTable.ecs_filter_finalize = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_filter_fini = (delegate* unmanaged[Cdecl]<ecs_filter_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_filter_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, ecs_filter_desc_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_id_match = (delegate* unmanaged[Cdecl]<ecs_id_t, ecs_id_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_term_fini = (delegate* unmanaged[Cdecl]<ecs_term_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_term_move = (delegate* unmanaged[Cdecl]<ecs_term_t*, ecs_term_t>)IntPtr.Zero;
-        _virtualTable.ecs_term_copy = (delegate* unmanaged[Cdecl]<ecs_term_t*, ecs_term_t>)IntPtr.Zero;
-        _virtualTable.ecs_term_finalize = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString, ecs_term_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_term_is_trivial = (delegate* unmanaged[Cdecl]<ecs_term_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_term_is_set = (delegate* unmanaged[Cdecl]<ecs_term_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_set_name_prefix = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString>)IntPtr.Zero;
-        _virtualTable.ecs_get_scope = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_set_scope = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_scope_next = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_scope_iter_w_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_filter_t*, ecs_iter_t>)IntPtr.Zero;
-        _virtualTable.ecs_scope_iter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_iter_t>)IntPtr.Zero;
-        _virtualTable.ecs_get_child_count = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int>)IntPtr.Zero;
-        _virtualTable.ecs_add_path_w_sep = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, CString, CString, CString, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_new_from_path_w_sep = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, CString, CString, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_get_path_w_sep = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_entity_t, CString, CString, CString>)IntPtr.Zero;
-        _virtualTable.ecs_use = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, void>)IntPtr.Zero;
-        _virtualTable.ecs_lookup_symbol = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_lookup_path_w_sep = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, CString, CString, CBool, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_lookup_child = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_lookup = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_count_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_count_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int>)IntPtr.Zero;
-        _virtualTable.ecs_enable = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool, void>)IntPtr.Zero;
-        _virtualTable.ecs_get_object_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_id_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_id_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, CString, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.ecs_role_str = (delegate* unmanaged[Cdecl]<ecs_entity_t, CString>)IntPtr.Zero;
-        _virtualTable.ecs_get_name = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString>)IntPtr.Zero;
-        _virtualTable.ecs_get_typeid = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_get_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_exists = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_ensure = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_get_alive = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_is_alive = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_is_valid = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_has_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_set_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ulong, void*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_modified_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_get_mut_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool*, void*>)IntPtr.Zero;
-        _virtualTable.ecs_get_case = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_get_ref_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_ref_t*, ecs_entity_t, ecs_id_t, void*>)IntPtr.Zero;
-        _virtualTable.ecs_get_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void*>)IntPtr.Zero;
-        _virtualTable.ecs_delete_children = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_delete = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_clear = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_make_pair = (delegate* unmanaged[Cdecl]<ecs_entity_t, ecs_entity_t, ecs_id_t>)IntPtr.Zero;
-        _virtualTable.ecs_is_component_enabled_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_enable_component_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool, void>)IntPtr.Zero;
-        _virtualTable.ecs_remove_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_add_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_clone = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, CBool, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_new_w_data = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, ecs_entities_t*, void*, ecs_entity_t*>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_new_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int, ecs_entity_t*>)IntPtr.Zero;
-        _virtualTable.ecs_type_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_desc_t*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_component_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_component_desc_t*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_entity_init = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_desc_t*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_new_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_new_component_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_new_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_get_threads = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_set_target_fps = (delegate* unmanaged[Cdecl]<ecs_world_t*, float, void>)IntPtr.Zero;
-        _virtualTable.ecs_measure_system_time = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, void>)IntPtr.Zero;
-        _virtualTable.ecs_measure_frame_time = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, void>)IntPtr.Zero;
-        _virtualTable.ecs_tracing_enable = (delegate* unmanaged[Cdecl]<int, void>)IntPtr.Zero;
-        _virtualTable.ecs_end_wait = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_begin_wait = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_unlock = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_lock = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_enable_locking = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_enable_range_check = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_set_entity_range = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_dim = (delegate* unmanaged[Cdecl]<ecs_world_t*, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_get_world_info = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_info_t*>)IntPtr.Zero;
-        _virtualTable.ecs_get_context = (delegate* unmanaged[Cdecl]<ecs_world_t*, void*>)IntPtr.Zero;
-        _virtualTable.ecs_set_context = (delegate* unmanaged[Cdecl]<ecs_world_t*, void*, void>)IntPtr.Zero;
-        _virtualTable.ecs_set_component_actions_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, EcsComponentLifecycle*, void>)IntPtr.Zero;
-        _virtualTable.ecs_should_quit = (delegate* unmanaged[Cdecl]<ecs_world_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_quit = (delegate* unmanaged[Cdecl]<ecs_world_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_run_post_frame = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_fini_action_t, void*, void>)IntPtr.Zero;
-        _virtualTable.ecs_atfini = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_fini_action_t, void*, void>)IntPtr.Zero;
-        _virtualTable.ecs_fini = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_init_w_args = (delegate* unmanaged[Cdecl]<int, CString*, ecs_world_t*>)IntPtr.Zero;
-        _virtualTable.ecs_mini = (delegate* unmanaged[Cdecl]<ecs_world_t*>)IntPtr.Zero;
-        _virtualTable.ecs_init = (delegate* unmanaged[Cdecl]<ecs_world_t*>)IntPtr.Zero;
-        _virtualTable.ecs_query_group_by = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, ecs_entity_t, ecs_rank_type_action_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_query_order_by = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, ecs_entity_t, ecs_compare_action_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_query_free = (delegate* unmanaged[Cdecl]<ecs_query_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_subquery_new = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, CString, ecs_query_t*>)IntPtr.Zero;
-        _virtualTable.ecs_query_new = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_query_t*>)IntPtr.Zero;
-        _virtualTable.ecs_set_rate_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, ecs_entity_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_table_component_index = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_entity_t, int>)IntPtr.Zero;
-        _virtualTable.ecs_table_column_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong>)IntPtr.Zero;
-        _virtualTable.ecs_table_column = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, void*>)IntPtr.Zero;
-        _virtualTable.ecs_is_owned = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_is_readonly = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_column_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong>)IntPtr.Zero;
-        _virtualTable.ecs_column_type = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_column_entity = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_column_source = (delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_element_w_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, int, void*>)IntPtr.Zero;
-        _virtualTable.ecs_column_index_from_name = (delegate* unmanaged[Cdecl]<ecs_iter_t*, CString, int>)IntPtr.Zero;
-        _virtualTable.ecs_column_w_size = (delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, void*>)IntPtr.Zero;
-        _virtualTable.ecs_type_owns_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_type_has_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_type_to_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_type_from_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_add_remove_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ecs_id_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_remove_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_add_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_get_thread_index = (delegate* unmanaged[Cdecl]<ecs_world_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_get_parent_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_entity_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, CString, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.ecs_has_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_set_ptr_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ulong, void*, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_modified_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_get_mut_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool*, void*>)IntPtr.Zero;
-        _virtualTable.ecs_get_ref_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_ref_t*, ecs_entity_t, ecs_id_t, void*>)IntPtr.Zero;
-        _virtualTable.ecs_get_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void*>)IntPtr.Zero;
-        _virtualTable.ecs_get_w_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void*>)IntPtr.Zero;
-        _virtualTable.ecs_is_component_enabled_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_enable_component_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool, void>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_new_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int, ecs_entity_t*>)IntPtr.Zero;
-        _virtualTable.ecs_new_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_set_component_actions_w_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, EcsComponentLifecycle*, void>)IntPtr.Zero;
-        _virtualTable.ecs_count_w_filter = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_count_entity = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int>)IntPtr.Zero;
-        _virtualTable.ecs_count_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, int>)IntPtr.Zero;
-        _virtualTable.ecs_has_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_add_remove_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, ecs_type_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_remove_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_add_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_bulk_new_w_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, int, ecs_entity_t*>)IntPtr.Zero;
-        _virtualTable.ecs_new_w_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_dim_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_type_match = (delegate* unmanaged[Cdecl]<ecs_type_t, int, ecs_entity_t, int>)IntPtr.Zero;
-        _virtualTable.ecs_type_index_of = (delegate* unmanaged[Cdecl]<ecs_type_t, ecs_entity_t, int>)IntPtr.Zero;
-        _virtualTable.ecs_type_get_entity_for_xor = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_type_find_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_entity_t, int, int, ecs_entity_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_type_owns_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, CBool, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_type_owns_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_type_has_type = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_type_has_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_type_remove = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_type_add = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_type_merge = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, ecs_type_t, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_type_find = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t*, int, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_type_from_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_type_t>)IntPtr.Zero;
-        _virtualTable.ecs_type_str = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, CString>)IntPtr.Zero;
-        _virtualTable.ecs_type_to_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_type_from_id = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t>)IntPtr.Zero;
-        _virtualTable._ecs_parser_error = (delegate* unmanaged[Cdecl]<CString, CString, long, CString, void>)IntPtr.Zero;
-        _virtualTable._ecs_assert = (delegate* unmanaged[Cdecl]<CBool, int, CString, CString, CString, int, void>)IntPtr.Zero;
-        _virtualTable._ecs_abort = (delegate* unmanaged[Cdecl]<int, CString, CString, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_strerror = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.ecs_log_pop = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.ecs_log_push = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable._ecs_deprecated = (delegate* unmanaged[Cdecl]<CString, int, CString, void>)IntPtr.Zero;
-        _virtualTable._ecs_err = (delegate* unmanaged[Cdecl]<CString, int, CString, void>)IntPtr.Zero;
-        _virtualTable._ecs_warn = (delegate* unmanaged[Cdecl]<CString, int, CString, void>)IntPtr.Zero;
-        _virtualTable._ecs_trace = (delegate* unmanaged[Cdecl]<int, CString, int, CString, void>)IntPtr.Zero;
-        _virtualTable.ecs_query_get_filter = (delegate* unmanaged[Cdecl]<ecs_query_t*, ecs_filter_t*>)IntPtr.Zero;
-        _virtualTable.ecs_identifier_is_var = (delegate* unmanaged[Cdecl]<CString, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_identifier_is_0 = (delegate* unmanaged[Cdecl]<CString, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_component_has_actions = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_module_path_from_c = (delegate* unmanaged[Cdecl]<CString, CString>)IntPtr.Zero;
-        _virtualTable.ecs_new_module = (delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, ulong, ulong, ecs_entity_t>)IntPtr.Zero;
-        _virtualTable.ecs_os_has_modules = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.ecs_os_has_dl = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.ecs_os_has_logging = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.ecs_os_has_time = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.ecs_os_has_threading = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.ecs_os_has_heap = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.ecs_os_memdup = (delegate* unmanaged[Cdecl]<void*, ecs_size_t, void*>)IntPtr.Zero;
-        _virtualTable.ecs_time_to_double = (delegate* unmanaged[Cdecl]<ecs_time_t, double>)IntPtr.Zero;
-        _virtualTable.ecs_time_sub = (delegate* unmanaged[Cdecl]<ecs_time_t, ecs_time_t, ecs_time_t>)IntPtr.Zero;
-        _virtualTable.ecs_time_measure = (delegate* unmanaged[Cdecl]<ecs_time_t*, double>)IntPtr.Zero;
-        _virtualTable.ecs_sleepf = (delegate* unmanaged[Cdecl]<double, void>)IntPtr.Zero;
-        _virtualTable.ecs_os_dbg = (delegate* unmanaged[Cdecl]<CString, void>)IntPtr.Zero;
-        _virtualTable.ecs_os_err = (delegate* unmanaged[Cdecl]<CString, void>)IntPtr.Zero;
-        _virtualTable.ecs_os_warn = (delegate* unmanaged[Cdecl]<CString, void>)IntPtr.Zero;
-        _virtualTable.ecs_os_log = (delegate* unmanaged[Cdecl]<CString, void>)IntPtr.Zero;
-        _virtualTable.ecs_os_set_api_defaults = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.ecs_os_set_api = (delegate* unmanaged[Cdecl]<ecs_os_api_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_os_fini = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.ecs_os_init = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_list_appendstr = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_list_append = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_list_next = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_list_pop = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, void>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_list_push = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CString, void>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_reset = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_get = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_appendstrn = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, int, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_appendstr_zerocpy_const = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_appendstr_zerocpy = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_mergebuff = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, ecs_strbuf_t*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_appendstr = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_vappend = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, IntPtr, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_strbuf_append = (delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_map_memory = (delegate* unmanaged[Cdecl]<ecs_map_t*, int*, int*, void>)IntPtr.Zero;
-        _virtualTable.ecs_map_set_size = (delegate* unmanaged[Cdecl]<ecs_map_t*, int, void>)IntPtr.Zero;
-        _virtualTable.ecs_map_grow = (delegate* unmanaged[Cdecl]<ecs_map_t*, int, void>)IntPtr.Zero;
-        _virtualTable._ecs_map_next_ptr = (delegate* unmanaged[Cdecl]<ecs_map_iter_t*, ecs_map_key_t*, void*>)IntPtr.Zero;
-        _virtualTable._ecs_map_next = (delegate* unmanaged[Cdecl]<ecs_map_iter_t*, ecs_size_t, ecs_map_key_t*, void*>)IntPtr.Zero;
-        _virtualTable.ecs_map_iter = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_map_iter_t>)IntPtr.Zero;
-        _virtualTable.ecs_map_bucket_count = (delegate* unmanaged[Cdecl]<ecs_map_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_map_count = (delegate* unmanaged[Cdecl]<ecs_map_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_map_clear = (delegate* unmanaged[Cdecl]<ecs_map_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_map_remove = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_map_key_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_map_free = (delegate* unmanaged[Cdecl]<ecs_map_t*, void>)IntPtr.Zero;
-        _virtualTable._ecs_map_set = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_size_t, ecs_map_key_t, void*, void*>)IntPtr.Zero;
-        _virtualTable._ecs_map_ensure = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_size_t, ecs_map_key_t, void*>)IntPtr.Zero;
-        _virtualTable._ecs_map_get_ptr = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_map_key_t, void*>)IntPtr.Zero;
-        _virtualTable._ecs_map_get = (delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_size_t, ecs_map_key_t, void*>)IntPtr.Zero;
-        _virtualTable._ecs_map_new = (delegate* unmanaged[Cdecl]<ecs_size_t, ecs_size_t, int, ecs_map_t*>)IntPtr.Zero;
-        _virtualTable._ecs_vector_copy = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, ecs_vector_t*>)IntPtr.Zero;
-        _virtualTable._ecs_vector_memory = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, int*, int*, void>)IntPtr.Zero;
-        _virtualTable._ecs_vector_sort = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, ecs_comparator_t, void>)IntPtr.Zero;
-        _virtualTable._ecs_vector_first = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void*>)IntPtr.Zero;
-        _virtualTable.ecs_vector_size = (delegate* unmanaged[Cdecl]<ecs_vector_t*, int>)IntPtr.Zero;
-        _virtualTable.ecs_vector_count = (delegate* unmanaged[Cdecl]<ecs_vector_t*, int>)IntPtr.Zero;
-        _virtualTable._ecs_vector_set_count = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)IntPtr.Zero;
-        _virtualTable._ecs_vector_set_size = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)IntPtr.Zero;
-        _virtualTable._ecs_vector_grow = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)IntPtr.Zero;
-        _virtualTable._ecs_vector_reclaim = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, void>)IntPtr.Zero;
-        _virtualTable._ecs_vector_remove_index = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, int, int>)IntPtr.Zero;
-        _virtualTable._ecs_vector_move_index = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_vector_t*, ecs_size_t, short, int, int>)IntPtr.Zero;
-        _virtualTable._ecs_vector_pop = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void*, CBool>)IntPtr.Zero;
-        _virtualTable.ecs_vector_remove_last = (delegate* unmanaged[Cdecl]<ecs_vector_t*, void>)IntPtr.Zero;
-        _virtualTable._ecs_vector_set_min_count = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)IntPtr.Zero;
-        _virtualTable._ecs_vector_set_min_size = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int>)IntPtr.Zero;
-        _virtualTable._ecs_vector_last = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void*>)IntPtr.Zero;
-        _virtualTable._ecs_vector_get = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, int, void*>)IntPtr.Zero;
-        _virtualTable._ecs_vector_addn = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, void*>)IntPtr.Zero;
-        _virtualTable._ecs_vector_add = (delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, void*>)IntPtr.Zero;
-        _virtualTable.ecs_vector_assert_alignment = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_vector_assert_size = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, void>)IntPtr.Zero;
-        _virtualTable.ecs_vector_clear = (delegate* unmanaged[Cdecl]<ecs_vector_t*, void>)IntPtr.Zero;
-        _virtualTable.ecs_vector_free = (delegate* unmanaged[Cdecl]<ecs_vector_t*, void>)IntPtr.Zero;
-        _virtualTable._ecs_vector_zero = (delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void>)IntPtr.Zero;
-        _virtualTable._ecs_vector_from_array = (delegate* unmanaged[Cdecl]<ecs_size_t, short, int, void*, ecs_vector_t*>)IntPtr.Zero;
-        _virtualTable._ecs_vector_new = (delegate* unmanaged[Cdecl]<ecs_size_t, short, int, ecs_vector_t*>)IntPtr.Zero;
-
-        #endregion
-
-        #region "Variables"
-
-        _virtualTable.FLECS__TEcsRateFilter = IntPtr.Zero;
-        _virtualTable.FLECS__TEcsTimer = IntPtr.Zero;
-        _virtualTable.FLECS__TEcsTickSource = IntPtr.Zero;
-        _virtualTable.FLECS__TEcsSystem = IntPtr.Zero;
-        _virtualTable.EcsPostFrame = IntPtr.Zero;
-        _virtualTable.EcsOnStore = IntPtr.Zero;
-        _virtualTable.EcsPreStore = IntPtr.Zero;
-        _virtualTable.EcsPostUpdate = IntPtr.Zero;
-        _virtualTable.EcsOnValidate = IntPtr.Zero;
-        _virtualTable.EcsOnUpdate = IntPtr.Zero;
-        _virtualTable.EcsPreUpdate = IntPtr.Zero;
-        _virtualTable.EcsPostLoad = IntPtr.Zero;
-        _virtualTable.EcsOnLoad = IntPtr.Zero;
-        _virtualTable.EcsPreFrame = IntPtr.Zero;
-        _virtualTable.EcsPipeline = IntPtr.Zero;
-        _virtualTable.EcsInactive = IntPtr.Zero;
-        _virtualTable.EcsDisabledIntern = IntPtr.Zero;
-        _virtualTable.EcsMonitor = IntPtr.Zero;
-        _virtualTable.EcsOnDemand = IntPtr.Zero;
-        _virtualTable.EcsThrow = IntPtr.Zero;
-        _virtualTable.EcsDelete = IntPtr.Zero;
-        _virtualTable.EcsRemove = IntPtr.Zero;
-        _virtualTable.EcsOnDeleteObject = IntPtr.Zero;
-        _virtualTable.EcsOnDelete = IntPtr.Zero;
-        _virtualTable.EcsUnSet = IntPtr.Zero;
-        _virtualTable.EcsOnSet = IntPtr.Zero;
-        _virtualTable.EcsOnRemove = IntPtr.Zero;
-        _virtualTable.EcsOnAdd = IntPtr.Zero;
-        _virtualTable.EcsHidden = IntPtr.Zero;
-        _virtualTable.EcsDisabled = IntPtr.Zero;
-        _virtualTable.EcsPrefab = IntPtr.Zero;
-        _virtualTable.EcsModule = IntPtr.Zero;
-        _virtualTable.EcsIsA = IntPtr.Zero;
-        _virtualTable.EcsChildOf = IntPtr.Zero;
-        _virtualTable.EcsFinal = IntPtr.Zero;
-        _virtualTable.EcsTransitive = IntPtr.Zero;
-        _virtualTable.EcsThis = IntPtr.Zero;
-        _virtualTable.EcsWildcard = IntPtr.Zero;
-        _virtualTable.EcsWorld = IntPtr.Zero;
-        _virtualTable.EcsFlecsCore = IntPtr.Zero;
-        _virtualTable.EcsFlecs = IntPtr.Zero;
-        _virtualTable.ECS_DISABLED = IntPtr.Zero;
-        _virtualTable.ECS_OWNED = IntPtr.Zero;
-        _virtualTable.ECS_PAIR = IntPtr.Zero;
-        _virtualTable.ECS_SWITCH = IntPtr.Zero;
-        _virtualTable.ECS_CASE = IntPtr.Zero;
-        _virtualTable.FLECS__TEcsName = IntPtr.Zero;
-        _virtualTable.FLECS__TEcsType = IntPtr.Zero;
-        _virtualTable.FLECS__TEcsComponentLifecycle = IntPtr.Zero;
-        _virtualTable.FLECS__TEcsComponent = IntPtr.Zero;
-        _virtualTable.ecs_os_api = IntPtr.Zero;
-        _virtualTable.ecs_os_api_free_count = IntPtr.Zero;
-        _virtualTable.ecs_os_api_calloc_count = IntPtr.Zero;
-        _virtualTable.ecs_os_api_realloc_count = IntPtr.Zero;
-        _virtualTable.ecs_os_api_malloc_count = IntPtr.Zero;
-
-        #endregion
-    }
-
-    // The virtual table represents a list of pointers to functions or variables which are resolved in a late manner.
-    //	This allows for flexibility in swapping implementations at runtime.
-    //	You can think of it in traditional OOP terms in C# as the locations of the virtual methods and/or properties of an object.
-    public struct _VirtualTable
-    {
-        #region "Function Pointers"
-        // These pointers hold the locations in the native library where functions are located at runtime.
-        // See: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
-
-        public delegate* unmanaged[Cdecl]<ecs_gauge_t*, int, ecs_gauge_t*, int, void> ecs_gauge_reduce;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_pipeline_stats_t*, CBool> ecs_get_pipeline_stats;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_system_stats_t*, CBool> ecs_get_system_stats;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, ecs_query_stats_t*, void> ecs_get_query_stats;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_stats_t*, void> ecs_dump_world_stats;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_stats_t*, void> ecs_get_world_stats;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_record_t*, int, ulong, void*, int, void> ecs_record_move_to;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_record_t*, int, ulong, void*, int, void> ecs_record_copy_pod_to;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_record_t*, int, ulong, void*, int, void> ecs_record_copy_to;
-        public delegate* unmanaged[Cdecl]<ecs_record_t*, int, ulong, void*> ecs_record_get_column;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_record_t*> ecs_record_ensure;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_record_t*> ecs_record_find;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, int, ecs_vector_t*, void> ecs_table_delete_column;
-        public delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_vector_t*, ecs_vector_t*, void> ecs_table_set_entities;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_vector_t*, ecs_vector_t*, ecs_table_t*, void> ecs_records_update;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, void> ecs_records_clear;
-        public delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_vector_t*> ecs_table_get_records;
-        public delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_vector_t*> ecs_table_get_entities;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, int, ecs_vector_t*, ecs_vector_t*> ecs_table_set_column;
-        public delegate* unmanaged[Cdecl]<ecs_table_t*, int, ecs_vector_t*> ecs_table_get_column;
-        public delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_entity_t, int> ecs_table_find_column;
-        public delegate* unmanaged[Cdecl]<ecs_snapshot_t*, void> ecs_snapshot_free;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool> ecs_snapshot_next;
-        public delegate* unmanaged[Cdecl]<ecs_snapshot_t*, ecs_filter_t*, ecs_iter_t> ecs_snapshot_iter;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_snapshot_t*, void> ecs_snapshot_restore;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_iter_next_action_t, ecs_snapshot_t*> ecs_snapshot_take_w_iter;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_snapshot_t*> ecs_snapshot_take;
-        public delegate* unmanaged[Cdecl]<CString, int, ecs_writer_t*, int> ecs_writer_write;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_writer_t> ecs_writer_init;
-        public delegate* unmanaged[Cdecl]<CString, int, ecs_reader_t*, int> ecs_reader_read;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_iter_next_action_t, ecs_reader_t> ecs_reader_init_w_iter;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_reader_t> ecs_reader_init;
-        public delegate* unmanaged[Cdecl]<ecs_queue_t*, void> ecs_queue_free;
-        public delegate* unmanaged[Cdecl]<ecs_queue_t*, int> ecs_queue_count;
-        public delegate* unmanaged[Cdecl]<ecs_queue_t*, int> ecs_queue_index;
-        public delegate* unmanaged[Cdecl]<ecs_queue_t*, ecs_size_t, short, void*> _ecs_queue_last;
-        public delegate* unmanaged[Cdecl]<ecs_queue_t*, ecs_size_t, short, int, void*> _ecs_queue_get;
-        public delegate* unmanaged[Cdecl]<ecs_queue_t*, ecs_size_t, short, void*> _ecs_queue_push;
-        public delegate* unmanaged[Cdecl]<ecs_size_t, short, int, void*, ecs_queue_t*> _ecs_queue_from_array;
-        public delegate* unmanaged[Cdecl]<ecs_size_t, short, int, ecs_queue_t*> _ecs_queue_new;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString, CString, ecs_term_t*, CString> ecs_parse_term;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, ecs_dbg_table_t*, void> ecs_dbg_table;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, ecs_filter_t*, CBool> ecs_dbg_filter_table;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int, ecs_table_t*> ecs_dbg_get_table;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_table_t*> ecs_dbg_find_table;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_dbg_entity_t*, void> ecs_dbg_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, void> ecs_bulk_delete;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, ecs_filter_t*, void> ecs_bulk_add_remove_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_filter_t*, void> ecs_bulk_remove_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_filter_t*, void> ecs_bulk_remove_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_filter_t*, void> ecs_bulk_add_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_filter_t*, void> ecs_bulk_add_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> FlecsTimerImport;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, void> ecs_set_tick_source;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, ecs_entity_t, ecs_entity_t> ecs_set_rate;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void> ecs_stop_timer;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void> ecs_start_timer;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float> ecs_get_interval;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, ecs_entity_t> ecs_set_interval;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float> ecs_get_timeout;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, ecs_entity_t> ecs_set_timeout;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> FlecsPipelineImport;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int, void> ecs_set_threads;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_deactivate_systems;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, void> ecs_pipeline_run;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_reset_clock;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, float, void> ecs_set_time_scale;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, float, CBool> ecs_progress;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t> ecs_get_pipeline;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void> ecs_set_pipeline;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> FlecsSystemImport;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_match_failure_t*, CBool> ecs_dbg_match_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, ecs_type_t> ecs_dbg_get_column_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_dbg_system_t*, int, ecs_table_t*> ecs_dbg_get_inactive_table;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_dbg_system_t*, int, ecs_table_t*> ecs_dbg_get_active_table;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_dbg_system_t*, int> ecs_dbg_system;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void*> ecs_get_system_ctx;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_query_t*> ecs_get_query;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, int, int, ecs_filter_t*, void*, ecs_entity_t> ecs_run_w_filter;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, int, float, void*, ecs_entity_t> ecs_run_worker;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, float, void*, ecs_entity_t> ecs_run;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_system_desc_t*, ecs_entity_t> ecs_system_init;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString, ecs_entity_t> ecs_import_from_library;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_module_action_t, CString, void*, ulong, ecs_entity_t> ecs_import;
-        public delegate* unmanaged[Cdecl]<ecs_table_t*, int> ecs_table_count;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_table_t*, ecs_entity_t, ecs_record_t*, ecs_record_t> ecs_table_insert;
-        public delegate* unmanaged[Cdecl]<ecs_table_t*, ecs_type_t> ecs_table_get_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_table_t*> ecs_table_from_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_table_t*> ecs_table_from_str;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool> ecs_stage_is_async;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_async_stage_free;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_t*> ecs_async_stage_new;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool> ecs_stage_is_readonly;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_t*> ecs_get_world;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int, ecs_world_t*> ecs_get_stage;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int> ecs_get_stage_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int> ecs_get_stage_count;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int, void> ecs_set_stages;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, void> ecs_set_automerge;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool> ecs_defer_end;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool> ecs_defer_begin;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_merge;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_staging_end;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool> ecs_staging_begin;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_frame_end;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, float, float> ecs_frame_begin;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong> ecs_iter_column_size;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, void*> ecs_iter_column_w_size;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_id_t, int> ecs_iter_find_column;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_type_t> ecs_iter_type;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool> ecs_term_is_owned;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool> ecs_term_is_readonly;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong> ecs_term_size;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_entity_t> ecs_term_source;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_id_t> ecs_term_id;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, void*> ecs_term_w_size;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void*> ecs_get_trigger_ctx;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_trigger_desc_t*, ecs_entity_t> ecs_trigger_init;
-        public delegate* unmanaged[Cdecl]<ecs_query_t*, CBool> ecs_query_orphaned;
-        public delegate* unmanaged[Cdecl]<ecs_query_t*, CBool> ecs_query_changed;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, int, CBool> ecs_query_next_worker;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_filter_t*, CBool> ecs_query_next_w_filter;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool> ecs_query_next;
-        public delegate* unmanaged[Cdecl]<ecs_query_t*, int, int, ecs_iter_t> ecs_query_iter_page;
-        public delegate* unmanaged[Cdecl]<ecs_query_t*, ecs_iter_t> ecs_query_iter;
-        public delegate* unmanaged[Cdecl]<ecs_query_t*, void> ecs_query_fini;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_desc_t*, ecs_query_t*> ecs_query_init;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool> ecs_filter_next;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, ecs_iter_t> ecs_filter_iter;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, ecs_entity_t, CBool> ecs_filter_match_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, CString> ecs_filter_str;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, int> ecs_filter_finalize;
-        public delegate* unmanaged[Cdecl]<ecs_filter_t*, void> ecs_filter_fini;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, ecs_filter_desc_t*, int> ecs_filter_init;
-        public delegate* unmanaged[Cdecl]<ecs_id_t, ecs_id_t, CBool> ecs_id_match;
-        public delegate* unmanaged[Cdecl]<ecs_term_t*, void> ecs_term_fini;
-        public delegate* unmanaged[Cdecl]<ecs_term_t*, ecs_term_t> ecs_term_move;
-        public delegate* unmanaged[Cdecl]<ecs_term_t*, ecs_term_t> ecs_term_copy;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString, ecs_term_t*, int> ecs_term_finalize;
-        public delegate* unmanaged[Cdecl]<ecs_term_t*, CBool> ecs_term_is_trivial;
-        public delegate* unmanaged[Cdecl]<ecs_term_t*, CBool> ecs_term_is_set;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CString, CString> ecs_set_name_prefix;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t> ecs_get_scope;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t> ecs_set_scope;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, CBool> ecs_scope_next;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_filter_t*, ecs_iter_t> ecs_scope_iter_w_filter;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_iter_t> ecs_scope_iter;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int> ecs_get_child_count;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, CString, CString, CString, ecs_entity_t> ecs_add_path_w_sep;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, CString, CString, ecs_entity_t> ecs_new_from_path_w_sep;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_entity_t, CString, CString, CString> ecs_get_path_w_sep;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, void> ecs_use;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_entity_t> ecs_lookup_symbol;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, CString, CString, CBool, ecs_entity_t> ecs_lookup_path_w_sep;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, ecs_entity_t> ecs_lookup_child;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_entity_t> ecs_lookup;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, int> ecs_count_filter;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int> ecs_count_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool, void> ecs_enable;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_id_t, ecs_entity_t> ecs_get_object_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, CString, ulong, ulong> ecs_id_str;
-        public delegate* unmanaged[Cdecl]<ecs_entity_t, CString> ecs_role_str;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString> ecs_get_name;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t> ecs_get_typeid;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t> ecs_get_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool> ecs_exists;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void> ecs_ensure;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t> ecs_get_alive;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool> ecs_is_alive;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool> ecs_is_valid;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool> ecs_has_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ulong, void*, ecs_entity_t> ecs_set_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void> ecs_modified_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool*, void*> ecs_get_mut_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, ecs_entity_t> ecs_get_case;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_ref_t*, ecs_entity_t, ecs_id_t, void*> ecs_get_ref_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void*> ecs_get_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void> ecs_delete_children;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void> ecs_delete;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, void> ecs_clear;
-        public delegate* unmanaged[Cdecl]<ecs_entity_t, ecs_entity_t, ecs_id_t> ecs_make_pair;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool> ecs_is_component_enabled_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool, void> ecs_enable_component_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void> ecs_remove_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void> ecs_add_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, CBool, ecs_entity_t> ecs_clone;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int, ecs_entities_t*, void*, ecs_entity_t*> ecs_bulk_new_w_data;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int, ecs_entity_t*> ecs_bulk_new_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_desc_t*, ecs_entity_t> ecs_type_init;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_component_desc_t*, ecs_entity_t> ecs_component_init;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_desc_t*, ecs_entity_t> ecs_entity_init;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, ecs_entity_t> ecs_new_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t> ecs_new_component_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t> ecs_new_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int> ecs_get_threads;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, float, void> ecs_set_target_fps;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, void> ecs_measure_system_time;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, void> ecs_measure_frame_time;
-        public delegate* unmanaged[Cdecl]<int, void> ecs_tracing_enable;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_end_wait;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_begin_wait;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_unlock;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_lock;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, CBool> ecs_enable_locking;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool, CBool> ecs_enable_range_check;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, void> ecs_set_entity_range;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int, void> ecs_dim;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_world_info_t*> ecs_get_world_info;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void*> ecs_get_context;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void*, void> ecs_set_context;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, EcsComponentLifecycle*, void> ecs_set_component_actions_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CBool> ecs_should_quit;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, void> ecs_quit;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_fini_action_t, void*, void> ecs_run_post_frame;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_fini_action_t, void*, void> ecs_atfini;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int> ecs_fini;
-        public delegate* unmanaged[Cdecl]<int, CString*, ecs_world_t*> ecs_init_w_args;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*> ecs_mini;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*> ecs_init;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, ecs_entity_t, ecs_rank_type_action_t, void> ecs_query_group_by;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, ecs_entity_t, ecs_compare_action_t, void> ecs_query_order_by;
-        public delegate* unmanaged[Cdecl]<ecs_query_t*, void> ecs_query_free;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_query_t*, CString, ecs_query_t*> ecs_subquery_new;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_query_t*> ecs_query_new;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, int, ecs_entity_t, ecs_entity_t> ecs_set_rate_filter;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ecs_entity_t, int> ecs_table_component_index;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong> ecs_table_column_size;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, void*> ecs_table_column;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool> ecs_is_owned;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, CBool> ecs_is_readonly;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ulong> ecs_column_size;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_type_t> ecs_column_type;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_entity_t> ecs_column_entity;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, int, ecs_entity_t> ecs_column_source;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, int, void*> ecs_element_w_size;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, CString, int> ecs_column_index_from_name;
-        public delegate* unmanaged[Cdecl]<ecs_iter_t*, ulong, int, void*> ecs_column_w_size;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool, CBool> ecs_type_owns_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool> ecs_type_has_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t> ecs_type_to_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t> ecs_type_from_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ecs_id_t, void> ecs_add_remove_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void> ecs_remove_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_entity_t, void> ecs_add_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, int> ecs_get_thread_index;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ecs_entity_t> ecs_get_parent_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, CString, ulong, ulong> ecs_entity_str;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool> ecs_has_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, ulong, void*, ecs_entity_t> ecs_set_ptr_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void> ecs_modified_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool*, void*> ecs_get_mut_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_ref_t*, ecs_entity_t, ecs_id_t, void*> ecs_get_ref_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void*> ecs_get_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, void*> ecs_get_w_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool> ecs_is_component_enabled_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_id_t, CBool, void> ecs_enable_component_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int, ecs_entity_t*> ecs_bulk_new_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, ecs_entity_t> ecs_new_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, EcsComponentLifecycle*, void> ecs_set_component_actions_w_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_filter_t*, int> ecs_count_w_filter;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_id_t, int> ecs_count_entity;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, int> ecs_count_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, CBool> ecs_has_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, ecs_type_t, void> ecs_add_remove_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, void> ecs_remove_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t, void> ecs_add_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, int, ecs_entity_t*> ecs_bulk_new_w_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t> ecs_new_w_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, int, void> ecs_dim_type;
-        public delegate* unmanaged[Cdecl]<ecs_type_t, int, ecs_entity_t, int> ecs_type_match;
-        public delegate* unmanaged[Cdecl]<ecs_type_t, ecs_entity_t, int> ecs_type_index_of;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_entity_t> ecs_type_get_entity_for_xor;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_entity_t, int, int, ecs_entity_t*, CBool> ecs_type_find_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, CBool, CBool> ecs_type_owns_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool, CBool> ecs_type_owns_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, CBool> ecs_type_has_type;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, CBool> ecs_type_has_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_type_t> ecs_type_remove;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t, ecs_type_t> ecs_type_add;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_type_t, ecs_type_t, ecs_type_t> ecs_type_merge;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t*, int, ecs_type_t> ecs_type_find;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, CString, ecs_type_t> ecs_type_from_str;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, CString> ecs_type_str;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_type_t, ecs_entity_t> ecs_type_to_id;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, ecs_type_t> ecs_type_from_id;
-        public delegate* unmanaged[Cdecl]<CString, CString, long, CString, void> _ecs_parser_error;
-        public delegate* unmanaged[Cdecl]<CBool, int, CString, CString, CString, int, void> _ecs_assert;
-        public delegate* unmanaged[Cdecl]<int, CString, CString, int, void> _ecs_abort;
-        public delegate* unmanaged[Cdecl]<int, CString> ecs_strerror;
-        public delegate* unmanaged[Cdecl]<void> ecs_log_pop;
-        public delegate* unmanaged[Cdecl]<void> ecs_log_push;
-        public delegate* unmanaged[Cdecl]<CString, int, CString, void> _ecs_deprecated;
-        public delegate* unmanaged[Cdecl]<CString, int, CString, void> _ecs_err;
-        public delegate* unmanaged[Cdecl]<CString, int, CString, void> _ecs_warn;
-        public delegate* unmanaged[Cdecl]<int, CString, int, CString, void> _ecs_trace;
-        public delegate* unmanaged[Cdecl]<ecs_query_t*, ecs_filter_t*> ecs_query_get_filter;
-        public delegate* unmanaged[Cdecl]<CString, CBool> ecs_identifier_is_var;
-        public delegate* unmanaged[Cdecl]<CString, CBool> ecs_identifier_is_0;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CBool> ecs_component_has_actions;
-        public delegate* unmanaged[Cdecl]<CString, CString> ecs_module_path_from_c;
-        public delegate* unmanaged[Cdecl]<ecs_world_t*, ecs_entity_t, CString, ulong, ulong, ecs_entity_t> ecs_new_module;
-        public delegate* unmanaged[Cdecl]<CBool> ecs_os_has_modules;
-        public delegate* unmanaged[Cdecl]<CBool> ecs_os_has_dl;
-        public delegate* unmanaged[Cdecl]<CBool> ecs_os_has_logging;
-        public delegate* unmanaged[Cdecl]<CBool> ecs_os_has_time;
-        public delegate* unmanaged[Cdecl]<CBool> ecs_os_has_threading;
-        public delegate* unmanaged[Cdecl]<CBool> ecs_os_has_heap;
-        public delegate* unmanaged[Cdecl]<void*, ecs_size_t, void*> ecs_os_memdup;
-        public delegate* unmanaged[Cdecl]<ecs_time_t, double> ecs_time_to_double;
-        public delegate* unmanaged[Cdecl]<ecs_time_t, ecs_time_t, ecs_time_t> ecs_time_sub;
-        public delegate* unmanaged[Cdecl]<ecs_time_t*, double> ecs_time_measure;
-        public delegate* unmanaged[Cdecl]<double, void> ecs_sleepf;
-        public delegate* unmanaged[Cdecl]<CString, void> ecs_os_dbg;
-        public delegate* unmanaged[Cdecl]<CString, void> ecs_os_err;
-        public delegate* unmanaged[Cdecl]<CString, void> ecs_os_warn;
-        public delegate* unmanaged[Cdecl]<CString, void> ecs_os_log;
-        public delegate* unmanaged[Cdecl]<void> ecs_os_set_api_defaults;
-        public delegate* unmanaged[Cdecl]<ecs_os_api_t*, void> ecs_os_set_api;
-        public delegate* unmanaged[Cdecl]<void> ecs_os_fini;
-        public delegate* unmanaged[Cdecl]<void> ecs_os_init;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool> ecs_strbuf_list_appendstr;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool> ecs_strbuf_list_append;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, void> ecs_strbuf_list_next;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, void> ecs_strbuf_list_pop;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CString, void> ecs_strbuf_list_push;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, void> ecs_strbuf_reset;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString> ecs_strbuf_get;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, int, CBool> ecs_strbuf_appendstrn;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool> ecs_strbuf_appendstr_zerocpy_const;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool> ecs_strbuf_appendstr_zerocpy;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, ecs_strbuf_t*, CBool> ecs_strbuf_mergebuff;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool> ecs_strbuf_appendstr;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, IntPtr, CBool> ecs_strbuf_vappend;
-        public delegate* unmanaged[Cdecl]<ecs_strbuf_t*, CString, CBool> ecs_strbuf_append;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, int*, int*, void> ecs_map_memory;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, int, void> ecs_map_set_size;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, int, void> ecs_map_grow;
-        public delegate* unmanaged[Cdecl]<ecs_map_iter_t*, ecs_map_key_t*, void*> _ecs_map_next_ptr;
-        public delegate* unmanaged[Cdecl]<ecs_map_iter_t*, ecs_size_t, ecs_map_key_t*, void*> _ecs_map_next;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_map_iter_t> ecs_map_iter;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, int> ecs_map_bucket_count;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, int> ecs_map_count;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, void> ecs_map_clear;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_map_key_t, void> ecs_map_remove;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, void> ecs_map_free;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_size_t, ecs_map_key_t, void*, void*> _ecs_map_set;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_size_t, ecs_map_key_t, void*> _ecs_map_ensure;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_map_key_t, void*> _ecs_map_get_ptr;
-        public delegate* unmanaged[Cdecl]<ecs_map_t*, ecs_size_t, ecs_map_key_t, void*> _ecs_map_get;
-        public delegate* unmanaged[Cdecl]<ecs_size_t, ecs_size_t, int, ecs_map_t*> _ecs_map_new;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, ecs_vector_t*> _ecs_vector_copy;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, int*, int*, void> _ecs_vector_memory;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, ecs_comparator_t, void> _ecs_vector_sort;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void*> _ecs_vector_first;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, int> ecs_vector_size;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, int> ecs_vector_count;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int> _ecs_vector_set_count;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int> _ecs_vector_set_size;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int> _ecs_vector_grow;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, void> _ecs_vector_reclaim;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, int, int> _ecs_vector_remove_index;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_vector_t*, ecs_size_t, short, int, int> _ecs_vector_move_index;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void*, CBool> _ecs_vector_pop;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, void> ecs_vector_remove_last;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int> _ecs_vector_set_min_count;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, int> _ecs_vector_set_min_size;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void*> _ecs_vector_last;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, int, void*> _ecs_vector_get;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, int, void*> _ecs_vector_addn;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t**, ecs_size_t, short, void*> _ecs_vector_add;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, void> ecs_vector_assert_alignment;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, void> ecs_vector_assert_size;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, void> ecs_vector_clear;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, void> ecs_vector_free;
-        public delegate* unmanaged[Cdecl]<ecs_vector_t*, ecs_size_t, short, void> _ecs_vector_zero;
-        public delegate* unmanaged[Cdecl]<ecs_size_t, short, int, void*, ecs_vector_t*> _ecs_vector_from_array;
-        public delegate* unmanaged[Cdecl]<ecs_size_t, short, int, ecs_vector_t*> _ecs_vector_new;
-
-        #endregion
-
-        #region "Variables"
-        // These pointers hold the locations in the native library where global variables are located at runtime.
-        //	The value pointed by these pointers are updated by reading/writing memory.
-
-        public IntPtr FLECS__TEcsRateFilter;
-        public IntPtr FLECS__TEcsTimer;
-        public IntPtr FLECS__TEcsTickSource;
-        public IntPtr FLECS__TEcsSystem;
-        public IntPtr EcsPostFrame;
-        public IntPtr EcsOnStore;
-        public IntPtr EcsPreStore;
-        public IntPtr EcsPostUpdate;
-        public IntPtr EcsOnValidate;
-        public IntPtr EcsOnUpdate;
-        public IntPtr EcsPreUpdate;
-        public IntPtr EcsPostLoad;
-        public IntPtr EcsOnLoad;
-        public IntPtr EcsPreFrame;
-        public IntPtr EcsPipeline;
-        public IntPtr EcsInactive;
-        public IntPtr EcsDisabledIntern;
-        public IntPtr EcsMonitor;
-        public IntPtr EcsOnDemand;
-        public IntPtr EcsThrow;
-        public IntPtr EcsDelete;
-        public IntPtr EcsRemove;
-        public IntPtr EcsOnDeleteObject;
-        public IntPtr EcsOnDelete;
-        public IntPtr EcsUnSet;
-        public IntPtr EcsOnSet;
-        public IntPtr EcsOnRemove;
-        public IntPtr EcsOnAdd;
-        public IntPtr EcsHidden;
-        public IntPtr EcsDisabled;
-        public IntPtr EcsPrefab;
-        public IntPtr EcsModule;
-        public IntPtr EcsIsA;
-        public IntPtr EcsChildOf;
-        public IntPtr EcsFinal;
-        public IntPtr EcsTransitive;
-        public IntPtr EcsThis;
-        public IntPtr EcsWildcard;
-        public IntPtr EcsWorld;
-        public IntPtr EcsFlecsCore;
-        public IntPtr EcsFlecs;
-        public IntPtr ECS_DISABLED;
-        public IntPtr ECS_OWNED;
-        public IntPtr ECS_PAIR;
-        public IntPtr ECS_SWITCH;
-        public IntPtr ECS_CASE;
-        public IntPtr FLECS__TEcsName;
-        public IntPtr FLECS__TEcsType;
-        public IntPtr FLECS__TEcsComponentLifecycle;
-        public IntPtr FLECS__TEcsComponent;
-        public IntPtr ecs_os_api;
-        public IntPtr ecs_os_api_free_count;
-        public IntPtr ecs_os_api_calloc_count;
-        public IntPtr ecs_os_api_realloc_count;
-        public IntPtr ecs_os_api_malloc_count;
-
-        #endregion
-    }
-
-    private static _VirtualTable _virtualTable;
 }

--- a/src/cs/examples/helloworld/helloworld-cs/helloworld.cs
+++ b/src/cs/examples/helloworld/helloworld-cs/helloworld.cs
@@ -20,82 +20,8 @@ using C2CS;
 public static unsafe partial class helloworld
 {
     private const string LibraryName = "helloworld";
-    private static IntPtr _libraryHandle;
-
-    static helloworld()
-    {
-        TryLoadApi();
-    }
-
-    public static bool TryLoadApi(string? libraryName = LibraryName)
-    {
-        UnloadApi();
-        _libraryHandle = Runtime.LibraryLoad(libraryName!);
-        if (_libraryHandle == IntPtr.Zero) return false;
-        _LoadVirtualTable();
-        return true;
-    }
-
-    public static void UnloadApi()
-    {
-        if (_libraryHandle == IntPtr.Zero) return;
-        _UnloadVirtualTable();
-        Runtime.LibraryUnload(_libraryHandle);
-    }
 
     // Function @ helloworld.h:6:6
-    public static void hello_world()
-    {
-        _virtualTable.hello_world();
-    }
-
-    private static void _LoadVirtualTable()
-    {
-        #region "Functions"
-        _virtualTable.hello_world = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "hello_world");
-        #endregion
-
-        #region "Variables"
-
-        #endregion
-    }
-
-    private static void _UnloadVirtualTable()
-    {
-        #region "Functions"
-
-        _virtualTable.hello_world = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-
-        #endregion
-
-        #region "Variables"
-
-
-
-        #endregion
-    }
-
-    // The virtual table represents a list of pointers to functions or variables which are resolved in a late manner.
-    //	This allows for flexibility in swapping implementations at runtime.
-    //	You can think of it in traditional OOP terms in C# as the locations of the virtual methods and/or properties of an object.
-    public struct _VirtualTable
-    {
-        #region "Function Pointers"
-        // These pointers hold the locations in the native library where functions are located at runtime.
-        // See: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
-
-        public delegate* unmanaged[Cdecl]<void> hello_world;
-
-        #endregion
-
-        #region "Variables"
-        // These pointers hold the locations in the native library where global variables are located at runtime.
-        //	The value pointed by these pointers are updated by reading/writing memory.
-
-
-
-        #endregion
-    }
-
-    private static _VirtualTable _virtualTable;
+    [DllImport("helloworld")]
+    public static extern void hello_world();
 }

--- a/src/cs/examples/libuv/libuv-c/ast.json
+++ b/src/cs/examples/libuv/libuv-c/ast.json
@@ -58,18 +58,18 @@
           "name": "t1",
           "type": "uv_thread_t*",
           "location": {
-            "file": "win.h",
-            "line": 236,
-            "column": 16
+            "file": "unix.h",
+            "line": 136,
+            "column": 19
           }
         },
         {
           "name": "t2",
           "type": "uv_thread_t*",
           "location": {
-            "file": "win.h",
-            "line": 236,
-            "column": 16
+            "file": "unix.h",
+            "line": 136,
+            "column": 19
           }
         }
       ],
@@ -87,9 +87,9 @@
           "name": "tid",
           "type": "uv_thread_t*",
           "location": {
-            "file": "win.h",
-            "line": 236,
-            "column": 16
+            "file": "unix.h",
+            "line": 136,
+            "column": 19
           }
         }
       ],
@@ -117,9 +117,9 @@
           "name": "tid",
           "type": "uv_thread_t*",
           "location": {
-            "file": "win.h",
-            "line": 236,
-            "column": 16
+            "file": "unix.h",
+            "line": 136,
+            "column": 19
           }
         },
         {
@@ -164,9 +164,9 @@
           "name": "tid",
           "type": "uv_thread_t*",
           "location": {
-            "file": "win.h",
-            "line": 236,
-            "column": 16
+            "file": "unix.h",
+            "line": 136,
+            "column": 19
           }
         },
         {
@@ -222,9 +222,9 @@
           "name": "key",
           "type": "uv_key_t*",
           "location": {
-            "file": "win.h",
-            "line": 286,
-            "column": 3
+            "file": "unix.h",
+            "line": 141,
+            "column": 23
           }
         },
         {
@@ -251,9 +251,9 @@
           "name": "key",
           "type": "uv_key_t*",
           "location": {
-            "file": "win.h",
-            "line": 286,
-            "column": 3
+            "file": "unix.h",
+            "line": 141,
+            "column": 23
           }
         }
       ],
@@ -271,9 +271,9 @@
           "name": "key",
           "type": "uv_key_t*",
           "location": {
-            "file": "win.h",
-            "line": 286,
-            "column": 3
+            "file": "unix.h",
+            "line": 141,
+            "column": 23
           }
         }
       ],
@@ -291,9 +291,9 @@
           "name": "key",
           "type": "uv_key_t*",
           "location": {
-            "file": "win.h",
-            "line": 286,
-            "column": 3
+            "file": "unix.h",
+            "line": 141,
+            "column": 23
           }
         }
       ],
@@ -311,9 +311,9 @@
           "name": "guard",
           "type": "uv_once_t*",
           "location": {
-            "file": "win.h",
-            "line": 293,
-            "column": 3
+            "file": "unix.h",
+            "line": 135,
+            "column": 24
           }
         },
         {
@@ -340,26 +340,26 @@
           "name": "cond",
           "type": "uv_cond_t*",
           "location": {
-            "file": "win.h",
-            "line": 257,
-            "column": 3
+            "file": "unix.h",
+            "line": 140,
+            "column": 24
           }
         },
         {
           "name": "mutex",
           "type": "uv_mutex_t*",
           "location": {
-            "file": "win.h",
-            "line": 240,
-            "column": 26
+            "file": "unix.h",
+            "line": 137,
+            "column": 25
           }
         },
         {
           "name": "timeout",
           "type": "uint64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -379,18 +379,18 @@
           "name": "cond",
           "type": "uv_cond_t*",
           "location": {
-            "file": "win.h",
-            "line": 257,
-            "column": 3
+            "file": "unix.h",
+            "line": 140,
+            "column": 24
           }
         },
         {
           "name": "mutex",
           "type": "uv_mutex_t*",
           "location": {
-            "file": "win.h",
-            "line": 240,
-            "column": 26
+            "file": "unix.h",
+            "line": 137,
+            "column": 25
           }
         }
       ],
@@ -408,8 +408,8 @@
           "name": "barrier",
           "type": "uv_barrier_t*",
           "location": {
-            "file": "win.h",
-            "line": 282,
+            "file": "unix.h",
+            "line": 162,
             "column": 3
           }
         }
@@ -428,8 +428,8 @@
           "name": "barrier",
           "type": "uv_barrier_t*",
           "location": {
-            "file": "win.h",
-            "line": 282,
+            "file": "unix.h",
+            "line": 162,
             "column": 3
           }
         }
@@ -448,8 +448,8 @@
           "name": "barrier",
           "type": "uv_barrier_t*",
           "location": {
-            "file": "win.h",
-            "line": 282,
+            "file": "unix.h",
+            "line": 162,
             "column": 3
           }
         },
@@ -477,9 +477,9 @@
           "name": "cond",
           "type": "uv_cond_t*",
           "location": {
-            "file": "win.h",
-            "line": 257,
-            "column": 3
+            "file": "unix.h",
+            "line": 140,
+            "column": 24
           }
         }
       ],
@@ -497,9 +497,9 @@
           "name": "cond",
           "type": "uv_cond_t*",
           "location": {
-            "file": "win.h",
-            "line": 257,
-            "column": 3
+            "file": "unix.h",
+            "line": 140,
+            "column": 24
           }
         }
       ],
@@ -517,9 +517,9 @@
           "name": "cond",
           "type": "uv_cond_t*",
           "location": {
-            "file": "win.h",
-            "line": 257,
-            "column": 3
+            "file": "unix.h",
+            "line": 140,
+            "column": 24
           }
         }
       ],
@@ -537,9 +537,9 @@
           "name": "cond",
           "type": "uv_cond_t*",
           "location": {
-            "file": "win.h",
-            "line": 257,
-            "column": 3
+            "file": "unix.h",
+            "line": 140,
+            "column": 24
           }
         }
       ],
@@ -557,9 +557,9 @@
           "name": "sem",
           "type": "uv_sem_t*",
           "location": {
-            "file": "win.h",
-            "line": 238,
-            "column": 16
+            "file": "unix.h",
+            "line": 139,
+            "column": 27
           }
         }
       ],
@@ -577,9 +577,9 @@
           "name": "sem",
           "type": "uv_sem_t*",
           "location": {
-            "file": "win.h",
-            "line": 238,
-            "column": 16
+            "file": "unix.h",
+            "line": 139,
+            "column": 27
           }
         }
       ],
@@ -597,9 +597,9 @@
           "name": "sem",
           "type": "uv_sem_t*",
           "location": {
-            "file": "win.h",
-            "line": 238,
-            "column": 16
+            "file": "unix.h",
+            "line": 139,
+            "column": 27
           }
         }
       ],
@@ -617,9 +617,9 @@
           "name": "sem",
           "type": "uv_sem_t*",
           "location": {
-            "file": "win.h",
-            "line": 238,
-            "column": 16
+            "file": "unix.h",
+            "line": 139,
+            "column": 27
           }
         }
       ],
@@ -637,9 +637,9 @@
           "name": "sem",
           "type": "uv_sem_t*",
           "location": {
-            "file": "win.h",
-            "line": 238,
-            "column": 16
+            "file": "unix.h",
+            "line": 139,
+            "column": 27
           }
         },
         {
@@ -666,9 +666,9 @@
           "name": "rwlock",
           "type": "uv_rwlock_t*",
           "location": {
-            "file": "win.h",
-            "line": 274,
-            "column": 3
+            "file": "unix.h",
+            "line": 138,
+            "column": 26
           }
         }
       ],
@@ -686,9 +686,9 @@
           "name": "rwlock",
           "type": "uv_rwlock_t*",
           "location": {
-            "file": "win.h",
-            "line": 274,
-            "column": 3
+            "file": "unix.h",
+            "line": 138,
+            "column": 26
           }
         }
       ],
@@ -706,9 +706,9 @@
           "name": "rwlock",
           "type": "uv_rwlock_t*",
           "location": {
-            "file": "win.h",
-            "line": 274,
-            "column": 3
+            "file": "unix.h",
+            "line": 138,
+            "column": 26
           }
         }
       ],
@@ -726,9 +726,9 @@
           "name": "rwlock",
           "type": "uv_rwlock_t*",
           "location": {
-            "file": "win.h",
-            "line": 274,
-            "column": 3
+            "file": "unix.h",
+            "line": 138,
+            "column": 26
           }
         }
       ],
@@ -746,9 +746,9 @@
           "name": "rwlock",
           "type": "uv_rwlock_t*",
           "location": {
-            "file": "win.h",
-            "line": 274,
-            "column": 3
+            "file": "unix.h",
+            "line": 138,
+            "column": 26
           }
         }
       ],
@@ -766,9 +766,9 @@
           "name": "rwlock",
           "type": "uv_rwlock_t*",
           "location": {
-            "file": "win.h",
-            "line": 274,
-            "column": 3
+            "file": "unix.h",
+            "line": 138,
+            "column": 26
           }
         }
       ],
@@ -786,9 +786,9 @@
           "name": "rwlock",
           "type": "uv_rwlock_t*",
           "location": {
-            "file": "win.h",
-            "line": 274,
-            "column": 3
+            "file": "unix.h",
+            "line": 138,
+            "column": 26
           }
         }
       ],
@@ -806,9 +806,9 @@
           "name": "rwlock",
           "type": "uv_rwlock_t*",
           "location": {
-            "file": "win.h",
-            "line": 274,
-            "column": 3
+            "file": "unix.h",
+            "line": 138,
+            "column": 26
           }
         }
       ],
@@ -826,9 +826,9 @@
           "name": "handle",
           "type": "uv_mutex_t*",
           "location": {
-            "file": "win.h",
-            "line": 240,
-            "column": 26
+            "file": "unix.h",
+            "line": 137,
+            "column": 25
           }
         }
       ],
@@ -846,9 +846,9 @@
           "name": "handle",
           "type": "uv_mutex_t*",
           "location": {
-            "file": "win.h",
-            "line": 240,
-            "column": 26
+            "file": "unix.h",
+            "line": 137,
+            "column": 25
           }
         }
       ],
@@ -866,9 +866,9 @@
           "name": "handle",
           "type": "uv_mutex_t*",
           "location": {
-            "file": "win.h",
-            "line": 240,
-            "column": 26
+            "file": "unix.h",
+            "line": 137,
+            "column": 25
           }
         }
       ],
@@ -886,9 +886,9 @@
           "name": "handle",
           "type": "uv_mutex_t*",
           "location": {
-            "file": "win.h",
-            "line": 240,
-            "column": 26
+            "file": "unix.h",
+            "line": 137,
+            "column": 25
           }
         }
       ],
@@ -906,9 +906,9 @@
           "name": "handle",
           "type": "uv_mutex_t*",
           "location": {
-            "file": "win.h",
-            "line": 240,
-            "column": 26
+            "file": "unix.h",
+            "line": 137,
+            "column": 25
           }
         }
       ],
@@ -926,9 +926,9 @@
           "name": "handle",
           "type": "uv_mutex_t*",
           "location": {
-            "file": "win.h",
-            "line": 240,
-            "column": 26
+            "file": "unix.h",
+            "line": 137,
+            "column": 25
           }
         }
       ],
@@ -946,8 +946,8 @@
           "name": "lib",
           "type": "uv_lib_t*",
           "location": {
-            "file": "win.h",
-            "line": 323,
+            "file": "unix.h",
+            "line": 221,
             "column": 3
           }
         }
@@ -966,8 +966,8 @@
           "name": "lib",
           "type": "uv_lib_t*",
           "location": {
-            "file": "win.h",
-            "line": 323,
+            "file": "unix.h",
+            "line": 221,
             "column": 3
           }
         },
@@ -1004,8 +1004,8 @@
           "name": "lib",
           "type": "uv_lib_t*",
           "location": {
-            "file": "win.h",
-            "line": 323,
+            "file": "unix.h",
+            "line": 221,
             "column": 3
           }
         }
@@ -1033,8 +1033,8 @@
           "name": "lib",
           "type": "uv_lib_t*",
           "location": {
-            "file": "win.h",
-            "line": 323,
+            "file": "unix.h",
+            "line": 221,
             "column": 3
           }
         }
@@ -1152,9 +1152,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -1182,9 +1182,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -1221,9 +1221,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -1260,9 +1260,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -1308,9 +1308,9 @@
           "name": "buflen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         },
@@ -1412,9 +1412,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -1433,9 +1433,9 @@
           "name": "src",
           "type": "sockaddr_in6*",
           "location": {
-            "file": "ws2ipdef.h",
-            "line": 190,
-            "column": 16,
+            "file": "in6.h",
+            "line": 170,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -1452,9 +1452,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -1473,9 +1473,9 @@
           "name": "src",
           "type": "sockaddr_in*",
           "location": {
-            "file": "ws2def.h",
-            "line": 638,
-            "column": 16,
+            "file": "in.h",
+            "line": 375,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -1492,9 +1492,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -1531,9 +1531,9 @@
           "name": "addr",
           "type": "sockaddr_in6*",
           "location": {
-            "file": "ws2ipdef.h",
-            "line": 190,
-            "column": 16,
+            "file": "in6.h",
+            "line": 170,
+            "column": 8,
             "isSystem": true
           }
         }
@@ -1570,9 +1570,9 @@
           "name": "addr",
           "type": "sockaddr_in*",
           "location": {
-            "file": "ws2def.h",
-            "line": 638,
-            "column": 16,
+            "file": "in.h",
+            "line": 375,
+            "column": 8,
             "isSystem": true
           }
         }
@@ -1609,9 +1609,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -1889,9 +1889,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -2080,18 +2080,18 @@
           "name": "uid",
           "type": "uv_uid_t",
           "location": {
-            "file": "win.h",
-            "line": 296,
-            "column": 23
+            "file": "unix.h",
+            "line": 169,
+            "column": 15
           }
         },
         {
           "name": "gid",
           "type": "uv_gid_t",
           "location": {
-            "file": "win.h",
-            "line": 297,
-            "column": 23
+            "file": "unix.h",
+            "line": 168,
+            "column": 15
           }
         },
         {
@@ -2136,8 +2136,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -2145,18 +2145,18 @@
           "name": "uid",
           "type": "uv_uid_t",
           "location": {
-            "file": "win.h",
-            "line": 296,
-            "column": 23
+            "file": "unix.h",
+            "line": 169,
+            "column": 15
           }
         },
         {
           "name": "gid",
           "type": "uv_gid_t",
           "location": {
-            "file": "win.h",
-            "line": 297,
-            "column": 23
+            "file": "unix.h",
+            "line": 168,
+            "column": 15
           }
         },
         {
@@ -2210,18 +2210,18 @@
           "name": "uid",
           "type": "uv_uid_t",
           "location": {
-            "file": "win.h",
-            "line": 296,
-            "column": 23
+            "file": "unix.h",
+            "line": 169,
+            "column": 15
           }
         },
         {
           "name": "gid",
           "type": "uv_gid_t",
           "location": {
-            "file": "win.h",
-            "line": 297,
-            "column": 23
+            "file": "unix.h",
+            "line": 168,
+            "column": 15
           }
         },
         {
@@ -2266,8 +2266,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -2649,8 +2649,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -2891,8 +2891,8 @@
           "name": "out_fd",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -2900,8 +2900,8 @@
           "name": "in_fd",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -2909,9 +2909,9 @@
           "name": "in_offset",
           "type": "int64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 21,
-            "column": 28,
+            "file": "_int64_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -2919,9 +2919,9 @@
           "name": "length",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         },
@@ -2967,8 +2967,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -2976,9 +2976,9 @@
           "name": "offset",
           "type": "int64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 21,
-            "column": 28,
+            "file": "_int64_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -3024,8 +3024,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -3071,8 +3071,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -3174,8 +3174,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -3756,8 +3756,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -3783,9 +3783,9 @@
           "name": "offset",
           "type": "int64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 21,
-            "column": 28,
+            "file": "_int64_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -3878,8 +3878,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -3905,9 +3905,9 @@
           "name": "offset",
           "type": "int64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 21,
-            "column": 28,
+            "file": "_int64_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -4018,8 +4018,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -4236,9 +4236,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -4324,9 +4324,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -4519,9 +4519,9 @@
           "name": "pid",
           "type": "uv_pid_t",
           "location": {
-            "file": "win.h",
-            "line": 234,
-            "column": 13
+            "file": "unix.h",
+            "line": 131,
+            "column": 15
           }
         },
         {
@@ -4548,9 +4548,9 @@
           "name": "pid",
           "type": "uv_pid_t",
           "location": {
-            "file": "win.h",
-            "line": 234,
-            "column": 13
+            "file": "unix.h",
+            "line": 131,
+            "column": 15
           }
         },
         {
@@ -4646,9 +4646,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -4676,9 +4676,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -4717,9 +4717,9 @@
           "name": "os_fd",
           "type": "uv_os_fd_t",
           "location": {
-            "file": "win.h",
-            "line": 233,
-            "column": 16
+            "file": "unix.h",
+            "line": 130,
+            "column": 13
           }
         }
       ],
@@ -4777,9 +4777,9 @@
           "name": "rss",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -4827,9 +4827,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -5087,9 +5087,9 @@
           "name": "addr",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -5117,9 +5117,9 @@
           "name": "ai",
           "type": "addrinfo*",
           "location": {
-            "file": "ws2def.h",
-            "line": 904,
-            "column": 16,
+            "file": "netdb.h",
+            "line": 147,
+            "column": 8,
             "isSystem": true
           }
         }
@@ -5183,9 +5183,9 @@
           "name": "hints",
           "type": "addrinfo*",
           "location": {
-            "file": "ws2def.h",
-            "line": 904,
-            "column": 16,
+            "file": "netdb.h",
+            "line": 147,
+            "column": 8,
             "isSystem": true
           }
         }
@@ -5253,8 +5253,8 @@
           "name": "repeat",
           "type": "uint64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -5332,8 +5332,8 @@
           "name": "timeout",
           "type": "uint64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -5342,8 +5342,8 @@
           "name": "repeat",
           "type": "uint64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -5760,9 +5760,9 @@
           "name": "socket",
           "type": "uv_os_sock_t",
           "location": {
-            "file": "win.h",
-            "line": 232,
-            "column": 16
+            "file": "unix.h",
+            "line": 129,
+            "column": 13
           }
         }
       ],
@@ -5934,9 +5934,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -5973,9 +5973,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -6079,8 +6079,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         }
@@ -6137,8 +6137,8 @@
           "name": "file",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         }
@@ -6292,8 +6292,8 @@
           "name": "fd",
           "type": "uv_file",
           "location": {
-            "file": "win.h",
-            "line": 231,
+            "file": "unix.h",
+            "line": 128,
             "column": 13
           }
         },
@@ -6466,9 +6466,9 @@
           "name": "addr",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         }
@@ -6523,9 +6523,9 @@
           "name": "addr",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -6810,9 +6810,9 @@
           "name": "name",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -6849,9 +6849,9 @@
           "name": "name",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -6888,9 +6888,9 @@
           "name": "addr",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         }
@@ -6918,9 +6918,9 @@
           "name": "addr",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -6957,9 +6957,9 @@
           "name": "sock",
           "type": "uv_os_sock_t",
           "location": {
-            "file": "win.h",
-            "line": 232,
-            "column": 16
+            "file": "unix.h",
+            "line": 129,
+            "column": 13
           }
         }
       ],
@@ -7062,9 +7062,9 @@
           "name": "addr",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -7130,9 +7130,9 @@
           "name": "name",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -7169,9 +7169,9 @@
           "name": "name",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -7208,9 +7208,9 @@
           "name": "addr",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -7343,9 +7343,9 @@
           "name": "sock",
           "type": "uv_os_sock_t",
           "location": {
-            "file": "win.h",
-            "line": 232,
-            "column": 16
+            "file": "unix.h",
+            "line": 129,
+            "column": 13
           }
         }
       ],
@@ -7955,9 +7955,9 @@
           "name": "fd",
           "type": "uv_os_fd_t*",
           "location": {
-            "file": "win.h",
-            "line": 233,
-            "column": 16
+            "file": "unix.h",
+            "line": 130,
+            "column": 13
           }
         }
       ],
@@ -8071,9 +8071,9 @@
           "name": "stream",
           "type": "FILE*",
           "location": {
-            "file": "corecrt_wstdio.h",
-            "line": 31,
-            "column": 7,
+            "file": "_stdio.h",
+            "line": 157,
+            "column": 3,
             "isSystem": true
           }
         }
@@ -8101,9 +8101,9 @@
           "name": "stream",
           "type": "FILE*",
           "location": {
-            "file": "corecrt_wstdio.h",
-            "line": 31,
-            "column": 7,
+            "file": "_stdio.h",
+            "line": 157,
+            "column": 3,
             "isSystem": true
           }
         }
@@ -8474,9 +8474,9 @@
           "name": "buflen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -8533,9 +8533,9 @@
           "name": "buflen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -9081,9 +9081,9 @@
           "name": "buflen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -9310,9 +9310,9 @@
           "name": "exit_status",
           "type": "int64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 21,
-            "column": 28,
+            "file": "_int64_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -9407,9 +9407,9 @@
           "name": "res",
           "type": "addrinfo*",
           "location": {
-            "file": "ws2def.h",
-            "line": 904,
-            "column": 16,
+            "file": "netdb.h",
+            "line": 147,
+            "column": 8,
             "isSystem": true
           }
         }
@@ -9612,17 +9612,18 @@
           "name": "nread",
           "type": "ssize_t",
           "location": {
-            "file": "win.h",
-            "line": 27,
-            "column": 18
+            "file": "_ssize_t.h",
+            "line": 31,
+            "column": 33,
+            "isSystem": true
           }
         },
         {
           "name": "buf",
           "type": "uv_buf_t*",
           "location": {
-            "file": "win.h",
-            "line": 229,
+            "file": "unix.h",
+            "line": 126,
             "column": 3
           }
         },
@@ -9630,9 +9631,9 @@
           "name": "addr",
           "type": "sockaddr*",
           "location": {
-            "file": "ws2def.h",
-            "line": 240,
-            "column": 16,
+            "file": "socket.h",
+            "line": 408,
+            "column": 8,
             "isSystem": true
           }
         },
@@ -9670,9 +9671,9 @@
           "name": "suggested_size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         },
@@ -9680,8 +9681,8 @@
           "name": "buf",
           "type": "uv_buf_t*",
           "location": {
-            "file": "win.h",
-            "line": 229,
+            "file": "unix.h",
+            "line": 126,
             "column": 3
           }
         }
@@ -9791,17 +9792,18 @@
           "name": "nread",
           "type": "ssize_t",
           "location": {
-            "file": "win.h",
-            "line": 27,
-            "column": 18
+            "file": "_ssize_t.h",
+            "line": 31,
+            "column": 33,
+            "isSystem": true
           }
         },
         {
           "name": "buf",
           "type": "uv_buf_t*",
           "location": {
-            "file": "win.h",
-            "line": 229,
+            "file": "unix.h",
+            "line": 126,
             "column": 3
           }
         }
@@ -9932,9 +9934,9 @@
           "name": "count",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         },
@@ -9942,9 +9944,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -9973,9 +9975,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -9995,9 +9997,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -10028,9 +10030,9 @@
           "type": "size_t",
           "offset": 8,
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
             "isSystem": true
           }
         }
@@ -10049,9 +10051,9 @@
           "name": "tv_sec",
           "type": "int64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 21,
-            "column": 28,
+            "file": "_int64_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         },
@@ -10061,9 +10063,9 @@
           "offset": 8,
           "padding": 4,
           "location": {
-            "file": "stdint.h",
-            "line": 20,
-            "column": 28,
+            "file": "_int32_t.h",
+            "line": 30,
+            "column": 33,
             "isSystem": true
           }
         }
@@ -10080,12 +10082,11 @@
       "fields": [
         {
           "name": "handle",
-          "type": "HMODULE",
+          "type": "void*",
           "location": {
-            "file": "minwindef.h",
-            "line": 251,
-            "column": 19,
-            "isSystem": true
+            "file": "unix.h",
+            "line": 219,
+            "column": 9
           }
         },
         {
@@ -10093,39 +10094,17 @@
           "type": "char*",
           "offset": 8,
           "location": {
-            "file": "win.h",
-            "line": 322,
+            "file": "unix.h",
+            "line": 220,
             "column": 9
           }
         }
       ],
       "nestedRecords": [],
       "location": {
-        "file": "win.h",
-        "line": 323,
+        "file": "unix.h",
+        "line": 221,
         "column": 3
-      }
-    },
-    {
-      "type": "HINSTANCE__",
-      "fields": [
-        {
-          "name": "unused",
-          "type": "int",
-          "location": {
-            "file": "minwindef.h",
-            "line": 250,
-            "column": 1,
-            "isSystem": true
-          }
-        }
-      ],
-      "nestedRecords": [],
-      "location": {
-        "file": "minwindef.h",
-        "line": 250,
-        "column": 1,
-        "isSystem": true
       }
     },
     {
@@ -10135,8 +10114,8 @@
           "name": "st_dev",
           "type": "uint64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10146,8 +10125,8 @@
           "type": "uint64_t",
           "offset": 8,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10157,8 +10136,8 @@
           "type": "uint64_t",
           "offset": 16,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10168,8 +10147,8 @@
           "type": "uint64_t",
           "offset": 24,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10179,8 +10158,8 @@
           "type": "uint64_t",
           "offset": 32,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10190,8 +10169,8 @@
           "type": "uint64_t",
           "offset": 40,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10201,8 +10180,8 @@
           "type": "uint64_t",
           "offset": 48,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10212,8 +10191,8 @@
           "type": "uint64_t",
           "offset": 56,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10223,8 +10202,8 @@
           "type": "uint64_t",
           "offset": 64,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10234,8 +10213,8 @@
           "type": "uint64_t",
           "offset": 72,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10245,8 +10224,8 @@
           "type": "uint64_t",
           "offset": 80,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10256,8 +10235,8 @@
           "type": "uint64_t",
           "offset": 88,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10275,7 +10254,7 @@
         {
           "name": "st_mtim",
           "type": "uv_timespec_t",
-          "offset": 104,
+          "offset": 112,
           "location": {
             "file": "uv.h",
             "line": 346,
@@ -10285,7 +10264,7 @@
         {
           "name": "st_ctim",
           "type": "uv_timespec_t",
-          "offset": 112,
+          "offset": 128,
           "location": {
             "file": "uv.h",
             "line": 346,
@@ -10295,7 +10274,7 @@
         {
           "name": "st_birthtim",
           "type": "uv_timespec_t",
-          "offset": 120,
+          "offset": 144,
           "location": {
             "file": "uv.h",
             "line": 346,
@@ -10325,7 +10304,7 @@
         {
           "name": "tv_nsec",
           "type": "long",
-          "offset": 4,
+          "offset": 8,
           "location": {
             "file": "uv.h",
             "line": 345,
@@ -10375,31 +10354,30 @@
       "type": "uv_buf_t",
       "fields": [
         {
-          "name": "len",
-          "type": "ULONG",
-          "padding": 4,
+          "name": "base",
+          "type": "char*",
           "location": {
-            "file": "winsmcrd.h",
-            "line": 36,
-            "column": 15,
-            "isSystem": true
+            "file": "unix.h",
+            "line": 124,
+            "column": 9
           }
         },
         {
-          "name": "base",
-          "type": "char*",
+          "name": "len",
+          "type": "size_t",
           "offset": 8,
           "location": {
-            "file": "win.h",
-            "line": 228,
-            "column": 9
+            "file": "stddef.h",
+            "line": 46,
+            "column": 23,
+            "isSystem": true
           }
         }
       ],
       "nestedRecords": [],
       "location": {
-        "file": "win.h",
-        "line": 229,
+        "file": "unix.h",
+        "line": 126,
         "column": 3
       }
     },
@@ -10547,9 +10525,9 @@
               "name": "address4",
               "type": "sockaddr_in",
               "location": {
-                "file": "ws2def.h",
-                "line": 638,
-                "column": 16,
+                "file": "in.h",
+                "line": 375,
+                "column": 8,
                 "isSystem": true
               }
             },
@@ -10557,9 +10535,9 @@
               "name": "address6",
               "type": "sockaddr_in6",
               "location": {
-                "file": "ws2ipdef.h",
-                "line": 190,
-                "column": 16,
+                "file": "in6.h",
+                "line": 170,
+                "column": 8,
                 "isSystem": true
               }
             }
@@ -10579,9 +10557,9 @@
               "name": "netmask4",
               "type": "sockaddr_in",
               "location": {
-                "file": "ws2def.h",
-                "line": 638,
-                "column": 16,
+                "file": "in.h",
+                "line": 375,
+                "column": 8,
                 "isSystem": true
               }
             },
@@ -10589,9 +10567,9 @@
               "name": "netmask6",
               "type": "sockaddr_in6",
               "location": {
-                "file": "ws2ipdef.h",
-                "line": 190,
-                "column": 16,
+                "file": "in6.h",
+                "line": 170,
+                "column": 8,
                 "isSystem": true
               }
             }
@@ -10658,8 +10636,8 @@
           "name": "user",
           "type": "uint64_t",
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10669,8 +10647,8 @@
           "type": "uint64_t",
           "offset": 8,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10680,8 +10658,8 @@
           "type": "uint64_t",
           "offset": 16,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10691,8 +10669,8 @@
           "type": "uint64_t",
           "offset": 24,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10702,8 +10680,8 @@
           "type": "uint64_t",
           "offset": 32,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10741,7 +10719,7 @@
         {
           "name": "gid",
           "type": "long",
-          "offset": 12,
+          "offset": 16,
           "location": {
             "file": "uv.h",
             "line": 1129,
@@ -10751,7 +10729,7 @@
         {
           "name": "shell",
           "type": "char*",
-          "offset": 16,
+          "offset": 24,
           "location": {
             "file": "uv.h",
             "line": 1130,
@@ -10761,7 +10739,7 @@
         {
           "name": "homedir",
           "type": "char*",
-          "offset": 24,
+          "offset": 32,
           "location": {
             "file": "uv.h",
             "line": 1131,
@@ -10791,7 +10769,7 @@
         {
           "name": "ru_stime",
           "type": "uv_timeval_t",
-          "offset": 8,
+          "offset": 16,
           "location": {
             "file": "uv.h",
             "line": 1182,
@@ -10801,10 +10779,10 @@
         {
           "name": "ru_maxrss",
           "type": "uint64_t",
-          "offset": 16,
+          "offset": 32,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10812,10 +10790,10 @@
         {
           "name": "ru_ixrss",
           "type": "uint64_t",
-          "offset": 24,
+          "offset": 40,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10823,10 +10801,10 @@
         {
           "name": "ru_idrss",
           "type": "uint64_t",
-          "offset": 32,
+          "offset": 48,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10834,10 +10812,10 @@
         {
           "name": "ru_isrss",
           "type": "uint64_t",
-          "offset": 40,
+          "offset": 56,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10845,10 +10823,10 @@
         {
           "name": "ru_minflt",
           "type": "uint64_t",
-          "offset": 48,
+          "offset": 64,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10856,10 +10834,10 @@
         {
           "name": "ru_majflt",
           "type": "uint64_t",
-          "offset": 56,
+          "offset": 72,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10867,10 +10845,10 @@
         {
           "name": "ru_nswap",
           "type": "uint64_t",
-          "offset": 64,
+          "offset": 80,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10878,10 +10856,10 @@
         {
           "name": "ru_inblock",
           "type": "uint64_t",
-          "offset": 72,
+          "offset": 88,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10889,10 +10867,10 @@
         {
           "name": "ru_oublock",
           "type": "uint64_t",
-          "offset": 80,
+          "offset": 96,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10900,10 +10878,10 @@
         {
           "name": "ru_msgsnd",
           "type": "uint64_t",
-          "offset": 88,
+          "offset": 104,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10911,10 +10889,10 @@
         {
           "name": "ru_msgrcv",
           "type": "uint64_t",
-          "offset": 96,
+          "offset": 112,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10922,10 +10900,10 @@
         {
           "name": "ru_nsignals",
           "type": "uint64_t",
-          "offset": 104,
+          "offset": 120,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10933,10 +10911,10 @@
         {
           "name": "ru_nvcsw",
           "type": "uint64_t",
-          "offset": 112,
+          "offset": 128,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10944,10 +10922,10 @@
         {
           "name": "ru_nivcsw",
           "type": "uint64_t",
-          "offset": 120,
+          "offset": 136,
           "location": {
-            "file": "stdint.h",
-            "line": 25,
+            "file": "_uint64_t.h",
+            "line": 31,
             "column": 28,
             "isSystem": true
           }
@@ -10975,7 +10953,7 @@
         {
           "name": "tv_usec",
           "type": "long",
-          "offset": 4,
+          "offset": 8,
           "location": {
             "file": "uv.h",
             "line": 1181,
@@ -11077,20 +11055,19 @@
           "type": "uv_uid_t",
           "offset": 56,
           "location": {
-            "file": "win.h",
-            "line": 296,
-            "column": 23
+            "file": "unix.h",
+            "line": 169,
+            "column": 15
           }
         },
         {
           "name": "gid",
           "type": "uv_gid_t",
-          "offset": 57,
-          "padding": 6,
+          "offset": 60,
           "location": {
-            "file": "win.h",
-            "line": 297,
-            "column": 23
+            "file": "unix.h",
+            "line": 168,
+            "column": 15
           }
         }
       ],
@@ -11169,7 +11146,7 @@
     {
       "name": "uv_dirent_type_t",
       "type": "uv_dirent_type_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "UV_DIRENT_UNKNOWN",
@@ -11605,7 +11582,7 @@
     {
       "name": "uv_stdio_flags",
       "type": "uv_stdio_flags",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "UV_IGNORE",
@@ -11688,7 +11665,7 @@
     {
       "name": "uv_handle_type",
       "type": "uv_handle_type",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "UV_UNKNOWN_HANDLE",
@@ -11870,7 +11847,7 @@
     {
       "name": "uv_tty_vtermstate_t",
       "type": "uv_tty_vtermstate_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "UV_TTY_SUPPORTED",
@@ -11899,7 +11876,7 @@
     {
       "name": "uv_tty_mode_t",
       "type": "uv_tty_mode_t",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "UV_TTY_MODE_NORMAL",
@@ -11937,7 +11914,7 @@
     {
       "name": "uv_membership",
       "type": "uv_membership",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "UV_LEAVE_GROUP",
@@ -11966,7 +11943,7 @@
     {
       "name": "uv_req_type",
       "type": "uv_req_type",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "UV_UNKNOWN_REQ",
@@ -12067,80 +12044,8 @@
           }
         },
         {
-          "name": "UV_ACCEPT",
-          "value": 11,
-          "location": {
-            "file": "uv.h",
-            "line": 203,
-            "column": 3
-          }
-        },
-        {
-          "name": "UV_FS_EVENT_REQ",
-          "value": 12,
-          "location": {
-            "file": "uv.h",
-            "line": 203,
-            "column": 3
-          }
-        },
-        {
-          "name": "UV_POLL_REQ",
-          "value": 13,
-          "location": {
-            "file": "uv.h",
-            "line": 203,
-            "column": 3
-          }
-        },
-        {
-          "name": "UV_PROCESS_EXIT",
-          "value": 14,
-          "location": {
-            "file": "uv.h",
-            "line": 203,
-            "column": 3
-          }
-        },
-        {
-          "name": "UV_READ",
-          "value": 15,
-          "location": {
-            "file": "uv.h",
-            "line": 203,
-            "column": 3
-          }
-        },
-        {
-          "name": "UV_UDP_RECV",
-          "value": 16,
-          "location": {
-            "file": "uv.h",
-            "line": 203,
-            "column": 3
-          }
-        },
-        {
-          "name": "UV_WAKEUP",
-          "value": 17,
-          "location": {
-            "file": "uv.h",
-            "line": 203,
-            "column": 3
-          }
-        },
-        {
-          "name": "UV_SIGNAL_REQ",
-          "value": 18,
-          "location": {
-            "file": "uv.h",
-            "line": 203,
-            "column": 3
-          }
-        },
-        {
           "name": "UV_REQ_TYPE_MAX",
-          "value": 19,
+          "value": 11,
           "location": {
             "file": "uv.h",
             "line": 204,
@@ -12157,7 +12062,7 @@
     {
       "name": "uv_run_mode",
       "type": "uv_run_mode",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "UV_RUN_DEFAULT",
@@ -12195,7 +12100,7 @@
     {
       "name": "uv_loop_option",
       "type": "uv_loop_option",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "UV_LOOP_BLOCK_SIGNAL",
@@ -12234,57 +12139,57 @@
     {
       "name": "uv_key_t",
       "location": {
-        "file": "win.h",
-        "line": 286,
-        "column": 3
+        "file": "unix.h",
+        "line": 141,
+        "column": 23
       }
     },
     {
       "name": "uv_once_t",
       "location": {
-        "file": "win.h",
-        "line": 293,
-        "column": 3
+        "file": "unix.h",
+        "line": 135,
+        "column": 24
       }
     },
     {
       "name": "uv_mutex_t",
       "location": {
-        "file": "win.h",
-        "line": 240,
-        "column": 26
+        "file": "unix.h",
+        "line": 137,
+        "column": 25
       }
     },
     {
       "name": "uv_cond_t",
       "location": {
-        "file": "win.h",
-        "line": 257,
-        "column": 3
+        "file": "unix.h",
+        "line": 140,
+        "column": 24
       }
     },
     {
       "name": "uv_barrier_t",
       "location": {
-        "file": "win.h",
-        "line": 282,
+        "file": "unix.h",
+        "line": 162,
         "column": 3
       }
     },
     {
       "name": "uv_sem_t",
       "location": {
-        "file": "win.h",
-        "line": 238,
-        "column": 16
+        "file": "unix.h",
+        "line": 139,
+        "column": 27
       }
     },
     {
       "name": "uv_rwlock_t",
       "location": {
-        "file": "win.h",
-        "line": 274,
-        "column": 3
+        "file": "unix.h",
+        "line": 138,
+        "column": 26
       }
     },
     {
@@ -12507,144 +12412,65 @@
   "typedefs": [
     {
       "name": "uv_thread_t",
-      "underlyingType": "HANDLE",
+      "underlyingType": "pthread_t",
       "location": {
-        "file": "win.h",
-        "line": 236,
-        "column": 16
-      }
-    },
-    {
-      "name": "HANDLE",
-      "underlyingType": "void*",
-      "location": {
-        "file": "winnt.h",
-        "line": 660,
-        "column": 15,
-        "isSystem": true
-      }
-    },
-    {
-      "name": "HMODULE",
-      "underlyingType": "HINSTANCE",
-      "location": {
-        "file": "minwindef.h",
-        "line": 251,
-        "column": 19,
-        "isSystem": true
-      }
-    },
-    {
-      "name": "HINSTANCE",
-      "underlyingType": "HINSTANCE__*",
-      "location": {
-        "file": "minwindef.h",
-        "line": 250,
-        "column": 16,
-        "isSystem": true
+        "file": "unix.h",
+        "line": 136,
+        "column": 19
       }
     },
     {
       "name": "uv_gid_t",
-      "underlyingType": "unsigned char",
+      "underlyingType": "gid_t",
       "location": {
-        "file": "win.h",
-        "line": 297,
-        "column": 23
+        "file": "unix.h",
+        "line": 168,
+        "column": 15
       }
     },
     {
       "name": "uv_uid_t",
-      "underlyingType": "unsigned char",
+      "underlyingType": "uid_t",
       "location": {
-        "file": "win.h",
-        "line": 296,
-        "column": 23
+        "file": "unix.h",
+        "line": 169,
+        "column": 15
       }
     },
     {
       "name": "uv_file",
       "underlyingType": "int",
       "location": {
-        "file": "win.h",
-        "line": 231,
+        "file": "unix.h",
+        "line": 128,
         "column": 13
-      }
-    },
-    {
-      "name": "ULONG",
-      "underlyingType": "DWORD",
-      "location": {
-        "file": "winsmcrd.h",
-        "line": 36,
-        "column": 15,
-        "isSystem": true
-      }
-    },
-    {
-      "name": "DWORD",
-      "underlyingType": "unsigned long",
-      "location": {
-        "file": "minwindef.h",
-        "line": 156,
-        "column": 29,
-        "isSystem": true
-      }
-    },
-    {
-      "name": "ssize_t",
-      "underlyingType": "intptr_t",
-      "location": {
-        "file": "win.h",
-        "line": 27,
-        "column": 18
       }
     },
     {
       "name": "uv_pid_t",
-      "underlyingType": "int",
+      "underlyingType": "pid_t",
       "location": {
-        "file": "win.h",
-        "line": 234,
-        "column": 13
+        "file": "unix.h",
+        "line": 131,
+        "column": 15
       }
     },
     {
       "name": "uv_os_fd_t",
-      "underlyingType": "HANDLE",
+      "underlyingType": "int",
       "location": {
-        "file": "win.h",
-        "line": 233,
-        "column": 16
+        "file": "unix.h",
+        "line": 130,
+        "column": 13
       }
     },
     {
       "name": "uv_os_sock_t",
-      "underlyingType": "SOCKET",
+      "underlyingType": "int",
       "location": {
-        "file": "win.h",
-        "line": 232,
-        "column": 16
-      }
-    },
-    {
-      "name": "SOCKET",
-      "underlyingType": "UINT_PTR",
-      "location": {
-        "file": "winsock2.h",
-        "line": 122,
-        "column": 25,
-        "isSystem": true
-      }
-    },
-    {
-      "name": "UINT_PTR",
-      "underlyingType": "unsigned long long",
-      "location": {
-        "file": "basetsd.h",
-        "line": 126,
-        "column": 30,
-        "isSystem": true
+        "file": "unix.h",
+        "line": 129,
+        "column": 13
       }
     }
   ],
@@ -12669,7 +12495,7 @@
     {
       "name": "uv_loop_t",
       "kind": "typedef",
-      "sizeOf": 464,
+      "sizeOf": 1072,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -12697,9 +12523,9 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 236,
-        "column": 16
+        "file": "unix.h",
+        "line": 136,
+        "column": 19
       }
     },
     {
@@ -12708,13 +12534,13 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 236,
-        "column": 16
+        "file": "unix.h",
+        "line": 136,
+        "column": 19
       }
     },
     {
-      "name": "HANDLE",
+      "name": "pthread_t",
       "kind": "typedef",
       "sizeOf": 8,
       "alignOf": 8,
@@ -12809,20 +12635,20 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 286,
-        "column": 3
+        "file": "unix.h",
+        "line": 141,
+        "column": 23
       }
     },
     {
       "name": "uv_key_t",
       "kind": "typedef",
-      "sizeOf": 4,
-      "alignOf": 4,
+      "sizeOf": 8,
+      "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 286,
-        "column": 3
+        "file": "unix.h",
+        "line": 141,
+        "column": 23
       }
     },
     {
@@ -12831,9 +12657,9 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 293,
-        "column": 3
+        "file": "unix.h",
+        "line": 135,
+        "column": 24
       }
     },
     {
@@ -12842,9 +12668,9 @@
       "sizeOf": 16,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 293,
-        "column": 3
+        "file": "unix.h",
+        "line": 135,
+        "column": 24
       }
     },
     {
@@ -12864,20 +12690,20 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 257,
-        "column": 3
+        "file": "unix.h",
+        "line": 140,
+        "column": 24
       }
     },
     {
       "name": "uv_cond_t",
       "kind": "typedef",
-      "sizeOf": 64,
+      "sizeOf": 48,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 257,
-        "column": 3
+        "file": "unix.h",
+        "line": 140,
+        "column": 24
       }
     },
     {
@@ -12886,20 +12712,20 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 240,
-        "column": 26
+        "file": "unix.h",
+        "line": 137,
+        "column": 25
       }
     },
     {
       "name": "uv_mutex_t",
       "kind": "typedef",
-      "sizeOf": 40,
+      "sizeOf": 64,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 240,
-        "column": 26
+        "file": "unix.h",
+        "line": 137,
+        "column": 25
       }
     },
     {
@@ -12915,19 +12741,19 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 282,
+        "file": "unix.h",
+        "line": 162,
         "column": 3
       }
     },
     {
       "name": "uv_barrier_t",
       "kind": "typedef",
-      "sizeOf": 64,
+      "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 282,
+        "file": "unix.h",
+        "line": 162,
         "column": 3
       }
     },
@@ -12937,20 +12763,20 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 238,
-        "column": 16
+        "file": "unix.h",
+        "line": 139,
+        "column": 27
       }
     },
     {
       "name": "uv_sem_t",
       "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
+      "sizeOf": 4,
+      "alignOf": 4,
       "location": {
-        "file": "win.h",
-        "line": 238,
-        "column": 16
+        "file": "unix.h",
+        "line": 139,
+        "column": 27
       }
     },
     {
@@ -12959,20 +12785,20 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 274,
-        "column": 3
+        "file": "unix.h",
+        "line": 138,
+        "column": 26
       }
     },
     {
       "name": "uv_rwlock_t",
       "kind": "typedef",
-      "sizeOf": 80,
+      "sizeOf": 200,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 274,
-        "column": 3
+        "file": "unix.h",
+        "line": 138,
+        "column": 26
       }
     },
     {
@@ -12995,8 +12821,8 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 323,
+        "file": "unix.h",
+        "line": 221,
         "column": 3
       }
     },
@@ -13006,38 +12832,10 @@
       "sizeOf": 16,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 323,
+        "file": "unix.h",
+        "line": 221,
         "column": 3
       }
-    },
-    {
-      "name": "HMODULE",
-      "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "isSystem": true
-    },
-    {
-      "name": "HINSTANCE",
-      "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "isSystem": true
-    },
-    {
-      "name": "HINSTANCE__*",
-      "kind": "pointer",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "isSystem": true
-    },
-    {
-      "name": "HINSTANCE__",
-      "kind": "record",
-      "sizeOf": 4,
-      "alignOf": 4,
-      "isSystem": true
     },
     {
       "name": "void**",
@@ -13067,7 +12865,7 @@
     {
       "name": "uv_random_t",
       "kind": "typedef",
-      "sizeOf": 192,
+      "sizeOf": 144,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13128,7 +12926,7 @@
     {
       "name": "uv_fs_event_t",
       "kind": "typedef",
-      "sizeOf": 272,
+      "sizeOf": 304,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13177,7 +12975,7 @@
     {
       "name": "uv_signal_t",
       "kind": "typedef",
-      "sizeOf": 264,
+      "sizeOf": 152,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13243,7 +13041,7 @@
     {
       "name": "uv_stat_t",
       "kind": "typedef",
-      "sizeOf": 128,
+      "sizeOf": 160,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13254,8 +13052,8 @@
     {
       "name": "uv_timespec_t",
       "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 4,
+      "sizeOf": 16,
+      "alignOf": 8,
       "location": {
         "file": "uv.h",
         "line": 346,
@@ -13265,8 +13063,8 @@
     {
       "name": "long",
       "kind": "primitive",
-      "sizeOf": 4,
-      "alignOf": 4,
+      "sizeOf": 8,
+      "alignOf": 8,
       "isSystem": true
     },
     {
@@ -13283,7 +13081,7 @@
     {
       "name": "uv_fs_t",
       "kind": "typedef",
-      "sizeOf": 456,
+      "sizeOf": 440,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13305,30 +13103,37 @@
     {
       "name": "uv_uid_t",
       "kind": "typedef",
-      "sizeOf": 1,
-      "alignOf": 1,
+      "sizeOf": 4,
+      "alignOf": 4,
       "location": {
-        "file": "win.h",
-        "line": 296,
-        "column": 23
+        "file": "unix.h",
+        "line": 169,
+        "column": 15
       }
     },
     {
       "name": "uv_gid_t",
       "kind": "typedef",
-      "sizeOf": 1,
-      "alignOf": 1,
+      "sizeOf": 4,
+      "alignOf": 4,
       "location": {
-        "file": "win.h",
-        "line": 297,
-        "column": 23
+        "file": "unix.h",
+        "line": 168,
+        "column": 15
       }
     },
     {
-      "name": "unsigned char",
-      "kind": "primitive",
-      "sizeOf": 1,
-      "alignOf": 1,
+      "name": "gid_t",
+      "kind": "typedef",
+      "sizeOf": 4,
+      "alignOf": 4,
+      "isSystem": true
+    },
+    {
+      "name": "uid_t",
+      "kind": "typedef",
+      "sizeOf": 4,
+      "alignOf": 4,
       "isSystem": true
     },
     {
@@ -13337,8 +13142,8 @@
       "sizeOf": 4,
       "alignOf": 4,
       "location": {
-        "file": "win.h",
-        "line": 231,
+        "file": "unix.h",
+        "line": 128,
         "column": 13
       }
     },
@@ -13356,7 +13161,7 @@
     {
       "name": "uv_dir_t",
       "kind": "typedef",
-      "sizeOf": 656,
+      "sizeOf": 56,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13413,45 +13218,13 @@
       "sizeOf": 16,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 229,
+        "file": "unix.h",
+        "line": 126,
         "column": 3
       }
     },
     {
-      "name": "ULONG",
-      "kind": "typedef",
-      "sizeOf": 4,
-      "alignOf": 4,
-      "isSystem": true
-    },
-    {
-      "name": "DWORD",
-      "kind": "typedef",
-      "sizeOf": 4,
-      "alignOf": 4,
-      "isSystem": true
-    },
-    {
-      "name": "unsigned long",
-      "kind": "primitive",
-      "sizeOf": 4,
-      "alignOf": 4,
-      "isSystem": true
-    },
-    {
       "name": "ssize_t",
-      "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "location": {
-        "file": "win.h",
-        "line": 27,
-        "column": 18
-      }
-    },
-    {
-      "name": "intptr_t",
       "kind": "typedef",
       "sizeOf": 8,
       "alignOf": 8,
@@ -13653,10 +13426,17 @@
       "sizeOf": 4,
       "alignOf": 4,
       "location": {
-        "file": "win.h",
-        "line": 234,
-        "column": 13
+        "file": "unix.h",
+        "line": 131,
+        "column": 15
       }
+    },
+    {
+      "name": "pid_t",
+      "kind": "typedef",
+      "sizeOf": 4,
+      "alignOf": 4,
+      "isSystem": true
     },
     {
       "name": "uv_passwd_t*",
@@ -13672,7 +13452,7 @@
     {
       "name": "uv_passwd_t",
       "kind": "typedef",
-      "sizeOf": 32,
+      "sizeOf": 40,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13694,7 +13474,7 @@
     {
       "name": "uv_rusage_t",
       "kind": "typedef",
-      "sizeOf": 128,
+      "sizeOf": 144,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13705,8 +13485,8 @@
     {
       "name": "uv_timeval_t",
       "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 4,
+      "sizeOf": 16,
+      "alignOf": 8,
       "location": {
         "file": "uv.h",
         "line": 1182,
@@ -13716,12 +13496,12 @@
     {
       "name": "uv_os_fd_t",
       "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
+      "sizeOf": 4,
+      "alignOf": 4,
       "location": {
-        "file": "win.h",
-        "line": 233,
-        "column": 16
+        "file": "unix.h",
+        "line": 130,
+        "column": 13
       }
     },
     {
@@ -13752,7 +13532,7 @@
     {
       "name": "uv_req_t",
       "kind": "typedef",
-      "sizeOf": 112,
+      "sizeOf": 64,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13774,7 +13554,7 @@
     {
       "name": "uv_work_t",
       "kind": "typedef",
-      "sizeOf": 176,
+      "sizeOf": 128,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13818,7 +13598,7 @@
     {
       "name": "uv_process_t",
       "kind": "typedef",
-      "sizeOf": 264,
+      "sizeOf": 136,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13917,7 +13697,7 @@
     {
       "name": "uv_stream_t",
       "kind": "typedef",
-      "sizeOf": 272,
+      "sizeOf": 264,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13939,7 +13719,7 @@
     {
       "name": "uv_getnameinfo_t",
       "kind": "typedef",
-      "sizeOf": 1368,
+      "sizeOf": 1320,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -13969,7 +13749,7 @@
       "name": "sockaddr",
       "kind": "record",
       "sizeOf": 16,
-      "alignOf": 2,
+      "alignOf": 1,
       "isSystem": true
     },
     {
@@ -14000,7 +13780,7 @@
     {
       "name": "uv_getaddrinfo_t",
       "kind": "typedef",
-      "sizeOf": 216,
+      "sizeOf": 160,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14033,7 +13813,7 @@
     {
       "name": "uv_timer_t",
       "kind": "typedef",
-      "sizeOf": 160,
+      "sizeOf": 152,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14066,7 +13846,7 @@
     {
       "name": "uv_async_t",
       "kind": "typedef",
-      "sizeOf": 224,
+      "sizeOf": 128,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14198,7 +13978,7 @@
     {
       "name": "uv_poll_t",
       "kind": "typedef",
-      "sizeOf": 416,
+      "sizeOf": 168,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14220,34 +14000,13 @@
     {
       "name": "uv_os_sock_t",
       "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
+      "sizeOf": 4,
+      "alignOf": 4,
       "location": {
-        "file": "win.h",
-        "line": 232,
-        "column": 16
+        "file": "unix.h",
+        "line": 129,
+        "column": 13
       }
-    },
-    {
-      "name": "SOCKET",
-      "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "isSystem": true
-    },
-    {
-      "name": "UINT_PTR",
-      "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "isSystem": true
-    },
-    {
-      "name": "unsigned long long",
-      "kind": "primitive",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "isSystem": true
     },
     {
       "name": "uv_pipe_t*",
@@ -14263,7 +14022,7 @@
     {
       "name": "uv_pipe_t",
       "kind": "typedef",
-      "sizeOf": 576,
+      "sizeOf": 280,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14296,7 +14055,7 @@
     {
       "name": "uv_connect_t",
       "kind": "typedef",
-      "sizeOf": 128,
+      "sizeOf": 96,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14384,7 +14143,7 @@
     {
       "name": "uv_udp_t",
       "kind": "typedef",
-      "sizeOf": 424,
+      "sizeOf": 224,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14450,7 +14209,7 @@
     {
       "name": "uv_udp_send_t",
       "kind": "typedef",
-      "sizeOf": 128,
+      "sizeOf": 320,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14494,7 +14253,7 @@
     {
       "name": "uv_tcp_t",
       "kind": "typedef",
-      "sizeOf": 320,
+      "sizeOf": 264,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14527,7 +14286,7 @@
     {
       "name": "uv_write_t",
       "kind": "typedef",
-      "sizeOf": 176,
+      "sizeOf": 192,
       "alignOf": 8,
       "location": {
         "file": "uv.h",
@@ -14571,9 +14330,9 @@
     {
       "name": "uv_os_sock_t[2]",
       "kind": "array",
-      "sizeOf": 16,
-      "alignOf": 8,
-      "sizeOfElement": 8,
+      "sizeOf": 8,
+      "alignOf": 4,
+      "sizeOfElement": 4,
       "arraySize": 2,
       "location": {
         "file": "uv.h",
@@ -14600,9 +14359,9 @@
       "sizeOf": 8,
       "alignOf": 8,
       "location": {
-        "file": "win.h",
-        "line": 233,
-        "column": 16
+        "file": "unix.h",
+        "line": 130,
+        "column": 13
       }
     },
     {
@@ -14615,7 +14374,7 @@
     {
       "name": "FILE",
       "kind": "typedef",
-      "sizeOf": 8,
+      "sizeOf": 152,
       "alignOf": 8,
       "isSystem": true
     },
@@ -14655,7 +14414,7 @@
     {
       "name": "uv_shutdown_t",
       "kind": "typedef",
-      "sizeOf": 128,
+      "sizeOf": 80,
       "alignOf": 8,
       "location": {
         "file": "uv.h",

--- a/src/cs/examples/libuv/libuv-cs/uv.cs
+++ b/src/cs/examples/libuv/libuv-cs/uv.cs
@@ -20,1768 +20,1166 @@ using C2CS;
 public static unsafe partial class uv
 {
     private const string LibraryName = "uv";
-    private static IntPtr _libraryHandle;
-
-    static uv()
-    {
-        TryLoadApi();
-    }
-
-    public static bool TryLoadApi(string? libraryName = LibraryName)
-    {
-        UnloadApi();
-        _libraryHandle = Runtime.LibraryLoad(libraryName!);
-        if (_libraryHandle == IntPtr.Zero) return false;
-        _LoadVirtualTable();
-        return true;
-    }
-
-    public static void UnloadApi()
-    {
-        if (_libraryHandle == IntPtr.Zero) return;
-        _UnloadVirtualTable();
-        Runtime.LibraryUnload(_libraryHandle);
-    }
 
     // Function @ uv.h:1814:16
-    public static void uv_loop_set_data(uv_loop_t* param, void* data)
-    {
-        _virtualTable.uv_loop_set_data(param, data);
-    }
+    [DllImport("uv")]
+    public static extern void uv_loop_set_data(uv_loop_t* param, void* data);
 
     // Function @ uv.h:1813:17
-    public static void* uv_loop_get_data(uv_loop_t* param)
-    {
-        return _virtualTable.uv_loop_get_data(param);
-    }
+    [DllImport("uv")]
+    public static extern void* uv_loop_get_data(uv_loop_t* param);
 
     // Function @ uv.h:1782:15
-    public static int uv_thread_equal(uv_thread_t* t1, uv_thread_t* t2)
-    {
-        return _virtualTable.uv_thread_equal(t1, t2);
-    }
+    [DllImport("uv")]
+    public static extern int uv_thread_equal(uv_thread_t* t1, uv_thread_t* t2);
 
     // Function @ uv.h:1781:15
-    public static int uv_thread_join(uv_thread_t* tid)
-    {
-        return _virtualTable.uv_thread_join(tid);
-    }
+    [DllImport("uv")]
+    public static extern int uv_thread_join(uv_thread_t* tid);
 
     // Function @ uv.h:1780:23
-    public static uv_thread_t uv_thread_self()
-    {
-        return _virtualTable.uv_thread_self();
-    }
+    [DllImport("uv")]
+    public static extern uv_thread_t uv_thread_self();
 
     // Function @ uv.h:1776:15
-    public static int uv_thread_create_ex(uv_thread_t* tid, uv_thread_options_t* @params, uv_thread_cb entry, void* arg)
-    {
-        return _virtualTable.uv_thread_create_ex(tid, @params, entry, arg);
-    }
+    [DllImport("uv")]
+    public static extern int uv_thread_create_ex(uv_thread_t* tid, uv_thread_options_t* @params, uv_thread_cb entry, void* arg);
 
     // Function @ uv.h:1761:15
-    public static int uv_thread_create(uv_thread_t* tid, uv_thread_cb entry, void* arg)
-    {
-        return _virtualTable.uv_thread_create(tid, entry, arg);
-    }
+    [DllImport("uv")]
+    public static extern int uv_thread_create(uv_thread_t* tid, uv_thread_cb entry, void* arg);
 
     // Function @ uv.h:1757:15
-    public static int uv_gettimeofday(uv_timeval64_t* tv)
-    {
-        return _virtualTable.uv_gettimeofday(tv);
-    }
+    [DllImport("uv")]
+    public static extern int uv_gettimeofday(uv_timeval64_t* tv);
 
     // Function @ uv.h:1755:16
-    public static void uv_key_set(uv_key_t* key, void* value)
-    {
-        _virtualTable.uv_key_set(key, value);
-    }
+    [DllImport("uv")]
+    public static extern void uv_key_set(uv_key_t* key, void* value);
 
     // Function @ uv.h:1754:17
-    public static void* uv_key_get(uv_key_t* key)
-    {
-        return _virtualTable.uv_key_get(key);
-    }
+    [DllImport("uv")]
+    public static extern void* uv_key_get(uv_key_t* key);
 
     // Function @ uv.h:1753:16
-    public static void uv_key_delete(uv_key_t* key)
-    {
-        _virtualTable.uv_key_delete(key);
-    }
+    [DllImport("uv")]
+    public static extern void uv_key_delete(uv_key_t* key);
 
     // Function @ uv.h:1752:15
-    public static int uv_key_create(uv_key_t* key)
-    {
-        return _virtualTable.uv_key_create(key);
-    }
+    [DllImport("uv")]
+    public static extern int uv_key_create(uv_key_t* key);
 
     // Function @ uv.h:1750:16
-    public static void uv_once(uv_once_t* guard, FnPtr_UV_Void callback)
-    {
-        _virtualTable.uv_once(guard, callback);
-    }
+    [DllImport("uv")]
+    public static extern void uv_once(uv_once_t* guard, FnPtr_UV_Void callback);
 
     // Function @ uv.h:1746:15
-    public static int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, ulong timeout)
-    {
-        return _virtualTable.uv_cond_timedwait(cond, mutex, timeout);
-    }
+    [DllImport("uv")]
+    public static extern int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, ulong timeout);
 
     // Function @ uv.h:1745:16
-    public static void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex)
-    {
-        _virtualTable.uv_cond_wait(cond, mutex);
-    }
+    [DllImport("uv")]
+    public static extern void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex);
 
     // Function @ uv.h:1743:15
-    public static int uv_barrier_wait(uv_barrier_t* barrier)
-    {
-        return _virtualTable.uv_barrier_wait(barrier);
-    }
+    [DllImport("uv")]
+    public static extern int uv_barrier_wait(uv_barrier_t* barrier);
 
     // Function @ uv.h:1742:16
-    public static void uv_barrier_destroy(uv_barrier_t* barrier)
-    {
-        _virtualTable.uv_barrier_destroy(barrier);
-    }
+    [DllImport("uv")]
+    public static extern void uv_barrier_destroy(uv_barrier_t* barrier);
 
     // Function @ uv.h:1741:15
-    public static int uv_barrier_init(uv_barrier_t* barrier, uint count)
-    {
-        return _virtualTable.uv_barrier_init(barrier, count);
-    }
+    [DllImport("uv")]
+    public static extern int uv_barrier_init(uv_barrier_t* barrier, uint count);
 
     // Function @ uv.h:1739:16
-    public static void uv_cond_broadcast(uv_cond_t* cond)
-    {
-        _virtualTable.uv_cond_broadcast(cond);
-    }
+    [DllImport("uv")]
+    public static extern void uv_cond_broadcast(uv_cond_t* cond);
 
     // Function @ uv.h:1738:16
-    public static void uv_cond_signal(uv_cond_t* cond)
-    {
-        _virtualTable.uv_cond_signal(cond);
-    }
+    [DllImport("uv")]
+    public static extern void uv_cond_signal(uv_cond_t* cond);
 
     // Function @ uv.h:1737:16
-    public static void uv_cond_destroy(uv_cond_t* cond)
-    {
-        _virtualTable.uv_cond_destroy(cond);
-    }
+    [DllImport("uv")]
+    public static extern void uv_cond_destroy(uv_cond_t* cond);
 
     // Function @ uv.h:1736:15
-    public static int uv_cond_init(uv_cond_t* cond)
-    {
-        return _virtualTable.uv_cond_init(cond);
-    }
+    [DllImport("uv")]
+    public static extern int uv_cond_init(uv_cond_t* cond);
 
     // Function @ uv.h:1734:15
-    public static int uv_sem_trywait(uv_sem_t* sem)
-    {
-        return _virtualTable.uv_sem_trywait(sem);
-    }
+    [DllImport("uv")]
+    public static extern int uv_sem_trywait(uv_sem_t* sem);
 
     // Function @ uv.h:1733:16
-    public static void uv_sem_wait(uv_sem_t* sem)
-    {
-        _virtualTable.uv_sem_wait(sem);
-    }
+    [DllImport("uv")]
+    public static extern void uv_sem_wait(uv_sem_t* sem);
 
     // Function @ uv.h:1732:16
-    public static void uv_sem_post(uv_sem_t* sem)
-    {
-        _virtualTable.uv_sem_post(sem);
-    }
+    [DllImport("uv")]
+    public static extern void uv_sem_post(uv_sem_t* sem);
 
     // Function @ uv.h:1731:16
-    public static void uv_sem_destroy(uv_sem_t* sem)
-    {
-        _virtualTable.uv_sem_destroy(sem);
-    }
+    [DllImport("uv")]
+    public static extern void uv_sem_destroy(uv_sem_t* sem);
 
     // Function @ uv.h:1730:15
-    public static int uv_sem_init(uv_sem_t* sem, uint value)
-    {
-        return _virtualTable.uv_sem_init(sem, value);
-    }
+    [DllImport("uv")]
+    public static extern int uv_sem_init(uv_sem_t* sem, uint value);
 
     // Function @ uv.h:1728:16
-    public static void uv_rwlock_wrunlock(uv_rwlock_t* rwlock)
-    {
-        _virtualTable.uv_rwlock_wrunlock(rwlock);
-    }
+    [DllImport("uv")]
+    public static extern void uv_rwlock_wrunlock(uv_rwlock_t* rwlock);
 
     // Function @ uv.h:1727:15
-    public static int uv_rwlock_trywrlock(uv_rwlock_t* rwlock)
-    {
-        return _virtualTable.uv_rwlock_trywrlock(rwlock);
-    }
+    [DllImport("uv")]
+    public static extern int uv_rwlock_trywrlock(uv_rwlock_t* rwlock);
 
     // Function @ uv.h:1726:16
-    public static void uv_rwlock_wrlock(uv_rwlock_t* rwlock)
-    {
-        _virtualTable.uv_rwlock_wrlock(rwlock);
-    }
+    [DllImport("uv")]
+    public static extern void uv_rwlock_wrlock(uv_rwlock_t* rwlock);
 
     // Function @ uv.h:1725:16
-    public static void uv_rwlock_rdunlock(uv_rwlock_t* rwlock)
-    {
-        _virtualTable.uv_rwlock_rdunlock(rwlock);
-    }
+    [DllImport("uv")]
+    public static extern void uv_rwlock_rdunlock(uv_rwlock_t* rwlock);
 
     // Function @ uv.h:1724:15
-    public static int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock)
-    {
-        return _virtualTable.uv_rwlock_tryrdlock(rwlock);
-    }
+    [DllImport("uv")]
+    public static extern int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock);
 
     // Function @ uv.h:1723:16
-    public static void uv_rwlock_rdlock(uv_rwlock_t* rwlock)
-    {
-        _virtualTable.uv_rwlock_rdlock(rwlock);
-    }
+    [DllImport("uv")]
+    public static extern void uv_rwlock_rdlock(uv_rwlock_t* rwlock);
 
     // Function @ uv.h:1722:16
-    public static void uv_rwlock_destroy(uv_rwlock_t* rwlock)
-    {
-        _virtualTable.uv_rwlock_destroy(rwlock);
-    }
+    [DllImport("uv")]
+    public static extern void uv_rwlock_destroy(uv_rwlock_t* rwlock);
 
     // Function @ uv.h:1721:15
-    public static int uv_rwlock_init(uv_rwlock_t* rwlock)
-    {
-        return _virtualTable.uv_rwlock_init(rwlock);
-    }
+    [DllImport("uv")]
+    public static extern int uv_rwlock_init(uv_rwlock_t* rwlock);
 
     // Function @ uv.h:1719:16
-    public static void uv_mutex_unlock(uv_mutex_t* handle)
-    {
-        _virtualTable.uv_mutex_unlock(handle);
-    }
+    [DllImport("uv")]
+    public static extern void uv_mutex_unlock(uv_mutex_t* handle);
 
     // Function @ uv.h:1718:15
-    public static int uv_mutex_trylock(uv_mutex_t* handle)
-    {
-        return _virtualTable.uv_mutex_trylock(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_mutex_trylock(uv_mutex_t* handle);
 
     // Function @ uv.h:1717:16
-    public static void uv_mutex_lock(uv_mutex_t* handle)
-    {
-        _virtualTable.uv_mutex_lock(handle);
-    }
+    [DllImport("uv")]
+    public static extern void uv_mutex_lock(uv_mutex_t* handle);
 
     // Function @ uv.h:1716:16
-    public static void uv_mutex_destroy(uv_mutex_t* handle)
-    {
-        _virtualTable.uv_mutex_destroy(handle);
-    }
+    [DllImport("uv")]
+    public static extern void uv_mutex_destroy(uv_mutex_t* handle);
 
     // Function @ uv.h:1715:15
-    public static int uv_mutex_init_recursive(uv_mutex_t* handle)
-    {
-        return _virtualTable.uv_mutex_init_recursive(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_mutex_init_recursive(uv_mutex_t* handle);
 
     // Function @ uv.h:1714:15
-    public static int uv_mutex_init(uv_mutex_t* handle)
-    {
-        return _virtualTable.uv_mutex_init(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_mutex_init(uv_mutex_t* handle);
 
     // Function @ uv.h:1712:23
-    public static CString uv_dlerror(uv_lib_t* lib)
-    {
-        return _virtualTable.uv_dlerror(lib);
-    }
+    [DllImport("uv")]
+    public static extern CString uv_dlerror(uv_lib_t* lib);
 
     // Function @ uv.h:1711:15
-    public static int uv_dlsym(uv_lib_t* lib, CString name, void** ptr)
-    {
-        return _virtualTable.uv_dlsym(lib, name, ptr);
-    }
+    [DllImport("uv")]
+    public static extern int uv_dlsym(uv_lib_t* lib, CString name, void** ptr);
 
     // Function @ uv.h:1710:16
-    public static void uv_dlclose(uv_lib_t* lib)
-    {
-        _virtualTable.uv_dlclose(lib);
-    }
+    [DllImport("uv")]
+    public static extern void uv_dlclose(uv_lib_t* lib);
 
     // Function @ uv.h:1709:15
-    public static int uv_dlopen(CString filename, uv_lib_t* lib)
-    {
-        return _virtualTable.uv_dlopen(filename, lib);
-    }
+    [DllImport("uv")]
+    public static extern int uv_dlopen(CString filename, uv_lib_t* lib);
 
     // Function @ uv.h:1707:16
-    public static void uv_disable_stdio_inheritance()
-    {
-        _virtualTable.uv_disable_stdio_inheritance();
-    }
+    [DllImport("uv")]
+    public static extern void uv_disable_stdio_inheritance();
 
     // Function @ uv.h:1705:16
-    public static void uv_sleep(uint msec)
-    {
-        _virtualTable.uv_sleep(msec);
-    }
+    [DllImport("uv")]
+    public static extern void uv_sleep(uint msec);
 
     // Function @ uv.h:1704:20
-    public static ulong uv_hrtime()
-    {
-        return _virtualTable.uv_hrtime();
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_hrtime();
 
     // Function @ uv.h:1702:20
-    public static ulong uv_get_constrained_memory()
-    {
-        return _virtualTable.uv_get_constrained_memory();
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_get_constrained_memory();
 
     // Function @ uv.h:1701:20
-    public static ulong uv_get_total_memory()
-    {
-        return _virtualTable.uv_get_total_memory();
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_get_total_memory();
 
     // Function @ uv.h:1700:20
-    public static ulong uv_get_free_memory()
-    {
-        return _virtualTable.uv_get_free_memory();
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_get_free_memory();
 
     // Function @ uv.h:1698:15
-    public static int uv_chdir(CString dir)
-    {
-        return _virtualTable.uv_chdir(dir);
-    }
+    [DllImport("uv")]
+    public static extern int uv_chdir(CString dir);
 
     // Function @ uv.h:1696:15
-    public static int uv_cwd(CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_cwd(buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_cwd(CString buffer, ulong* size);
 
     // Function @ uv.h:1694:15
-    public static int uv_exepath(CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_exepath(buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_exepath(CString buffer, ulong* size);
 
     // Function @ uv.h:1690:15
-    public static int uv_if_indextoiid(uint ifindex, CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_if_indextoiid(ifindex, buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_if_indextoiid(uint ifindex, CString buffer, ulong* size);
 
     // Function @ uv.h:1687:15
-    public static int uv_if_indextoname(uint ifindex, CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_if_indextoname(ifindex, buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_if_indextoname(uint ifindex, CString buffer, ulong* size);
 
     // Function @ uv.h:1672:15
-    public static int uv_random(uv_loop_t* loop, uv_random_t* req, void* buf, ulong buflen, uint flags, uv_random_cb cb)
-    {
-        return _virtualTable.uv_random(loop, req, buf, buflen, flags, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_random(uv_loop_t* loop, uv_random_t* req, void* buf, ulong buflen, uint flags, uv_random_cb cb);
 
     // Function @ uv.h:1657:15
-    public static int uv_inet_pton(int af, CString src, void* dst)
-    {
-        return _virtualTable.uv_inet_pton(af, src, dst);
-    }
+    [DllImport("uv")]
+    public static extern int uv_inet_pton(int af, CString src, void* dst);
 
     // Function @ uv.h:1656:15
-    public static int uv_inet_ntop(int af, void* src, CString dst, ulong size)
-    {
-        return _virtualTable.uv_inet_ntop(af, src, dst, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_inet_ntop(int af, void* src, CString dst, ulong size);
 
     // Function @ uv.h:1654:15
-    public static int uv_ip6_name(sockaddr_in6* src, CString dst, ulong size)
-    {
-        return _virtualTable.uv_ip6_name(src, dst, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_ip6_name(sockaddr_in6* src, CString dst, ulong size);
 
     // Function @ uv.h:1653:15
-    public static int uv_ip4_name(sockaddr_in* src, CString dst, ulong size)
-    {
-        return _virtualTable.uv_ip4_name(src, dst, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_ip4_name(sockaddr_in* src, CString dst, ulong size);
 
     // Function @ uv.h:1651:15
-    public static int uv_ip6_addr(CString ip, int port, sockaddr_in6* addr)
-    {
-        return _virtualTable.uv_ip6_addr(ip, port, addr);
-    }
+    [DllImport("uv")]
+    public static extern int uv_ip6_addr(CString ip, int port, sockaddr_in6* addr);
 
     // Function @ uv.h:1650:15
-    public static int uv_ip4_addr(CString ip, int port, sockaddr_in* addr)
-    {
-        return _virtualTable.uv_ip4_addr(ip, port, addr);
-    }
+    [DllImport("uv")]
+    public static extern int uv_ip4_addr(CString ip, int port, sockaddr_in* addr);
 
     // Function @ uv.h:1646:15
-    public static int uv_fs_event_getpath(uv_fs_event_t* handle, CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_fs_event_getpath(handle, buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_event_getpath(uv_fs_event_t* handle, CString buffer, ulong* size);
 
     // Function @ uv.h:1645:15
-    public static int uv_fs_event_stop(uv_fs_event_t* handle)
-    {
-        return _virtualTable.uv_fs_event_stop(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_event_stop(uv_fs_event_t* handle);
 
     // Function @ uv.h:1641:15
-    public static int uv_fs_event_start(uv_fs_event_t* handle, uv_fs_event_cb cb, CString path, uint flags)
-    {
-        return _virtualTable.uv_fs_event_start(handle, cb, path, flags);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_event_start(uv_fs_event_t* handle, uv_fs_event_cb cb, CString path, uint flags);
 
     // Function @ uv.h:1640:15
-    public static int uv_fs_event_init(uv_loop_t* loop, uv_fs_event_t* handle)
-    {
-        return _virtualTable.uv_fs_event_init(loop, handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_event_init(uv_loop_t* loop, uv_fs_event_t* handle);
 
     // Function @ uv.h:1606:16
-    public static void uv_loadavg(double* avg)
-    {
-        _virtualTable.uv_loadavg(avg);
-    }
+    [DllImport("uv")]
+    public static extern void uv_loadavg(double* avg);
 
     // Function @ uv.h:1604:15
-    public static int uv_signal_stop(uv_signal_t* handle)
-    {
-        return _virtualTable.uv_signal_stop(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_signal_stop(uv_signal_t* handle);
 
     // Function @ uv.h:1601:15
-    public static int uv_signal_start_oneshot(uv_signal_t* handle, uv_signal_cb signal_cb, int signum)
-    {
-        return _virtualTable.uv_signal_start_oneshot(handle, signal_cb, signum);
-    }
+    [DllImport("uv")]
+    public static extern int uv_signal_start_oneshot(uv_signal_t* handle, uv_signal_cb signal_cb, int signum);
 
     // Function @ uv.h:1598:15
-    public static int uv_signal_start(uv_signal_t* handle, uv_signal_cb signal_cb, int signum)
-    {
-        return _virtualTable.uv_signal_start(handle, signal_cb, signum);
-    }
+    [DllImport("uv")]
+    public static extern int uv_signal_start(uv_signal_t* handle, uv_signal_cb signal_cb, int signum);
 
     // Function @ uv.h:1597:15
-    public static int uv_signal_init(uv_loop_t* loop, uv_signal_t* handle)
-    {
-        return _virtualTable.uv_signal_init(loop, handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_signal_init(uv_loop_t* loop, uv_signal_t* handle);
 
     // Function @ uv.h:1585:15
-    public static int uv_fs_poll_getpath(uv_fs_poll_t* handle, CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_fs_poll_getpath(handle, buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_poll_getpath(uv_fs_poll_t* handle, CString buffer, ulong* size);
 
     // Function @ uv.h:1584:15
-    public static int uv_fs_poll_stop(uv_fs_poll_t* handle)
-    {
-        return _virtualTable.uv_fs_poll_stop(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_poll_stop(uv_fs_poll_t* handle);
 
     // Function @ uv.h:1580:15
-    public static int uv_fs_poll_start(uv_fs_poll_t* handle, uv_fs_poll_cb poll_cb, CString path, uint interval)
-    {
-        return _virtualTable.uv_fs_poll_start(handle, poll_cb, path, interval);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_poll_start(uv_fs_poll_t* handle, uv_fs_poll_cb poll_cb, CString path, uint interval);
 
     // Function @ uv.h:1579:15
-    public static int uv_fs_poll_init(uv_loop_t* loop, uv_fs_poll_t* handle)
-    {
-        return _virtualTable.uv_fs_poll_init(loop, handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_poll_init(uv_loop_t* loop, uv_fs_poll_t* handle);
 
     // Function @ uv.h:1550:15
-    public static int uv_fs_statfs(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_statfs(loop, req, path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_statfs(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb);
 
     // Function @ uv.h:1544:15
-    public static int uv_fs_lchown(uv_loop_t* loop, uv_fs_t* req, CString path, uv_uid_t uid, uv_gid_t gid, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_lchown(loop, req, path, uid, gid, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_lchown(uv_loop_t* loop, uv_fs_t* req, CString path, uv_uid_t uid, uv_gid_t gid, uv_fs_cb cb);
 
     // Function @ uv.h:1538:15
-    public static int uv_fs_fchown(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_uid_t uid, uv_gid_t gid, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_fchown(loop, req, file, uid, gid, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_fchown(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_uid_t uid, uv_gid_t gid, uv_fs_cb cb);
 
     // Function @ uv.h:1532:15
-    public static int uv_fs_chown(uv_loop_t* loop, uv_fs_t* req, CString path, uv_uid_t uid, uv_gid_t gid, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_chown(loop, req, path, uid, gid, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_chown(uv_loop_t* loop, uv_fs_t* req, CString path, uv_uid_t uid, uv_gid_t gid, uv_fs_cb cb);
 
     // Function @ uv.h:1527:15
-    public static int uv_fs_fchmod(uv_loop_t* loop, uv_fs_t* req, uv_file file, int mode, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_fchmod(loop, req, file, mode, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_fchmod(uv_loop_t* loop, uv_fs_t* req, uv_file file, int mode, uv_fs_cb cb);
 
     // Function @ uv.h:1523:15
-    public static int uv_fs_realpath(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_realpath(loop, req, path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_realpath(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb);
 
     // Function @ uv.h:1519:15
-    public static int uv_fs_readlink(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_readlink(loop, req, path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_readlink(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb);
 
     // Function @ uv.h:1513:15
-    public static int uv_fs_symlink(uv_loop_t* loop, uv_fs_t* req, CString path, CString new_path, int flags, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_symlink(loop, req, path, new_path, flags, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_symlink(uv_loop_t* loop, uv_fs_t* req, CString path, CString new_path, int flags, uv_fs_cb cb);
 
     // Function @ uv.h:1495:15
-    public static int uv_fs_link(uv_loop_t* loop, uv_fs_t* req, CString path, CString new_path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_link(loop, req, path, new_path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_link(uv_loop_t* loop, uv_fs_t* req, CString path, CString new_path, uv_fs_cb cb);
 
     // Function @ uv.h:1491:15
-    public static int uv_fs_lstat(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_lstat(loop, req, path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_lstat(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb);
 
     // Function @ uv.h:1485:15
-    public static int uv_fs_lutime(uv_loop_t* loop, uv_fs_t* req, CString path, double atime, double mtime, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_lutime(loop, req, path, atime, mtime, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_lutime(uv_loop_t* loop, uv_fs_t* req, CString path, double atime, double mtime, uv_fs_cb cb);
 
     // Function @ uv.h:1479:15
-    public static int uv_fs_futime(uv_loop_t* loop, uv_fs_t* req, uv_file file, double atime, double mtime, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_futime(loop, req, file, atime, mtime, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_futime(uv_loop_t* loop, uv_fs_t* req, uv_file file, double atime, double mtime, uv_fs_cb cb);
 
     // Function @ uv.h:1473:15
-    public static int uv_fs_utime(uv_loop_t* loop, uv_fs_t* req, CString path, double atime, double mtime, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_utime(loop, req, path, atime, mtime, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_utime(uv_loop_t* loop, uv_fs_t* req, CString path, double atime, double mtime, uv_fs_cb cb);
 
     // Function @ uv.h:1468:15
-    public static int uv_fs_chmod(uv_loop_t* loop, uv_fs_t* req, CString path, int mode, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_chmod(loop, req, path, mode, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_chmod(uv_loop_t* loop, uv_fs_t* req, CString path, int mode, uv_fs_cb cb);
 
     // Function @ uv.h:1463:15
-    public static int uv_fs_access(uv_loop_t* loop, uv_fs_t* req, CString path, int mode, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_access(loop, req, path, mode, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_access(uv_loop_t* loop, uv_fs_t* req, CString path, int mode, uv_fs_cb cb);
 
     // Function @ uv.h:1456:15
-    public static int uv_fs_sendfile(uv_loop_t* loop, uv_fs_t* req, uv_file out_fd, uv_file in_fd, long in_offset, ulong length, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_sendfile(loop, req, out_fd, in_fd, in_offset, length, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_sendfile(uv_loop_t* loop, uv_fs_t* req, uv_file out_fd, uv_file in_fd, long in_offset, ulong length, uv_fs_cb cb);
 
     // Function @ uv.h:1451:15
-    public static int uv_fs_ftruncate(uv_loop_t* loop, uv_fs_t* req, uv_file file, long offset, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_ftruncate(loop, req, file, offset, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_ftruncate(uv_loop_t* loop, uv_fs_t* req, uv_file file, long offset, uv_fs_cb cb);
 
     // Function @ uv.h:1447:15
-    public static int uv_fs_fdatasync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_fdatasync(loop, req, file, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_fdatasync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb);
 
     // Function @ uv.h:1443:15
-    public static int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_fsync(loop, req, file, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_fsync(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb);
 
     // Function @ uv.h:1438:15
-    public static int uv_fs_rename(uv_loop_t* loop, uv_fs_t* req, CString path, CString new_path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_rename(loop, req, path, new_path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_rename(uv_loop_t* loop, uv_fs_t* req, CString path, CString new_path, uv_fs_cb cb);
 
     // Function @ uv.h:1434:15
-    public static int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_fstat(loop, req, file, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_fstat(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb);
 
     // Function @ uv.h:1430:15
-    public static int uv_fs_stat(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_stat(loop, req, path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_stat(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb);
 
     // Function @ uv.h:1426:15
-    public static int uv_fs_closedir(uv_loop_t* loop, uv_fs_t* req, uv_dir_t* dir, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_closedir(loop, req, dir, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_closedir(uv_loop_t* loop, uv_fs_t* req, uv_dir_t* dir, uv_fs_cb cb);
 
     // Function @ uv.h:1422:15
-    public static int uv_fs_readdir(uv_loop_t* loop, uv_fs_t* req, uv_dir_t* dir, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_readdir(loop, req, dir, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_readdir(uv_loop_t* loop, uv_fs_t* req, uv_dir_t* dir, uv_fs_cb cb);
 
     // Function @ uv.h:1418:15
-    public static int uv_fs_opendir(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_opendir(loop, req, path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_opendir(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb);
 
     // Function @ uv.h:1416:15
-    public static int uv_fs_scandir_next(uv_fs_t* req, uv_dirent_t* ent)
-    {
-        return _virtualTable.uv_fs_scandir_next(req, ent);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_scandir_next(uv_fs_t* req, uv_dirent_t* ent);
 
     // Function @ uv.h:1411:15
-    public static int uv_fs_scandir(uv_loop_t* loop, uv_fs_t* req, CString path, int flags, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_scandir(loop, req, path, flags, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_scandir(uv_loop_t* loop, uv_fs_t* req, CString path, int flags, uv_fs_cb cb);
 
     // Function @ uv.h:1407:15
-    public static int uv_fs_rmdir(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_rmdir(loop, req, path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_rmdir(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb);
 
     // Function @ uv.h:1403:15
-    public static int uv_fs_mkstemp(uv_loop_t* loop, uv_fs_t* req, CString tpl, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_mkstemp(loop, req, tpl, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_mkstemp(uv_loop_t* loop, uv_fs_t* req, CString tpl, uv_fs_cb cb);
 
     // Function @ uv.h:1399:15
-    public static int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, CString tpl, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_mkdtemp(loop, req, tpl, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_mkdtemp(uv_loop_t* loop, uv_fs_t* req, CString tpl, uv_fs_cb cb);
 
     // Function @ uv.h:1394:15
-    public static int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, CString path, int mode, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_mkdir(loop, req, path, mode, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_mkdir(uv_loop_t* loop, uv_fs_t* req, CString path, int mode, uv_fs_cb cb);
 
     // Function @ uv.h:1388:15
-    public static int uv_fs_copyfile(uv_loop_t* loop, uv_fs_t* req, CString path, CString new_path, int flags, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_copyfile(loop, req, path, new_path, flags, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_copyfile(uv_loop_t* loop, uv_fs_t* req, CString path, CString new_path, int flags, uv_fs_cb cb);
 
     // Function @ uv.h:1363:15
-    public static int uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_buf_t* bufs, uint nbufs, long offset, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_write(loop, req, file, bufs, nbufs, offset, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_write(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_buf_t* bufs, uint nbufs, long offset, uv_fs_cb cb);
 
     // Function @ uv.h:1359:15
-    public static int uv_fs_unlink(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_unlink(loop, req, path, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_unlink(uv_loop_t* loop, uv_fs_t* req, CString path, uv_fs_cb cb);
 
     // Function @ uv.h:1352:15
-    public static int uv_fs_read(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_buf_t* bufs, uint nbufs, long offset, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_read(loop, req, file, bufs, nbufs, offset, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_read(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_buf_t* bufs, uint nbufs, long offset, uv_fs_cb cb);
 
     // Function @ uv.h:1346:15
-    public static int uv_fs_open(uv_loop_t* loop, uv_fs_t* req, CString path, int flags, int mode, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_open(loop, req, path, flags, mode, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_open(uv_loop_t* loop, uv_fs_t* req, CString path, int flags, int mode, uv_fs_cb cb);
 
     // Function @ uv.h:1342:15
-    public static int uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb)
-    {
-        return _virtualTable.uv_fs_close(loop, req, file, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_close(uv_loop_t* loop, uv_fs_t* req, uv_file file, uv_fs_cb cb);
 
     // Function @ uv.h:1341:16
-    public static void uv_fs_req_cleanup(uv_fs_t* req)
-    {
-        _virtualTable.uv_fs_req_cleanup(req);
-    }
+    [DllImport("uv")]
+    public static extern void uv_fs_req_cleanup(uv_fs_t* req);
 
     // Function @ uv.h:1339:22
-    public static uv_stat_t* uv_fs_get_statbuf(uv_fs_t* param)
-    {
-        return _virtualTable.uv_fs_get_statbuf(param);
-    }
+    [DllImport("uv")]
+    public static extern uv_stat_t* uv_fs_get_statbuf(uv_fs_t* param);
 
     // Function @ uv.h:1338:23
-    public static CString uv_fs_get_path(uv_fs_t* param)
-    {
-        return _virtualTable.uv_fs_get_path(param);
-    }
+    [DllImport("uv")]
+    public static extern CString uv_fs_get_path(uv_fs_t* param);
 
     // Function @ uv.h:1337:17
-    public static void* uv_fs_get_ptr(uv_fs_t* param)
-    {
-        return _virtualTable.uv_fs_get_ptr(param);
-    }
+    [DllImport("uv")]
+    public static extern void* uv_fs_get_ptr(uv_fs_t* param);
 
     // Function @ uv.h:1336:15
-    public static int uv_fs_get_system_error(uv_fs_t* param)
-    {
-        return _virtualTable.uv_fs_get_system_error(param);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fs_get_system_error(uv_fs_t* param);
 
     // Function @ uv.h:1335:19
-    public static ssize_t uv_fs_get_result(uv_fs_t* param)
-    {
-        return _virtualTable.uv_fs_get_result(param);
-    }
+    [DllImport("uv")]
+    public static extern long uv_fs_get_result(uv_fs_t* param);
 
     // Function @ uv.h:1334:22
-    public static uv_fs_type uv_fs_get_type(uv_fs_t* param)
-    {
-        return _virtualTable.uv_fs_get_type(param);
-    }
+    [DllImport("uv")]
+    public static extern uv_fs_type uv_fs_get_type(uv_fs_t* param);
 
     // Function @ uv.h:1271:20
-    public static ulong uv_metrics_idle_time(uv_loop_t* loop)
-    {
-        return _virtualTable.uv_metrics_idle_time(loop);
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_metrics_idle_time(uv_loop_t* loop);
 
     // Function @ uv.h:1269:15
-    public static int uv_os_uname(uv_utsname_t* buffer)
-    {
-        return _virtualTable.uv_os_uname(buffer);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_uname(uv_utsname_t* buffer);
 
     // Function @ uv.h:1267:15
-    public static int uv_os_gethostname(CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_os_gethostname(buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_gethostname(CString buffer, ulong* size);
 
     // Function @ uv.h:1254:15
-    public static int uv_os_unsetenv(CString name)
-    {
-        return _virtualTable.uv_os_unsetenv(name);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_unsetenv(CString name);
 
     // Function @ uv.h:1253:15
-    public static int uv_os_setenv(CString name, CString value)
-    {
-        return _virtualTable.uv_os_setenv(name, value);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_setenv(CString name, CString value);
 
     // Function @ uv.h:1252:15
-    public static int uv_os_getenv(CString name, CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_os_getenv(name, buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_getenv(CString name, CString buffer, ulong* size);
 
     // Function @ uv.h:1251:16
-    public static void uv_os_free_environ(uv_env_item_t* envitems, int count)
-    {
-        _virtualTable.uv_os_free_environ(envitems, count);
-    }
+    [DllImport("uv")]
+    public static extern void uv_os_free_environ(uv_env_item_t* envitems, int count);
 
     // Function @ uv.h:1250:15
-    public static int uv_os_environ(uv_env_item_t** envitems, long* count)
-    {
-        return _virtualTable.uv_os_environ(envitems, count);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_environ(uv_env_item_t** envitems, long* count);
 
     // Function @ uv.h:1242:16
-    public static void uv_free_interface_addresses(uv_interface_address_t* addresses, int count)
-    {
-        _virtualTable.uv_free_interface_addresses(addresses, count);
-    }
+    [DllImport("uv")]
+    public static extern void uv_free_interface_addresses(uv_interface_address_t* addresses, int count);
 
     // Function @ uv.h:1240:15
-    public static int uv_interface_addresses(uv_interface_address_t** addresses, long* count)
-    {
-        return _virtualTable.uv_interface_addresses(addresses, count);
-    }
+    [DllImport("uv")]
+    public static extern int uv_interface_addresses(uv_interface_address_t** addresses, long* count);
 
     // Function @ uv.h:1238:16
-    public static void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count)
-    {
-        _virtualTable.uv_free_cpu_info(cpu_infos, count);
-    }
+    [DllImport("uv")]
+    public static extern void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count);
 
     // Function @ uv.h:1237:15
-    public static int uv_cpu_info(uv_cpu_info_t** cpu_infos, long* count)
-    {
-        return _virtualTable.uv_cpu_info(cpu_infos, count);
-    }
+    [DllImport("uv")]
+    public static extern int uv_cpu_info(uv_cpu_info_t** cpu_infos, long* count);
 
     // Function @ uv.h:1235:15
-    public static int uv_os_setpriority(uv_pid_t pid, int priority)
-    {
-        return _virtualTable.uv_os_setpriority(pid, priority);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_setpriority(uv_pid_t pid, int priority);
 
     // Function @ uv.h:1234:15
-    public static int uv_os_getpriority(uv_pid_t pid, long* priority)
-    {
-        return _virtualTable.uv_os_getpriority(pid, priority);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_getpriority(uv_pid_t pid, long* priority);
 
     // Function @ uv.h:1215:20
-    public static uv_pid_t uv_os_getppid()
-    {
-        return _virtualTable.uv_os_getppid();
-    }
+    [DllImport("uv")]
+    public static extern uv_pid_t uv_os_getppid();
 
     // Function @ uv.h:1214:20
-    public static uv_pid_t uv_os_getpid()
-    {
-        return _virtualTable.uv_os_getpid();
-    }
+    [DllImport("uv")]
+    public static extern uv_pid_t uv_os_getpid();
 
     // Function @ uv.h:1213:16
-    public static void uv_os_free_passwd(uv_passwd_t* pwd)
-    {
-        _virtualTable.uv_os_free_passwd(pwd);
-    }
+    [DllImport("uv")]
+    public static extern void uv_os_free_passwd(uv_passwd_t* pwd);
 
     // Function @ uv.h:1212:15
-    public static int uv_os_get_passwd(uv_passwd_t* pwd)
-    {
-        return _virtualTable.uv_os_get_passwd(pwd);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_get_passwd(uv_passwd_t* pwd);
 
     // Function @ uv.h:1211:15
-    public static int uv_os_tmpdir(CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_os_tmpdir(buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_tmpdir(CString buffer, ulong* size);
 
     // Function @ uv.h:1210:15
-    public static int uv_os_homedir(CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_os_homedir(buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_os_homedir(CString buffer, ulong* size);
 
     // Function @ uv.h:1208:15
-    public static int uv_getrusage(uv_rusage_t* rusage)
-    {
-        return _virtualTable.uv_getrusage(rusage);
-    }
+    [DllImport("uv")]
+    public static extern int uv_getrusage(uv_rusage_t* rusage);
 
     // Function @ uv.h:1177:15
-    public static int uv_open_osfhandle(uv_os_fd_t os_fd)
-    {
-        return _virtualTable.uv_open_osfhandle(os_fd);
-    }
+    [DllImport("uv")]
+    public static extern int uv_open_osfhandle(uv_os_fd_t os_fd);
 
     // Function @ uv.h:1176:22
-    public static uv_os_fd_t uv_get_osfhandle(int fd)
-    {
-        return _virtualTable.uv_get_osfhandle(fd);
-    }
+    [DllImport("uv")]
+    public static extern uv_os_fd_t uv_get_osfhandle(int fd);
 
     // Function @ uv.h:1175:15
-    public static int uv_uptime(double* uptime)
-    {
-        return _virtualTable.uv_uptime(uptime);
-    }
+    [DllImport("uv")]
+    public static extern int uv_uptime(double* uptime);
 
     // Function @ uv.h:1174:15
-    public static int uv_resident_set_memory(ulong* rss)
-    {
-        return _virtualTable.uv_resident_set_memory(rss);
-    }
+    [DllImport("uv")]
+    public static extern int uv_resident_set_memory(ulong* rss);
 
     // Function @ uv.h:1173:15
-    public static int uv_set_process_title(CString title)
-    {
-        return _virtualTable.uv_set_process_title(title);
-    }
+    [DllImport("uv")]
+    public static extern int uv_set_process_title(CString title);
 
     // Function @ uv.h:1172:15
-    public static int uv_get_process_title(CString buffer, ulong size)
-    {
-        return _virtualTable.uv_get_process_title(buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_get_process_title(CString buffer, ulong size);
 
     // Function @ uv.h:1171:18
-    public static CString* uv_setup_args(int argc, CString* argv)
-    {
-        return _virtualTable.uv_setup_args(argc, argv);
-    }
+    [DllImport("uv")]
+    public static extern CString* uv_setup_args(int argc, CString* argv);
 
     // Function @ uv.h:1095:15
-    public static int uv_cancel(uv_req_t* req)
-    {
-        return _virtualTable.uv_cancel(req);
-    }
+    [DllImport("uv")]
+    public static extern int uv_cancel(uv_req_t* req);
 
     // Function @ uv.h:1090:15
-    public static int uv_queue_work(uv_loop_t* loop, uv_work_t* req, uv_work_cb work_cb, uv_after_work_cb after_work_cb)
-    {
-        return _virtualTable.uv_queue_work(loop, req, work_cb, after_work_cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_queue_work(uv_loop_t* loop, uv_work_t* req, uv_work_cb work_cb, uv_after_work_cb after_work_cb);
 
     // Function @ uv.h:1076:20
-    public static uv_pid_t uv_process_get_pid(uv_process_t* param)
-    {
-        return _virtualTable.uv_process_get_pid(param);
-    }
+    [DllImport("uv")]
+    public static extern uv_pid_t uv_process_get_pid(uv_process_t* param);
 
     // Function @ uv.h:1075:15
-    public static int uv_kill(int pid, int signum)
-    {
-        return _virtualTable.uv_kill(pid, signum);
-    }
+    [DllImport("uv")]
+    public static extern int uv_kill(int pid, int signum);
 
     // Function @ uv.h:1074:15
-    public static int uv_process_kill(uv_process_t* param, int signum)
-    {
-        return _virtualTable.uv_process_kill(param, signum);
-    }
+    [DllImport("uv")]
+    public static extern int uv_process_kill(uv_process_t* param, int signum);
 
     // Function @ uv.h:1071:15
-    public static int uv_spawn(uv_loop_t* loop, uv_process_t* handle, uv_process_options_t* options)
-    {
-        return _virtualTable.uv_spawn(loop, handle, options);
-    }
+    [DllImport("uv")]
+    public static extern int uv_spawn(uv_loop_t* loop, uv_process_t* handle, uv_process_options_t* options);
 
     // Function @ uv.h:926:15
-    public static int uv_getnameinfo(uv_loop_t* loop, uv_getnameinfo_t* req, uv_getnameinfo_cb getnameinfo_cb, sockaddr* addr, int flags)
-    {
-        return _virtualTable.uv_getnameinfo(loop, req, getnameinfo_cb, addr, flags);
-    }
+    [DllImport("uv")]
+    public static extern int uv_getnameinfo(uv_loop_t* loop, uv_getnameinfo_t* req, uv_getnameinfo_cb getnameinfo_cb, sockaddr* addr, int flags);
 
     // Function @ uv.h:910:16
-    public static void uv_freeaddrinfo(addrinfo* ai)
-    {
-        _virtualTable.uv_freeaddrinfo(ai);
-    }
+    [DllImport("uv")]
+    public static extern void uv_freeaddrinfo(addrinfo* ai);
 
     // Function @ uv.h:904:15
-    public static int uv_getaddrinfo(uv_loop_t* loop, uv_getaddrinfo_t* req, uv_getaddrinfo_cb getaddrinfo_cb, CString node, CString service, addrinfo* hints)
-    {
-        return _virtualTable.uv_getaddrinfo(loop, req, getaddrinfo_cb, node, service, hints);
-    }
+    [DllImport("uv")]
+    public static extern int uv_getaddrinfo(uv_loop_t* loop, uv_getaddrinfo_t* req, uv_getaddrinfo_cb getaddrinfo_cb, CString node, CString service, addrinfo* hints);
 
     // Function @ uv.h:887:20
-    public static ulong uv_timer_get_due_in(uv_timer_t* handle)
-    {
-        return _virtualTable.uv_timer_get_due_in(handle);
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_timer_get_due_in(uv_timer_t* handle);
 
     // Function @ uv.h:886:20
-    public static ulong uv_timer_get_repeat(uv_timer_t* handle)
-    {
-        return _virtualTable.uv_timer_get_repeat(handle);
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_timer_get_repeat(uv_timer_t* handle);
 
     // Function @ uv.h:885:16
-    public static void uv_timer_set_repeat(uv_timer_t* handle, ulong repeat)
-    {
-        _virtualTable.uv_timer_set_repeat(handle, repeat);
-    }
+    [DllImport("uv")]
+    public static extern void uv_timer_set_repeat(uv_timer_t* handle, ulong repeat);
 
     // Function @ uv.h:884:15
-    public static int uv_timer_again(uv_timer_t* handle)
-    {
-        return _virtualTable.uv_timer_again(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_timer_again(uv_timer_t* handle);
 
     // Function @ uv.h:883:15
-    public static int uv_timer_stop(uv_timer_t* handle)
-    {
-        return _virtualTable.uv_timer_stop(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_timer_stop(uv_timer_t* handle);
 
     // Function @ uv.h:879:15
-    public static int uv_timer_start(uv_timer_t* handle, uv_timer_cb cb, ulong timeout, ulong repeat)
-    {
-        return _virtualTable.uv_timer_start(handle, cb, timeout, repeat);
-    }
+    [DllImport("uv")]
+    public static extern int uv_timer_start(uv_timer_t* handle, uv_timer_cb cb, ulong timeout, ulong repeat);
 
     // Function @ uv.h:878:15
-    public static int uv_timer_init(uv_loop_t* param, uv_timer_t* handle)
-    {
-        return _virtualTable.uv_timer_init(param, handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_timer_init(uv_loop_t* param, uv_timer_t* handle);
 
     // Function @ uv.h:865:15
-    public static int uv_async_send(uv_async_t* async)
-    {
-        return _virtualTable.uv_async_send(async);
-    }
+    [DllImport("uv")]
+    public static extern int uv_async_send(uv_async_t* async);
 
     // Function @ uv.h:862:15
-    public static int uv_async_init(uv_loop_t* param, uv_async_t* async, uv_async_cb async_cb)
-    {
-        return _virtualTable.uv_async_init(param, async, async_cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_async_init(uv_loop_t* param, uv_async_t* async, uv_async_cb async_cb);
 
     // Function @ uv.h:854:15
-    public static int uv_idle_stop(uv_idle_t* idle)
-    {
-        return _virtualTable.uv_idle_stop(idle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_idle_stop(uv_idle_t* idle);
 
     // Function @ uv.h:853:15
-    public static int uv_idle_start(uv_idle_t* idle, uv_idle_cb cb)
-    {
-        return _virtualTable.uv_idle_start(idle, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_idle_start(uv_idle_t* idle, uv_idle_cb cb);
 
     // Function @ uv.h:852:15
-    public static int uv_idle_init(uv_loop_t* param, uv_idle_t* idle)
-    {
-        return _virtualTable.uv_idle_init(param, idle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_idle_init(uv_loop_t* param, uv_idle_t* idle);
 
     // Function @ uv.h:844:15
-    public static int uv_check_stop(uv_check_t* check)
-    {
-        return _virtualTable.uv_check_stop(check);
-    }
+    [DllImport("uv")]
+    public static extern int uv_check_stop(uv_check_t* check);
 
     // Function @ uv.h:843:15
-    public static int uv_check_start(uv_check_t* check, uv_check_cb cb)
-    {
-        return _virtualTable.uv_check_start(check, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_check_start(uv_check_t* check, uv_check_cb cb);
 
     // Function @ uv.h:842:15
-    public static int uv_check_init(uv_loop_t* param, uv_check_t* check)
-    {
-        return _virtualTable.uv_check_init(param, check);
-    }
+    [DllImport("uv")]
+    public static extern int uv_check_init(uv_loop_t* param, uv_check_t* check);
 
     // Function @ uv.h:834:15
-    public static int uv_prepare_stop(uv_prepare_t* prepare)
-    {
-        return _virtualTable.uv_prepare_stop(prepare);
-    }
+    [DllImport("uv")]
+    public static extern int uv_prepare_stop(uv_prepare_t* prepare);
 
     // Function @ uv.h:833:15
-    public static int uv_prepare_start(uv_prepare_t* prepare, uv_prepare_cb cb)
-    {
-        return _virtualTable.uv_prepare_start(prepare, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_prepare_start(uv_prepare_t* prepare, uv_prepare_cb cb);
 
     // Function @ uv.h:832:15
-    public static int uv_prepare_init(uv_loop_t* param, uv_prepare_t* prepare)
-    {
-        return _virtualTable.uv_prepare_init(param, prepare);
-    }
+    [DllImport("uv")]
+    public static extern int uv_prepare_init(uv_loop_t* param, uv_prepare_t* prepare);
 
     // Function @ uv.h:824:15
-    public static int uv_poll_stop(uv_poll_t* handle)
-    {
-        return _virtualTable.uv_poll_stop(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_poll_stop(uv_poll_t* handle);
 
     // Function @ uv.h:823:15
-    public static int uv_poll_start(uv_poll_t* handle, int events, uv_poll_cb cb)
-    {
-        return _virtualTable.uv_poll_start(handle, events, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_poll_start(uv_poll_t* handle, int events, uv_poll_cb cb);
 
     // Function @ uv.h:820:15
-    public static int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle, uv_os_sock_t socket)
-    {
-        return _virtualTable.uv_poll_init_socket(loop, handle, socket);
-    }
+    [DllImport("uv")]
+    public static extern int uv_poll_init_socket(uv_loop_t* loop, uv_poll_t* handle, uv_os_sock_t socket);
 
     // Function @ uv.h:819:15
-    public static int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd)
-    {
-        return _virtualTable.uv_poll_init(loop, handle, fd);
-    }
+    [DllImport("uv")]
+    public static extern int uv_poll_init(uv_loop_t* loop, uv_poll_t* handle, int fd);
 
     // Function @ uv.h:803:15
-    public static int uv_pipe_chmod(uv_pipe_t* handle, int flags)
-    {
-        return _virtualTable.uv_pipe_chmod(handle, flags);
-    }
+    [DllImport("uv")]
+    public static extern int uv_pipe_chmod(uv_pipe_t* handle, int flags);
 
     // Function @ uv.h:802:26
-    public static uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle)
-    {
-        return _virtualTable.uv_pipe_pending_type(handle);
-    }
+    [DllImport("uv")]
+    public static extern uv_handle_type uv_pipe_pending_type(uv_pipe_t* handle);
 
     // Function @ uv.h:801:15
-    public static int uv_pipe_pending_count(uv_pipe_t* handle)
-    {
-        return _virtualTable.uv_pipe_pending_count(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_pipe_pending_count(uv_pipe_t* handle);
 
     // Function @ uv.h:800:16
-    public static void uv_pipe_pending_instances(uv_pipe_t* handle, int count)
-    {
-        _virtualTable.uv_pipe_pending_instances(handle, count);
-    }
+    [DllImport("uv")]
+    public static extern void uv_pipe_pending_instances(uv_pipe_t* handle, int count);
 
     // Function @ uv.h:797:15
-    public static int uv_pipe_getpeername(uv_pipe_t* handle, CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_pipe_getpeername(handle, buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_pipe_getpeername(uv_pipe_t* handle, CString buffer, ulong* size);
 
     // Function @ uv.h:794:15
-    public static int uv_pipe_getsockname(uv_pipe_t* handle, CString buffer, ulong* size)
-    {
-        return _virtualTable.uv_pipe_getsockname(handle, buffer, size);
-    }
+    [DllImport("uv")]
+    public static extern int uv_pipe_getsockname(uv_pipe_t* handle, CString buffer, ulong* size);
 
     // Function @ uv.h:790:16
-    public static void uv_pipe_connect(uv_connect_t* req, uv_pipe_t* handle, CString name, uv_connect_cb cb)
-    {
-        _virtualTable.uv_pipe_connect(req, handle, name, cb);
-    }
+    [DllImport("uv")]
+    public static extern void uv_pipe_connect(uv_connect_t* req, uv_pipe_t* handle, CString name, uv_connect_cb cb);
 
     // Function @ uv.h:789:15
-    public static int uv_pipe_bind(uv_pipe_t* handle, CString name)
-    {
-        return _virtualTable.uv_pipe_bind(handle, name);
-    }
+    [DllImport("uv")]
+    public static extern int uv_pipe_bind(uv_pipe_t* handle, CString name);
 
     // Function @ uv.h:788:15
-    public static int uv_pipe_open(uv_pipe_t* param, uv_file file)
-    {
-        return _virtualTable.uv_pipe_open(param, file);
-    }
+    [DllImport("uv")]
+    public static extern int uv_pipe_open(uv_pipe_t* param, uv_file file);
 
     // Function @ uv.h:787:15
-    public static int uv_pipe_init(uv_loop_t* param, uv_pipe_t* handle, int ipc)
-    {
-        return _virtualTable.uv_pipe_init(param, handle, ipc);
-    }
+    [DllImport("uv")]
+    public static extern int uv_pipe_init(uv_loop_t* param, uv_pipe_t* handle, int ipc);
 
     // Function @ uv.h:772:26
-    public static uv_handle_type uv_guess_handle(uv_file file)
-    {
-        return _virtualTable.uv_guess_handle(file);
-    }
+    [DllImport("uv")]
+    public static extern uv_handle_type uv_guess_handle(uv_file file);
 
     // Function @ uv.h:760:15
-    public static int uv_tty_get_vterm_state(uv_tty_vtermstate_t* state)
-    {
-        return _virtualTable.uv_tty_get_vterm_state(state);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tty_get_vterm_state(uv_tty_vtermstate_t* state);
 
     // Function @ uv.h:759:16
-    public static void uv_tty_set_vterm_state(uv_tty_vtermstate_t state)
-    {
-        _virtualTable.uv_tty_set_vterm_state(state);
-    }
+    [DllImport("uv")]
+    public static extern void uv_tty_set_vterm_state(uv_tty_vtermstate_t state);
 
     // Function @ uv.h:758:15
-    public static int uv_tty_get_winsize(uv_tty_t* param, long* width, long* height)
-    {
-        return _virtualTable.uv_tty_get_winsize(param, width, height);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tty_get_winsize(uv_tty_t* param, long* width, long* height);
 
     // Function @ uv.h:757:15
-    public static int uv_tty_reset_mode()
-    {
-        return _virtualTable.uv_tty_reset_mode();
-    }
+    [DllImport("uv")]
+    public static extern int uv_tty_reset_mode();
 
     // Function @ uv.h:756:15
-    public static int uv_tty_set_mode(uv_tty_t* param, uv_tty_mode_t mode)
-    {
-        return _virtualTable.uv_tty_set_mode(param, mode);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tty_set_mode(uv_tty_t* param, uv_tty_mode_t mode);
 
     // Function @ uv.h:755:15
-    public static int uv_tty_init(uv_loop_t* param, uv_tty_t* param2, uv_file fd, int readable)
-    {
-        return _virtualTable.uv_tty_init(param, param2, fd, readable);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tty_init(uv_loop_t* param, uv_tty_t* param2, uv_file fd, int readable);
 
     // Function @ uv.h:719:18
-    public static ulong uv_udp_get_send_queue_count(uv_udp_t* handle)
-    {
-        return _virtualTable.uv_udp_get_send_queue_count(handle);
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_udp_get_send_queue_count(uv_udp_t* handle);
 
     // Function @ uv.h:718:18
-    public static ulong uv_udp_get_send_queue_size(uv_udp_t* handle)
-    {
-        return _virtualTable.uv_udp_get_send_queue_size(handle);
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_udp_get_send_queue_size(uv_udp_t* handle);
 
     // Function @ uv.h:717:15
-    public static int uv_udp_recv_stop(uv_udp_t* handle)
-    {
-        return _virtualTable.uv_udp_recv_stop(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_recv_stop(uv_udp_t* handle);
 
     // Function @ uv.h:716:15
-    public static int uv_udp_using_recvmmsg(uv_udp_t* handle)
-    {
-        return _virtualTable.uv_udp_using_recvmmsg(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_using_recvmmsg(uv_udp_t* handle);
 
     // Function @ uv.h:713:15
-    public static int uv_udp_recv_start(uv_udp_t* handle, uv_alloc_cb alloc_cb, uv_udp_recv_cb recv_cb)
-    {
-        return _virtualTable.uv_udp_recv_start(handle, alloc_cb, recv_cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_recv_start(uv_udp_t* handle, uv_alloc_cb alloc_cb, uv_udp_recv_cb recv_cb);
 
     // Function @ uv.h:709:15
-    public static int uv_udp_try_send(uv_udp_t* handle, uv_buf_t* bufs, uint nbufs, sockaddr* addr)
-    {
-        return _virtualTable.uv_udp_try_send(handle, bufs, nbufs, addr);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_try_send(uv_udp_t* handle, uv_buf_t* bufs, uint nbufs, sockaddr* addr);
 
     // Function @ uv.h:703:15
-    public static int uv_udp_send(uv_udp_send_t* req, uv_udp_t* handle, uv_buf_t* bufs, uint nbufs, sockaddr* addr, uv_udp_send_cb send_cb)
-    {
-        return _virtualTable.uv_udp_send(req, handle, bufs, nbufs, addr, send_cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_send(uv_udp_send_t* req, uv_udp_t* handle, uv_buf_t* bufs, uint nbufs, sockaddr* addr, uv_udp_send_cb send_cb);
 
     // Function @ uv.h:702:15
-    public static int uv_udp_set_ttl(uv_udp_t* handle, int ttl)
-    {
-        return _virtualTable.uv_udp_set_ttl(handle, ttl);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_set_ttl(uv_udp_t* handle, int ttl);
 
     // Function @ uv.h:701:15
-    public static int uv_udp_set_broadcast(uv_udp_t* handle, int on)
-    {
-        return _virtualTable.uv_udp_set_broadcast(handle, on);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_set_broadcast(uv_udp_t* handle, int on);
 
     // Function @ uv.h:699:15
-    public static int uv_udp_set_multicast_interface(uv_udp_t* handle, CString interface_addr)
-    {
-        return _virtualTable.uv_udp_set_multicast_interface(handle, interface_addr);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_set_multicast_interface(uv_udp_t* handle, CString interface_addr);
 
     // Function @ uv.h:698:15
-    public static int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl)
-    {
-        return _virtualTable.uv_udp_set_multicast_ttl(handle, ttl);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_set_multicast_ttl(uv_udp_t* handle, int ttl);
 
     // Function @ uv.h:697:15
-    public static int uv_udp_set_multicast_loop(uv_udp_t* handle, int on)
-    {
-        return _virtualTable.uv_udp_set_multicast_loop(handle, on);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_set_multicast_loop(uv_udp_t* handle, int on);
 
     // Function @ uv.h:692:15
-    public static int uv_udp_set_source_membership(uv_udp_t* handle, CString multicast_addr, CString interface_addr, CString source_addr, uv_membership membership)
-    {
-        return _virtualTable.uv_udp_set_source_membership(handle, multicast_addr, interface_addr, source_addr, membership);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_set_source_membership(uv_udp_t* handle, CString multicast_addr, CString interface_addr, CString source_addr, uv_membership membership);
 
     // Function @ uv.h:688:15
-    public static int uv_udp_set_membership(uv_udp_t* handle, CString multicast_addr, CString interface_addr, uv_membership membership)
-    {
-        return _virtualTable.uv_udp_set_membership(handle, multicast_addr, interface_addr, membership);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_set_membership(uv_udp_t* handle, CString multicast_addr, CString interface_addr, uv_membership membership);
 
     // Function @ uv.h:685:15
-    public static int uv_udp_getsockname(uv_udp_t* handle, sockaddr* name, long* namelen)
-    {
-        return _virtualTable.uv_udp_getsockname(handle, name, namelen);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_getsockname(uv_udp_t* handle, sockaddr* name, long* namelen);
 
     // Function @ uv.h:682:15
-    public static int uv_udp_getpeername(uv_udp_t* handle, sockaddr* name, long* namelen)
-    {
-        return _virtualTable.uv_udp_getpeername(handle, name, namelen);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_getpeername(uv_udp_t* handle, sockaddr* name, long* namelen);
 
     // Function @ uv.h:680:15
-    public static int uv_udp_connect(uv_udp_t* handle, sockaddr* addr)
-    {
-        return _virtualTable.uv_udp_connect(handle, addr);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_connect(uv_udp_t* handle, sockaddr* addr);
 
     // Function @ uv.h:677:15
-    public static int uv_udp_bind(uv_udp_t* handle, sockaddr* addr, uint flags)
-    {
-        return _virtualTable.uv_udp_bind(handle, addr, flags);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_bind(uv_udp_t* handle, sockaddr* addr, uint flags);
 
     // Function @ uv.h:676:15
-    public static int uv_udp_open(uv_udp_t* handle, uv_os_sock_t sock)
-    {
-        return _virtualTable.uv_udp_open(handle, sock);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_open(uv_udp_t* handle, uv_os_sock_t sock);
 
     // Function @ uv.h:675:15
-    public static int uv_udp_init_ex(uv_loop_t* param, uv_udp_t* handle, uint flags)
-    {
-        return _virtualTable.uv_udp_init_ex(param, handle, flags);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_init_ex(uv_loop_t* param, uv_udp_t* handle, uint flags);
 
     // Function @ uv.h:674:15
-    public static int uv_udp_init(uv_loop_t* param, uv_udp_t* handle)
-    {
-        return _virtualTable.uv_udp_init(param, handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_udp_init(uv_loop_t* param, uv_udp_t* handle);
 
     // Function @ uv.h:583:15
-    public static int uv_tcp_connect(uv_connect_t* req, uv_tcp_t* handle, sockaddr* addr, uv_connect_cb cb)
-    {
-        return _virtualTable.uv_tcp_connect(req, handle, addr, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_connect(uv_connect_t* req, uv_tcp_t* handle, sockaddr* addr, uv_connect_cb cb);
 
     // Function @ uv.h:582:15
-    public static int uv_tcp_close_reset(uv_tcp_t* handle, uv_close_cb close_cb)
-    {
-        return _virtualTable.uv_tcp_close_reset(handle, close_cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_close_reset(uv_tcp_t* handle, uv_close_cb close_cb);
 
     // Function @ uv.h:579:15
-    public static int uv_tcp_getpeername(uv_tcp_t* handle, sockaddr* name, long* namelen)
-    {
-        return _virtualTable.uv_tcp_getpeername(handle, name, namelen);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_getpeername(uv_tcp_t* handle, sockaddr* name, long* namelen);
 
     // Function @ uv.h:576:15
-    public static int uv_tcp_getsockname(uv_tcp_t* handle, sockaddr* name, long* namelen)
-    {
-        return _virtualTable.uv_tcp_getsockname(handle, name, namelen);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_getsockname(uv_tcp_t* handle, sockaddr* name, long* namelen);
 
     // Function @ uv.h:573:15
-    public static int uv_tcp_bind(uv_tcp_t* handle, sockaddr* addr, uint flags)
-    {
-        return _virtualTable.uv_tcp_bind(handle, addr, flags);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_bind(uv_tcp_t* handle, sockaddr* addr, uint flags);
 
     // Function @ uv.h:566:15
-    public static int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable)
-    {
-        return _virtualTable.uv_tcp_simultaneous_accepts(handle, enable);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_simultaneous_accepts(uv_tcp_t* handle, int enable);
 
     // Function @ uv.h:563:15
-    public static int uv_tcp_keepalive(uv_tcp_t* handle, int enable, uint delay)
-    {
-        return _virtualTable.uv_tcp_keepalive(handle, enable, delay);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_keepalive(uv_tcp_t* handle, int enable, uint delay);
 
     // Function @ uv.h:562:15
-    public static int uv_tcp_nodelay(uv_tcp_t* handle, int enable)
-    {
-        return _virtualTable.uv_tcp_nodelay(handle, enable);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_nodelay(uv_tcp_t* handle, int enable);
 
     // Function @ uv.h:561:15
-    public static int uv_tcp_open(uv_tcp_t* handle, uv_os_sock_t sock)
-    {
-        return _virtualTable.uv_tcp_open(handle, sock);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_open(uv_tcp_t* handle, uv_os_sock_t sock);
 
     // Function @ uv.h:560:15
-    public static int uv_tcp_init_ex(uv_loop_t* param, uv_tcp_t* handle, uint flags)
-    {
-        return _virtualTable.uv_tcp_init_ex(param, handle, flags);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_init_ex(uv_loop_t* param, uv_tcp_t* handle, uint flags);
 
     // Function @ uv.h:559:15
-    public static int uv_tcp_init(uv_loop_t* param, uv_tcp_t* handle)
-    {
-        return _virtualTable.uv_tcp_init(param, handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_tcp_init(uv_loop_t* param, uv_tcp_t* handle);
 
     // Function @ uv.h:545:15
-    public static int uv_is_closing(uv_handle_t* handle)
-    {
-        return _virtualTable.uv_is_closing(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_is_closing(uv_handle_t* handle);
 
     // Function @ uv.h:543:15
-    public static int uv_stream_set_blocking(uv_stream_t* handle, int blocking)
-    {
-        return _virtualTable.uv_stream_set_blocking(handle, blocking);
-    }
+    [DllImport("uv")]
+    public static extern int uv_stream_set_blocking(uv_stream_t* handle, int blocking);
 
     // Function @ uv.h:541:15
-    public static int uv_is_writable(uv_stream_t* handle)
-    {
-        return _virtualTable.uv_is_writable(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_is_writable(uv_stream_t* handle);
 
     // Function @ uv.h:540:15
-    public static int uv_is_readable(uv_stream_t* handle)
-    {
-        return _virtualTable.uv_is_readable(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_is_readable(uv_stream_t* handle);
 
     // Function @ uv.h:526:15
-    public static int uv_try_write(uv_stream_t* handle, uv_buf_t* bufs, uint nbufs)
-    {
-        return _virtualTable.uv_try_write(handle, bufs, nbufs);
-    }
+    [DllImport("uv")]
+    public static extern int uv_try_write(uv_stream_t* handle, uv_buf_t* bufs, uint nbufs);
 
     // Function @ uv.h:520:15
-    public static int uv_write2(uv_write_t* req, uv_stream_t* handle, uv_buf_t* bufs, uint nbufs, uv_stream_t* send_handle, uv_write_cb cb)
-    {
-        return _virtualTable.uv_write2(req, handle, bufs, nbufs, send_handle, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_write2(uv_write_t* req, uv_stream_t* handle, uv_buf_t* bufs, uint nbufs, uv_stream_t* send_handle, uv_write_cb cb);
 
     // Function @ uv.h:515:15
-    public static int uv_write(uv_write_t* req, uv_stream_t* handle, uv_buf_t* bufs, uint nbufs, uv_write_cb cb)
-    {
-        return _virtualTable.uv_write(req, handle, bufs, nbufs, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_write(uv_write_t* req, uv_stream_t* handle, uv_buf_t* bufs, uint nbufs, uv_write_cb cb);
 
     // Function @ uv.h:513:15
-    public static int uv_read_stop(uv_stream_t* param)
-    {
-        return _virtualTable.uv_read_stop(param);
-    }
+    [DllImport("uv")]
+    public static extern int uv_read_stop(uv_stream_t* param);
 
     // Function @ uv.h:510:15
-    public static int uv_read_start(uv_stream_t* param, uv_alloc_cb alloc_cb, uv_read_cb read_cb)
-    {
-        return _virtualTable.uv_read_start(param, alloc_cb, read_cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_read_start(uv_stream_t* param, uv_alloc_cb alloc_cb, uv_read_cb read_cb);
 
     // Function @ uv.h:508:15
-    public static int uv_accept(uv_stream_t* server, uv_stream_t* client)
-    {
-        return _virtualTable.uv_accept(server, client);
-    }
+    [DllImport("uv")]
+    public static extern int uv_accept(uv_stream_t* server, uv_stream_t* client);
 
     // Function @ uv.h:507:15
-    public static int uv_listen(uv_stream_t* stream, int backlog, uv_connection_cb cb)
-    {
-        return _virtualTable.uv_listen(stream, backlog, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_listen(uv_stream_t* stream, int backlog, uv_connection_cb cb);
 
     // Function @ uv.h:505:18
-    public static ulong uv_stream_get_write_queue_size(uv_stream_t* stream)
-    {
-        return _virtualTable.uv_stream_get_write_queue_size(stream);
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_stream_get_write_queue_size(uv_stream_t* stream);
 
     // Function @ uv.h:479:15
-    public static int uv_socketpair(int type, int protocol, uv_os_sock_t* socket_vector, int flags0, int flags1)
-    {
-        return _virtualTable.uv_socketpair(type, protocol, socket_vector, flags0, flags1);
-    }
+    [DllImport("uv")]
+    public static extern int uv_socketpair(int type, int protocol, uv_os_sock_t* socket_vector, int flags0, int flags1);
 
     // Function @ uv.h:478:15
-    public static int uv_pipe(uv_file* fds, int read_flags, int write_flags)
-    {
-        return _virtualTable.uv_pipe(fds, read_flags, write_flags);
-    }
+    [DllImport("uv")]
+    public static extern int uv_pipe(uv_file* fds, int read_flags, int write_flags);
 
     // Function @ uv.h:476:20
-    public static uv_buf_t uv_buf_init(CString @base, uint len)
-    {
-        return _virtualTable.uv_buf_init(@base, len);
-    }
+    [DllImport("uv")]
+    public static extern uv_buf_t uv_buf_init(CString @base, uint len);
 
     // Function @ uv.h:474:15
-    public static int uv_fileno(uv_handle_t* handle, uv_os_fd_t* fd)
-    {
-        return _virtualTable.uv_fileno(handle, fd);
-    }
+    [DllImport("uv")]
+    public static extern int uv_fileno(uv_handle_t* handle, uv_os_fd_t* fd);
 
     // Function @ uv.h:472:15
-    public static int uv_recv_buffer_size(uv_handle_t* handle, long* value)
-    {
-        return _virtualTable.uv_recv_buffer_size(handle, value);
-    }
+    [DllImport("uv")]
+    public static extern int uv_recv_buffer_size(uv_handle_t* handle, long* value);
 
     // Function @ uv.h:471:15
-    public static int uv_send_buffer_size(uv_handle_t* handle, long* value)
-    {
-        return _virtualTable.uv_send_buffer_size(handle, value);
-    }
+    [DllImport("uv")]
+    public static extern int uv_send_buffer_size(uv_handle_t* handle, long* value);
 
     // Function @ uv.h:469:16
-    public static void uv_close(uv_handle_t* handle, uv_close_cb close_cb)
-    {
-        _virtualTable.uv_close(handle, close_cb);
-    }
+    [DllImport("uv")]
+    public static extern void uv_close(uv_handle_t* handle, uv_close_cb close_cb);
 
     // Function @ uv.h:467:16
-    public static void uv_print_active_handles(uv_loop_t* loop, FILE* stream)
-    {
-        _virtualTable.uv_print_active_handles(loop, stream);
-    }
+    [DllImport("uv")]
+    public static extern void uv_print_active_handles(uv_loop_t* loop, FILE* stream);
 
     // Function @ uv.h:466:16
-    public static void uv_print_all_handles(uv_loop_t* loop, FILE* stream)
-    {
-        _virtualTable.uv_print_all_handles(loop, stream);
-    }
+    [DllImport("uv")]
+    public static extern void uv_print_all_handles(uv_loop_t* loop, FILE* stream);
 
     // Function @ uv.h:463:16
-    public static void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg)
-    {
-        _virtualTable.uv_walk(loop, walk_cb, arg);
-    }
+    [DllImport("uv")]
+    public static extern void uv_walk(uv_loop_t* loop, uv_walk_cb walk_cb, void* arg);
 
     // Function @ uv.h:461:15
-    public static int uv_is_active(uv_handle_t* handle)
-    {
-        return _virtualTable.uv_is_active(handle);
-    }
+    [DllImport("uv")]
+    public static extern int uv_is_active(uv_handle_t* handle);
 
     // Function @ uv.h:459:23
-    public static CString uv_req_type_name(uv_req_type type)
-    {
-        return _virtualTable.uv_req_type_name(type);
-    }
+    [DllImport("uv")]
+    public static extern CString uv_req_type_name(uv_req_type type);
 
     // Function @ uv.h:458:23
-    public static uv_req_type uv_req_get_type(uv_req_t* req)
-    {
-        return _virtualTable.uv_req_get_type(req);
-    }
+    [DllImport("uv")]
+    public static extern uv_req_type uv_req_get_type(uv_req_t* req);
 
     // Function @ uv.h:457:16
-    public static void uv_req_set_data(uv_req_t* req, void* data)
-    {
-        _virtualTable.uv_req_set_data(req, data);
-    }
+    [DllImport("uv")]
+    public static extern void uv_req_set_data(uv_req_t* req, void* data);
 
     // Function @ uv.h:456:17
-    public static void* uv_req_get_data(uv_req_t* req)
-    {
-        return _virtualTable.uv_req_get_data(req);
-    }
+    [DllImport("uv")]
+    public static extern void* uv_req_get_data(uv_req_t* req);
 
     // Function @ uv.h:455:18
-    public static ulong uv_req_size(uv_req_type type)
-    {
-        return _virtualTable.uv_req_size(type);
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_req_size(uv_req_type type);
 
     // Function @ uv.h:453:16
-    public static void uv_handle_set_data(uv_handle_t* handle, void* data)
-    {
-        _virtualTable.uv_handle_set_data(handle, data);
-    }
+    [DllImport("uv")]
+    public static extern void uv_handle_set_data(uv_handle_t* handle, void* data);
 
     // Function @ uv.h:452:22
-    public static uv_loop_t* uv_handle_get_loop(uv_handle_t* handle)
-    {
-        return _virtualTable.uv_handle_get_loop(handle);
-    }
+    [DllImport("uv")]
+    public static extern uv_loop_t* uv_handle_get_loop(uv_handle_t* handle);
 
     // Function @ uv.h:451:17
-    public static void* uv_handle_get_data(uv_handle_t* handle)
-    {
-        return _virtualTable.uv_handle_get_data(handle);
-    }
+    [DllImport("uv")]
+    public static extern void* uv_handle_get_data(uv_handle_t* handle);
 
     // Function @ uv.h:450:23
-    public static CString uv_handle_type_name(uv_handle_type type)
-    {
-        return _virtualTable.uv_handle_type_name(type);
-    }
+    [DllImport("uv")]
+    public static extern CString uv_handle_type_name(uv_handle_type type);
 
     // Function @ uv.h:449:26
-    public static uv_handle_type uv_handle_get_type(uv_handle_t* handle)
-    {
-        return _virtualTable.uv_handle_get_type(handle);
-    }
+    [DllImport("uv")]
+    public static extern uv_handle_type uv_handle_get_type(uv_handle_t* handle);
 
     // Function @ uv.h:448:18
-    public static ulong uv_handle_size(uv_handle_type type)
-    {
-        return _virtualTable.uv_handle_size(type);
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_handle_size(uv_handle_type type);
 
     // Function @ uv.h:416:15
-    public static int uv_shutdown(uv_shutdown_t* req, uv_stream_t* handle, uv_shutdown_cb cb)
-    {
-        return _virtualTable.uv_shutdown(req, handle, cb);
-    }
+    [DllImport("uv")]
+    public static extern int uv_shutdown(uv_shutdown_t* req, uv_stream_t* handle, uv_shutdown_cb cb);
 
     // Function @ uv.h:394:17
-    public static CString uv_err_name_r(int err, CString buf, ulong buflen)
-    {
-        return _virtualTable.uv_err_name_r(err, buf, buflen);
-    }
+    [DllImport("uv")]
+    public static extern CString uv_err_name_r(int err, CString buf, ulong buflen);
 
     // Function @ uv.h:393:23
-    public static CString uv_err_name(int err)
-    {
-        return _virtualTable.uv_err_name(err);
-    }
+    [DllImport("uv")]
+    public static extern CString uv_err_name(int err);
 
     // Function @ uv.h:391:17
-    public static CString uv_strerror_r(int err, CString buf, ulong buflen)
-    {
-        return _virtualTable.uv_strerror_r(err, buf, buflen);
-    }
+    [DllImport("uv")]
+    public static extern CString uv_strerror_r(int err, CString buf, ulong buflen);
 
     // Function @ uv.h:390:23
-    public static CString uv_strerror(int err)
-    {
-        return _virtualTable.uv_strerror(err);
-    }
+    [DllImport("uv")]
+    public static extern CString uv_strerror(int err);
 
     // Function @ uv.h:388:15
-    public static int uv_translate_sys_error(int sys_errno)
-    {
-        return _virtualTable.uv_translate_sys_error(sys_errno);
-    }
+    [DllImport("uv")]
+    public static extern int uv_translate_sys_error(int sys_errno);
 
     // Function @ uv.h:307:15
-    public static int uv_backend_timeout(uv_loop_t* param)
-    {
-        return _virtualTable.uv_backend_timeout(param);
-    }
+    [DllImport("uv")]
+    public static extern int uv_backend_timeout(uv_loop_t* param);
 
     // Function @ uv.h:306:15
-    public static int uv_backend_fd(uv_loop_t* param)
-    {
-        return _virtualTable.uv_backend_fd(param);
-    }
+    [DllImport("uv")]
+    public static extern int uv_backend_fd(uv_loop_t* param);
 
     // Function @ uv.h:304:20
-    public static ulong uv_now(uv_loop_t* param)
-    {
-        return _virtualTable.uv_now(param);
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_now(uv_loop_t* param);
 
     // Function @ uv.h:303:16
-    public static void uv_update_time(uv_loop_t* param)
-    {
-        _virtualTable.uv_update_time(param);
-    }
+    [DllImport("uv")]
+    public static extern void uv_update_time(uv_loop_t* param);
 
     // Function @ uv.h:301:15
-    public static int uv_has_ref(uv_handle_t* param)
-    {
-        return _virtualTable.uv_has_ref(param);
-    }
+    [DllImport("uv")]
+    public static extern int uv_has_ref(uv_handle_t* param);
 
     // Function @ uv.h:300:16
-    public static void uv_unref(uv_handle_t* param)
-    {
-        _virtualTable.uv_unref(param);
-    }
+    [DllImport("uv")]
+    public static extern void uv_unref(uv_handle_t* param);
 
     // Function @ uv.h:299:16
-    public static void uv_ref(uv_handle_t* param)
-    {
-        _virtualTable.uv_ref(param);
-    }
+    [DllImport("uv")]
+    public static extern void uv_ref(uv_handle_t* param);
 
     // Function @ uv.h:297:16
-    public static void uv_stop(uv_loop_t* param)
-    {
-        _virtualTable.uv_stop(param);
-    }
+    [DllImport("uv")]
+    public static extern void uv_stop(uv_loop_t* param);
 
     // Function @ uv.h:296:15
-    public static int uv_run(uv_loop_t* param, uv_run_mode mode)
-    {
-        return _virtualTable.uv_run(param, mode);
-    }
+    [DllImport("uv")]
+    public static extern int uv_run(uv_loop_t* param, uv_run_mode mode);
 
     // Function @ uv.h:294:15
-    public static int uv_loop_fork(uv_loop_t* loop)
-    {
-        return _virtualTable.uv_loop_fork(loop);
-    }
+    [DllImport("uv")]
+    public static extern int uv_loop_fork(uv_loop_t* loop);
 
     // Function @ uv.h:293:15
-    public static int uv_loop_configure(uv_loop_t* loop, uv_loop_option option)
-    {
-        return _virtualTable.uv_loop_configure(loop, option);
-    }
+    [DllImport("uv")]
+    public static extern int uv_loop_configure(uv_loop_t* loop, uv_loop_option option);
 
     // Function @ uv.h:292:15
-    public static int uv_loop_alive(uv_loop_t* loop)
-    {
-        return _virtualTable.uv_loop_alive(loop);
-    }
+    [DllImport("uv")]
+    public static extern int uv_loop_alive(uv_loop_t* loop);
 
     // Function @ uv.h:291:18
-    public static ulong uv_loop_size()
-    {
-        return _virtualTable.uv_loop_size();
-    }
+    [DllImport("uv")]
+    public static extern ulong uv_loop_size();
 
     // Function @ uv.h:290:16
-    public static void uv_loop_delete(uv_loop_t* param)
-    {
-        _virtualTable.uv_loop_delete(param);
-    }
+    [DllImport("uv")]
+    public static extern void uv_loop_delete(uv_loop_t* param);
 
     // Function @ uv.h:284:22
-    public static uv_loop_t* uv_loop_new()
-    {
-        return _virtualTable.uv_loop_new();
-    }
+    [DllImport("uv")]
+    public static extern uv_loop_t* uv_loop_new();
 
     // Function @ uv.h:278:15
-    public static int uv_loop_close(uv_loop_t* loop)
-    {
-        return _virtualTable.uv_loop_close(loop);
-    }
+    [DllImport("uv")]
+    public static extern int uv_loop_close(uv_loop_t* loop);
 
     // Function @ uv.h:277:15
-    public static int uv_loop_init(uv_loop_t* loop)
-    {
-        return _virtualTable.uv_loop_init(loop);
-    }
+    [DllImport("uv")]
+    public static extern int uv_loop_init(uv_loop_t* loop);
 
     // Function @ uv.h:276:22
-    public static uv_loop_t* uv_default_loop()
-    {
-        return _virtualTable.uv_default_loop();
-    }
+    [DllImport("uv")]
+    public static extern uv_loop_t* uv_default_loop();
 
     // Function @ uv.h:271:15
-    public static int uv_replace_allocator(uv_malloc_func malloc_func, uv_realloc_func realloc_func, uv_calloc_func calloc_func, uv_free_func free_func)
-    {
-        return _virtualTable.uv_replace_allocator(malloc_func, realloc_func, calloc_func, free_func);
-    }
+    [DllImport("uv")]
+    public static extern int uv_replace_allocator(uv_malloc_func malloc_func, uv_realloc_func realloc_func, uv_calloc_func calloc_func, uv_free_func free_func);
 
     // Function @ uv.h:269:16
-    public static void uv_library_shutdown()
-    {
-        _virtualTable.uv_library_shutdown();
-    }
+    [DllImport("uv")]
+    public static extern void uv_library_shutdown();
 
     // Function @ uv.h:262:23
-    public static CString uv_version_string()
-    {
-        return _virtualTable.uv_version_string();
-    }
+    [DllImport("uv")]
+    public static extern CString uv_version_string();
 
     // Function @ uv.h:261:24
-    public static uint uv_version()
-    {
-        return _virtualTable.uv_version();
-    }
+    [DllImport("uv")]
+    public static extern uint uv_version();
 
     // FunctionPointer @ uv.h:1759:16
     [StructLayout(LayoutKind.Sequential)]
@@ -1920,7 +1318,7 @@ public static unsafe partial class uv
     [StructLayout(LayoutKind.Sequential)]
     public struct uv_udp_recv_cb
     {
-        public delegate* unmanaged<uv_udp_t*, ssize_t, uv_buf_t*, sockaddr*, uint, void> Pointer;
+        public delegate* unmanaged<uv_udp_t*, long, uv_buf_t*, sockaddr*, uint, void> Pointer;
     }
 
     // FunctionPointer @ uv.h:309:16
@@ -1955,7 +1353,7 @@ public static unsafe partial class uv
     [StructLayout(LayoutKind.Sequential)]
     public struct uv_read_cb
     {
-        public delegate* unmanaged<uv_stream_t*, ssize_t, uv_buf_t*, void> Pointer;
+        public delegate* unmanaged<uv_stream_t*, long, uv_buf_t*, void> Pointer;
     }
 
     // FunctionPointer @ uv.h:318:16
@@ -2029,27 +1427,19 @@ public static unsafe partial class uv
         public int tv_usec;
     }
 
-    // Struct @ win.h:323:3
+    // Struct @ unix.h:221:3
     [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 8)]
     public struct uv_lib_t
     {
         [FieldOffset(0)] // size = 8, padding = 0
-        public HMODULE handle;
+        public void* handle;
 
         [FieldOffset(8)] // size = 8, padding = 0
         public CString errmsg;
     }
 
-    // Struct @ System
-    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
-    public struct HINSTANCE__
-    {
-        [FieldOffset(0)] // size = 4, padding = 0
-        public int unused;
-    }
-
     // Struct @ uv.h:366:3
-    [StructLayout(LayoutKind.Explicit, Size = 128, Pack = 8)]
+    [StructLayout(LayoutKind.Explicit, Size = 160, Pack = 8)]
     public struct uv_stat_t
     {
         [FieldOffset(0)] // size = 8, padding = 0
@@ -2088,28 +1478,28 @@ public static unsafe partial class uv
         [FieldOffset(88)] // size = 8, padding = 0
         public ulong st_gen;
 
-        [FieldOffset(96)] // size = 8, padding = 0
+        [FieldOffset(96)] // size = 16, padding = 0
         public uv_timespec_t st_atim;
 
-        [FieldOffset(104)] // size = 8, padding = 0
+        [FieldOffset(112)] // size = 16, padding = 0
         public uv_timespec_t st_mtim;
 
-        [FieldOffset(112)] // size = 8, padding = 0
+        [FieldOffset(128)] // size = 16, padding = 0
         public uv_timespec_t st_ctim;
 
-        [FieldOffset(120)] // size = 8, padding = 0
+        [FieldOffset(144)] // size = 16, padding = 0
         public uv_timespec_t st_birthtim;
     }
 
     // Struct @ uv.h:346:3
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
+    [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 8)]
     public struct uv_timespec_t
     {
-        [FieldOffset(0)] // size = 4, padding = 0
-        public int tv_sec;
+        [FieldOffset(0)] // size = 8, padding = 0
+        public long tv_sec;
 
-        [FieldOffset(4)] // size = 4, padding = 0
-        public int tv_nsec;
+        [FieldOffset(8)] // size = 8, padding = 0
+        public long tv_nsec;
     }
 
     // Struct @ uv.h:244:28
@@ -2123,15 +1513,15 @@ public static unsafe partial class uv
         public uv_dirent_type_t type;
     }
 
-    // Struct @ win.h:229:3
+    // Struct @ unix.h:126:3
     [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 8)]
     public struct uv_buf_t
     {
-        [FieldOffset(0)] // size = 4, padding = 4
-        public ULONG len;
+        [FieldOffset(0)] // size = 8, padding = 0
+        public CString @base;
 
         [FieldOffset(8)] // size = 8, padding = 0
-        public CString @base;
+        public ulong len;
     }
 
     // Struct @ uv.h:246:29
@@ -2304,87 +1694,87 @@ public static unsafe partial class uv
     }
 
     // Struct @ uv.h:245:28
-    [StructLayout(LayoutKind.Explicit, Size = 32, Pack = 8)]
+    [StructLayout(LayoutKind.Explicit, Size = 40, Pack = 8)]
     public struct uv_passwd_t
     {
         [FieldOffset(0)] // size = 8, padding = 0
         public CString username;
 
-        [FieldOffset(8)] // size = 4, padding = 0
-        public int uid;
-
-        [FieldOffset(12)] // size = 4, padding = 0
-        public int gid;
+        [FieldOffset(8)] // size = 8, padding = 0
+        public long uid;
 
         [FieldOffset(16)] // size = 8, padding = 0
-        public CString shell;
+        public long gid;
 
         [FieldOffset(24)] // size = 8, padding = 0
+        public CString shell;
+
+        [FieldOffset(32)] // size = 8, padding = 0
         public CString homedir;
     }
 
     // Struct @ uv.h:1206:3
-    [StructLayout(LayoutKind.Explicit, Size = 128, Pack = 8)]
+    [StructLayout(LayoutKind.Explicit, Size = 144, Pack = 8)]
     public struct uv_rusage_t
     {
-        [FieldOffset(0)] // size = 8, padding = 0
+        [FieldOffset(0)] // size = 16, padding = 0
         public uv_timeval_t ru_utime;
 
-        [FieldOffset(8)] // size = 8, padding = 0
+        [FieldOffset(16)] // size = 16, padding = 0
         public uv_timeval_t ru_stime;
 
-        [FieldOffset(16)] // size = 8, padding = 0
+        [FieldOffset(32)] // size = 8, padding = 0
         public ulong ru_maxrss;
 
-        [FieldOffset(24)] // size = 8, padding = 0
+        [FieldOffset(40)] // size = 8, padding = 0
         public ulong ru_ixrss;
 
-        [FieldOffset(32)] // size = 8, padding = 0
+        [FieldOffset(48)] // size = 8, padding = 0
         public ulong ru_idrss;
 
-        [FieldOffset(40)] // size = 8, padding = 0
+        [FieldOffset(56)] // size = 8, padding = 0
         public ulong ru_isrss;
 
-        [FieldOffset(48)] // size = 8, padding = 0
+        [FieldOffset(64)] // size = 8, padding = 0
         public ulong ru_minflt;
 
-        [FieldOffset(56)] // size = 8, padding = 0
+        [FieldOffset(72)] // size = 8, padding = 0
         public ulong ru_majflt;
 
-        [FieldOffset(64)] // size = 8, padding = 0
+        [FieldOffset(80)] // size = 8, padding = 0
         public ulong ru_nswap;
 
-        [FieldOffset(72)] // size = 8, padding = 0
+        [FieldOffset(88)] // size = 8, padding = 0
         public ulong ru_inblock;
 
-        [FieldOffset(80)] // size = 8, padding = 0
+        [FieldOffset(96)] // size = 8, padding = 0
         public ulong ru_oublock;
 
-        [FieldOffset(88)] // size = 8, padding = 0
+        [FieldOffset(104)] // size = 8, padding = 0
         public ulong ru_msgsnd;
 
-        [FieldOffset(96)] // size = 8, padding = 0
+        [FieldOffset(112)] // size = 8, padding = 0
         public ulong ru_msgrcv;
 
-        [FieldOffset(104)] // size = 8, padding = 0
+        [FieldOffset(120)] // size = 8, padding = 0
         public ulong ru_nsignals;
 
-        [FieldOffset(112)] // size = 8, padding = 0
+        [FieldOffset(128)] // size = 8, padding = 0
         public ulong ru_nvcsw;
 
-        [FieldOffset(120)] // size = 8, padding = 0
+        [FieldOffset(136)] // size = 8, padding = 0
         public ulong ru_nivcsw;
     }
 
     // Struct @ uv.h:1182:3
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
+    [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 8)]
     public struct uv_timeval_t
     {
-        [FieldOffset(0)] // size = 4, padding = 0
-        public int tv_sec;
+        [FieldOffset(0)] // size = 8, padding = 0
+        public long tv_sec;
 
-        [FieldOffset(4)] // size = 4, padding = 0
-        public int tv_usec;
+        [FieldOffset(8)] // size = 8, padding = 0
+        public long tv_usec;
     }
 
     // Struct @ uv.h:1010:3
@@ -2415,10 +1805,10 @@ public static unsafe partial class uv
         [FieldOffset(48)] // size = 8, padding = 0
         public uv_stdio_container_t* stdio;
 
-        [FieldOffset(56)] // size = 1, padding = 0
+        [FieldOffset(56)] // size = 4, padding = 0
         public uv_uid_t uid;
 
-        [FieldOffset(57)] // size = 1, padding = 6
+        [FieldOffset(60)] // size = 4, padding = 0
         public uv_gid_t gid;
     }
 
@@ -2450,43 +1840,43 @@ public static unsafe partial class uv
     {
     }
 
-    // OpaqueType @ win.h:286:3
+    // OpaqueType @ unix.h:141:23
     [StructLayout(LayoutKind.Sequential)]
     public struct uv_key_t
     {
     }
 
-    // OpaqueType @ win.h:293:3
+    // OpaqueType @ unix.h:135:24
     [StructLayout(LayoutKind.Sequential)]
     public struct uv_once_t
     {
     }
 
-    // OpaqueType @ win.h:240:26
+    // OpaqueType @ unix.h:137:25
     [StructLayout(LayoutKind.Sequential)]
     public struct uv_mutex_t
     {
     }
 
-    // OpaqueType @ win.h:257:3
+    // OpaqueType @ unix.h:140:24
     [StructLayout(LayoutKind.Sequential)]
     public struct uv_cond_t
     {
     }
 
-    // OpaqueType @ win.h:282:3
+    // OpaqueType @ unix.h:162:3
     [StructLayout(LayoutKind.Sequential)]
     public struct uv_barrier_t
     {
     }
 
-    // OpaqueType @ win.h:238:16
+    // OpaqueType @ unix.h:139:27
     [StructLayout(LayoutKind.Sequential)]
     public struct uv_sem_t
     {
     }
 
-    // OpaqueType @ win.h:274:3
+    // OpaqueType @ unix.h:138:26
     [StructLayout(LayoutKind.Sequential)]
     public struct uv_rwlock_t
     {
@@ -2654,73 +2044,40 @@ public static unsafe partial class uv
     {
     }
 
-    // Typedef @ win.h:236:16
+    // Typedef @ unix.h:136:19
     [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
     public struct uv_thread_t
     {
         [FieldOffset(0)] // size = 8, padding = 0
-        public HANDLE Data;
+        public pthread_t Data;
 
-        public static implicit operator HANDLE(uv_thread_t data) => data.Data;
-        public static implicit operator uv_thread_t(HANDLE data) => new() { Data = data };
+        public static implicit operator pthread_t(uv_thread_t data) => data.Data;
+        public static implicit operator uv_thread_t(pthread_t data) => new() { Data = data };
     }
 
-    // Typedef @ System
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
-    public struct HANDLE
-    {
-        [FieldOffset(0)] // size = 8, padding = 0
-        public void* Data;
-
-        public static implicit operator void*(HANDLE data) => data.Data;
-        public static implicit operator HANDLE(void* data) => new() { Data = data };
-    }
-
-    // Typedef @ System
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
-    public struct HMODULE
-    {
-        [FieldOffset(0)] // size = 8, padding = 0
-        public HINSTANCE Data;
-
-        public static implicit operator HINSTANCE(HMODULE data) => data.Data;
-        public static implicit operator HMODULE(HINSTANCE data) => new() { Data = data };
-    }
-
-    // Typedef @ System
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
-    public struct HINSTANCE
-    {
-        [FieldOffset(0)] // size = 8, padding = 0
-        public HINSTANCE__* Data;
-
-        public static implicit operator HINSTANCE__*(HINSTANCE data) => data.Data;
-        public static implicit operator HINSTANCE(HINSTANCE__* data) => new() { Data = data };
-    }
-
-    // Typedef @ win.h:297:23
-    [StructLayout(LayoutKind.Explicit, Size = 1, Pack = 1)]
+    // Typedef @ unix.h:168:15
+    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
     public struct uv_gid_t
     {
-        [FieldOffset(0)] // size = 1, padding = 0
-        public byte Data;
+        [FieldOffset(0)] // size = 4, padding = 0
+        public gid_t Data;
 
-        public static implicit operator byte(uv_gid_t data) => data.Data;
-        public static implicit operator uv_gid_t(byte data) => new() { Data = data };
+        public static implicit operator gid_t(uv_gid_t data) => data.Data;
+        public static implicit operator uv_gid_t(gid_t data) => new() { Data = data };
     }
 
-    // Typedef @ win.h:296:23
-    [StructLayout(LayoutKind.Explicit, Size = 1, Pack = 1)]
+    // Typedef @ unix.h:169:15
+    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
     public struct uv_uid_t
     {
-        [FieldOffset(0)] // size = 1, padding = 0
-        public byte Data;
+        [FieldOffset(0)] // size = 4, padding = 0
+        public uid_t Data;
 
-        public static implicit operator byte(uv_uid_t data) => data.Data;
-        public static implicit operator uv_uid_t(byte data) => new() { Data = data };
+        public static implicit operator uid_t(uv_uid_t data) => data.Data;
+        public static implicit operator uv_uid_t(uid_t data) => new() { Data = data };
     }
 
-    // Typedef @ win.h:231:13
+    // Typedef @ unix.h:128:13
     [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
     public struct uv_file
     {
@@ -2731,105 +2088,50 @@ public static unsafe partial class uv
         public static implicit operator uv_file(int data) => new() { Data = data };
     }
 
-    // Typedef @ System
-    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
-    public struct ULONG
-    {
-        [FieldOffset(0)] // size = 4, padding = 0
-        public DWORD Data;
-
-        public static implicit operator DWORD(ULONG data) => data.Data;
-        public static implicit operator ULONG(DWORD data) => new() { Data = data };
-    }
-
-    // Typedef @ System
-    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
-    public struct DWORD
-    {
-        [FieldOffset(0)] // size = 4, padding = 0
-        public uint Data;
-
-        public static implicit operator uint(DWORD data) => data.Data;
-        public static implicit operator DWORD(uint data) => new() { Data = data };
-    }
-
-    // Typedef @ win.h:27:18
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
-    public struct ssize_t
-    {
-        [FieldOffset(0)] // size = 8, padding = 0
-        public IntPtr Data;
-
-        public static implicit operator IntPtr(ssize_t data) => data.Data;
-        public static implicit operator ssize_t(IntPtr data) => new() { Data = data };
-    }
-
-    // Typedef @ win.h:234:13
+    // Typedef @ unix.h:131:15
     [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
     public struct uv_pid_t
     {
         [FieldOffset(0)] // size = 4, padding = 0
-        public int Data;
+        public pid_t Data;
 
-        public static implicit operator int(uv_pid_t data) => data.Data;
-        public static implicit operator uv_pid_t(int data) => new() { Data = data };
+        public static implicit operator pid_t(uv_pid_t data) => data.Data;
+        public static implicit operator uv_pid_t(pid_t data) => new() { Data = data };
     }
 
-    // Typedef @ win.h:233:16
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
+    // Typedef @ unix.h:130:13
+    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
     public struct uv_os_fd_t
     {
-        [FieldOffset(0)] // size = 8, padding = 0
-        public HANDLE Data;
+        [FieldOffset(0)] // size = 4, padding = 0
+        public int Data;
 
-        public static implicit operator HANDLE(uv_os_fd_t data) => data.Data;
-        public static implicit operator uv_os_fd_t(HANDLE data) => new() { Data = data };
+        public static implicit operator int(uv_os_fd_t data) => data.Data;
+        public static implicit operator uv_os_fd_t(int data) => new() { Data = data };
     }
 
-    // Typedef @ win.h:232:16
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
+    // Typedef @ unix.h:129:13
+    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
     public struct uv_os_sock_t
     {
-        [FieldOffset(0)] // size = 8, padding = 0
-        public SOCKET Data;
+        [FieldOffset(0)] // size = 4, padding = 0
+        public int Data;
 
-        public static implicit operator SOCKET(uv_os_sock_t data) => data.Data;
-        public static implicit operator uv_os_sock_t(SOCKET data) => new() { Data = data };
-    }
-
-    // Typedef @ System
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
-    public struct SOCKET
-    {
-        [FieldOffset(0)] // size = 8, padding = 0
-        public UINT_PTR Data;
-
-        public static implicit operator UINT_PTR(SOCKET data) => data.Data;
-        public static implicit operator SOCKET(UINT_PTR data) => new() { Data = data };
-    }
-
-    // Typedef @ System
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
-    public struct UINT_PTR
-    {
-        [FieldOffset(0)] // size = 8, padding = 0
-        public ulong Data;
-
-        public static implicit operator ulong(UINT_PTR data) => data.Data;
-        public static implicit operator UINT_PTR(ulong data) => new() { Data = data };
+        public static implicit operator int(uv_os_sock_t data) => data.Data;
+        public static implicit operator uv_os_sock_t(int data) => new() { Data = data };
     }
 
     // Enum @ uv.h:1164:3
-    public enum uv_dirent_type_t : int
+    public enum uv_dirent_type_t : uint
     {
-        UV_DIRENT_UNKNOWN = 0,
-        UV_DIRENT_FILE = 1,
-        UV_DIRENT_DIR = 2,
-        UV_DIRENT_LINK = 3,
-        UV_DIRENT_FIFO = 4,
-        UV_DIRENT_SOCKET = 5,
-        UV_DIRENT_CHAR = 6,
-        UV_DIRENT_BLOCK = 7
+        UV_DIRENT_UNKNOWN = 0U,
+        UV_DIRENT_FILE = 1U,
+        UV_DIRENT_DIR = 2U,
+        UV_DIRENT_LINK = 3U,
+        UV_DIRENT_FIFO = 4U,
+        UV_DIRENT_SOCKET = 5U,
+        UV_DIRENT_CHAR = 6U,
+        UV_DIRENT_BLOCK = 7U
     }
 
     // Enum @ uv.h:1312:3
@@ -2876,1018 +2178,93 @@ public static unsafe partial class uv
     }
 
     // Enum @ uv.h:956:3
-    public enum uv_stdio_flags : int
+    public enum uv_stdio_flags : uint
     {
-        UV_IGNORE = 0,
-        UV_CREATE_PIPE = 1,
-        UV_INHERIT_FD = 2,
-        UV_INHERIT_STREAM = 4,
-        UV_READABLE_PIPE = 16,
-        UV_WRITABLE_PIPE = 32,
-        UV_NONBLOCK_PIPE = 64,
-        UV_OVERLAPPED_PIPE = 64
+        UV_IGNORE = 0U,
+        UV_CREATE_PIPE = 1U,
+        UV_INHERIT_FD = 2U,
+        UV_INHERIT_STREAM = 4U,
+        UV_READABLE_PIPE = 16U,
+        UV_WRITABLE_PIPE = 32U,
+        UV_NONBLOCK_PIPE = 64U,
+        UV_OVERLAPPED_PIPE = 64U
     }
 
     // Enum @ uv.h:196:3
-    public enum uv_handle_type : int
+    public enum uv_handle_type : uint
     {
-        UV_UNKNOWN_HANDLE = 0,
-        UV_ASYNC = 1,
-        UV_CHECK = 2,
-        UV_FS_EVENT = 3,
-        UV_FS_POLL = 4,
-        UV_HANDLE = 5,
-        UV_IDLE = 6,
-        UV_NAMED_PIPE = 7,
-        UV_POLL = 8,
-        UV_PREPARE = 9,
-        UV_PROCESS = 10,
-        UV_STREAM = 11,
-        UV_TCP = 12,
-        UV_TIMER = 13,
-        UV_TTY = 14,
-        UV_UDP = 15,
-        UV_SIGNAL = 16,
-        UV_FILE = 17,
-        UV_HANDLE_TYPE_MAX = 18
+        UV_UNKNOWN_HANDLE = 0U,
+        UV_ASYNC = 1U,
+        UV_CHECK = 2U,
+        UV_FS_EVENT = 3U,
+        UV_FS_POLL = 4U,
+        UV_HANDLE = 5U,
+        UV_IDLE = 6U,
+        UV_NAMED_PIPE = 7U,
+        UV_POLL = 8U,
+        UV_PREPARE = 9U,
+        UV_PROCESS = 10U,
+        UV_STREAM = 11U,
+        UV_TCP = 12U,
+        UV_TIMER = 13U,
+        UV_TTY = 14U,
+        UV_UDP = 15U,
+        UV_SIGNAL = 16U,
+        UV_FILE = 17U,
+        UV_HANDLE_TYPE_MAX = 18U
     }
 
     // Enum @ uv.h:752:3
-    public enum uv_tty_vtermstate_t : int
+    public enum uv_tty_vtermstate_t : uint
     {
-        UV_TTY_SUPPORTED = 0,
-        UV_TTY_UNSUPPORTED = 1
+        UV_TTY_SUPPORTED = 0U,
+        UV_TTY_UNSUPPORTED = 1U
     }
 
     // Enum @ uv.h:740:3
-    public enum uv_tty_mode_t : int
+    public enum uv_tty_mode_t : uint
     {
-        UV_TTY_MODE_NORMAL = 0,
-        UV_TTY_MODE_RAW = 1,
-        UV_TTY_MODE_IO = 2
+        UV_TTY_MODE_NORMAL = 0U,
+        UV_TTY_MODE_RAW = 1U,
+        UV_TTY_MODE_IO = 2U
     }
 
     // Enum @ uv.h:385:3
-    public enum uv_membership : int
+    public enum uv_membership : uint
     {
-        UV_LEAVE_GROUP = 0,
-        UV_JOIN_GROUP = 1
+        UV_LEAVE_GROUP = 0U,
+        UV_JOIN_GROUP = 1U
     }
 
     // Enum @ uv.h:205:3
-    public enum uv_req_type : int
+    public enum uv_req_type : uint
     {
-        UV_UNKNOWN_REQ = 0,
-        UV_REQ = 1,
-        UV_CONNECT = 2,
-        UV_WRITE = 3,
-        UV_SHUTDOWN = 4,
-        UV_UDP_SEND = 5,
-        UV_FS = 6,
-        UV_WORK = 7,
-        UV_GETADDRINFO = 8,
-        UV_GETNAMEINFO = 9,
-        UV_RANDOM = 10,
-        UV_ACCEPT = 11,
-        UV_FS_EVENT_REQ = 12,
-        UV_POLL_REQ = 13,
-        UV_PROCESS_EXIT = 14,
-        UV_READ = 15,
-        UV_UDP_RECV = 16,
-        UV_WAKEUP = 17,
-        UV_SIGNAL_REQ = 18,
-        UV_REQ_TYPE_MAX = 19
+        UV_UNKNOWN_REQ = 0U,
+        UV_REQ = 1U,
+        UV_CONNECT = 2U,
+        UV_WRITE = 3U,
+        UV_SHUTDOWN = 4U,
+        UV_UDP_SEND = 5U,
+        UV_FS = 6U,
+        UV_WORK = 7U,
+        UV_GETADDRINFO = 8U,
+        UV_GETNAMEINFO = 9U,
+        UV_RANDOM = 10U,
+        UV_REQ_TYPE_MAX = 11U
     }
 
     // Enum @ uv.h:258:3
-    public enum uv_run_mode : int
+    public enum uv_run_mode : uint
     {
-        UV_RUN_DEFAULT = 0,
-        UV_RUN_ONCE = 1,
-        UV_RUN_NOWAIT = 2
+        UV_RUN_DEFAULT = 0U,
+        UV_RUN_ONCE = 1U,
+        UV_RUN_NOWAIT = 2U
     }
 
     // Enum @ uv.h:252:3
-    public enum uv_loop_option : int
+    public enum uv_loop_option : uint
     {
-        UV_LOOP_BLOCK_SIGNAL = 0,
-        UV_METRICS_IDLE_TIME = 1
+        UV_LOOP_BLOCK_SIGNAL = 0U,
+        UV_METRICS_IDLE_TIME = 1U
     }
-
-    private static void _LoadVirtualTable()
-    {
-        #region "Functions"
-        _virtualTable.uv_loop_set_data = (delegate* unmanaged[Cdecl]<uv_loop_t*, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_set_data");
-        _virtualTable.uv_loop_get_data = (delegate* unmanaged[Cdecl]<uv_loop_t*, void*>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_get_data");
-        _virtualTable.uv_thread_equal = (delegate* unmanaged[Cdecl]<uv_thread_t*, uv_thread_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_thread_equal");
-        _virtualTable.uv_thread_join = (delegate* unmanaged[Cdecl]<uv_thread_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_thread_join");
-        _virtualTable.uv_thread_self = (delegate* unmanaged[Cdecl]<uv_thread_t>)Runtime.LibraryGetExport(_libraryHandle, "uv_thread_self");
-        _virtualTable.uv_thread_create_ex = (delegate* unmanaged[Cdecl]<uv_thread_t*, uv_thread_options_t*, uv_thread_cb, void*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_thread_create_ex");
-        _virtualTable.uv_thread_create = (delegate* unmanaged[Cdecl]<uv_thread_t*, uv_thread_cb, void*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_thread_create");
-        _virtualTable.uv_gettimeofday = (delegate* unmanaged[Cdecl]<uv_timeval64_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_gettimeofday");
-        _virtualTable.uv_key_set = (delegate* unmanaged[Cdecl]<uv_key_t*, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_key_set");
-        _virtualTable.uv_key_get = (delegate* unmanaged[Cdecl]<uv_key_t*, void*>)Runtime.LibraryGetExport(_libraryHandle, "uv_key_get");
-        _virtualTable.uv_key_delete = (delegate* unmanaged[Cdecl]<uv_key_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_key_delete");
-        _virtualTable.uv_key_create = (delegate* unmanaged[Cdecl]<uv_key_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_key_create");
-        _virtualTable.uv_once = (delegate* unmanaged[Cdecl]<uv_once_t*, FnPtr_UV_Void, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_once");
-        _virtualTable.uv_cond_timedwait = (delegate* unmanaged[Cdecl]<uv_cond_t*, uv_mutex_t*, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_cond_timedwait");
-        _virtualTable.uv_cond_wait = (delegate* unmanaged[Cdecl]<uv_cond_t*, uv_mutex_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_cond_wait");
-        _virtualTable.uv_barrier_wait = (delegate* unmanaged[Cdecl]<uv_barrier_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_barrier_wait");
-        _virtualTable.uv_barrier_destroy = (delegate* unmanaged[Cdecl]<uv_barrier_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_barrier_destroy");
-        _virtualTable.uv_barrier_init = (delegate* unmanaged[Cdecl]<uv_barrier_t*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_barrier_init");
-        _virtualTable.uv_cond_broadcast = (delegate* unmanaged[Cdecl]<uv_cond_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_cond_broadcast");
-        _virtualTable.uv_cond_signal = (delegate* unmanaged[Cdecl]<uv_cond_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_cond_signal");
-        _virtualTable.uv_cond_destroy = (delegate* unmanaged[Cdecl]<uv_cond_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_cond_destroy");
-        _virtualTable.uv_cond_init = (delegate* unmanaged[Cdecl]<uv_cond_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_cond_init");
-        _virtualTable.uv_sem_trywait = (delegate* unmanaged[Cdecl]<uv_sem_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_sem_trywait");
-        _virtualTable.uv_sem_wait = (delegate* unmanaged[Cdecl]<uv_sem_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_sem_wait");
-        _virtualTable.uv_sem_post = (delegate* unmanaged[Cdecl]<uv_sem_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_sem_post");
-        _virtualTable.uv_sem_destroy = (delegate* unmanaged[Cdecl]<uv_sem_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_sem_destroy");
-        _virtualTable.uv_sem_init = (delegate* unmanaged[Cdecl]<uv_sem_t*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_sem_init");
-        _virtualTable.uv_rwlock_wrunlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_rwlock_wrunlock");
-        _virtualTable.uv_rwlock_trywrlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_rwlock_trywrlock");
-        _virtualTable.uv_rwlock_wrlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_rwlock_wrlock");
-        _virtualTable.uv_rwlock_rdunlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_rwlock_rdunlock");
-        _virtualTable.uv_rwlock_tryrdlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_rwlock_tryrdlock");
-        _virtualTable.uv_rwlock_rdlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_rwlock_rdlock");
-        _virtualTable.uv_rwlock_destroy = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_rwlock_destroy");
-        _virtualTable.uv_rwlock_init = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_rwlock_init");
-        _virtualTable.uv_mutex_unlock = (delegate* unmanaged[Cdecl]<uv_mutex_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_mutex_unlock");
-        _virtualTable.uv_mutex_trylock = (delegate* unmanaged[Cdecl]<uv_mutex_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_mutex_trylock");
-        _virtualTable.uv_mutex_lock = (delegate* unmanaged[Cdecl]<uv_mutex_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_mutex_lock");
-        _virtualTable.uv_mutex_destroy = (delegate* unmanaged[Cdecl]<uv_mutex_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_mutex_destroy");
-        _virtualTable.uv_mutex_init_recursive = (delegate* unmanaged[Cdecl]<uv_mutex_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_mutex_init_recursive");
-        _virtualTable.uv_mutex_init = (delegate* unmanaged[Cdecl]<uv_mutex_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_mutex_init");
-        _virtualTable.uv_dlerror = (delegate* unmanaged[Cdecl]<uv_lib_t*, CString>)Runtime.LibraryGetExport(_libraryHandle, "uv_dlerror");
-        _virtualTable.uv_dlsym = (delegate* unmanaged[Cdecl]<uv_lib_t*, CString, void**, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_dlsym");
-        _virtualTable.uv_dlclose = (delegate* unmanaged[Cdecl]<uv_lib_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_dlclose");
-        _virtualTable.uv_dlopen = (delegate* unmanaged[Cdecl]<CString, uv_lib_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_dlopen");
-        _virtualTable.uv_disable_stdio_inheritance = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "uv_disable_stdio_inheritance");
-        _virtualTable.uv_sleep = (delegate* unmanaged[Cdecl]<uint, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_sleep");
-        _virtualTable.uv_hrtime = (delegate* unmanaged[Cdecl]<ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_hrtime");
-        _virtualTable.uv_get_constrained_memory = (delegate* unmanaged[Cdecl]<ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_get_constrained_memory");
-        _virtualTable.uv_get_total_memory = (delegate* unmanaged[Cdecl]<ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_get_total_memory");
-        _virtualTable.uv_get_free_memory = (delegate* unmanaged[Cdecl]<ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_get_free_memory");
-        _virtualTable.uv_chdir = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_chdir");
-        _virtualTable.uv_cwd = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_cwd");
-        _virtualTable.uv_exepath = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_exepath");
-        _virtualTable.uv_if_indextoiid = (delegate* unmanaged[Cdecl]<uint, CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_if_indextoiid");
-        _virtualTable.uv_if_indextoname = (delegate* unmanaged[Cdecl]<uint, CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_if_indextoname");
-        _virtualTable.uv_random = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_random_t*, void*, ulong, uint, uv_random_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_random");
-        _virtualTable.uv_inet_pton = (delegate* unmanaged[Cdecl]<int, CString, void*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_inet_pton");
-        _virtualTable.uv_inet_ntop = (delegate* unmanaged[Cdecl]<int, void*, CString, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_inet_ntop");
-        _virtualTable.uv_ip6_name = (delegate* unmanaged[Cdecl]<sockaddr_in6*, CString, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_ip6_name");
-        _virtualTable.uv_ip4_name = (delegate* unmanaged[Cdecl]<sockaddr_in*, CString, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_ip4_name");
-        _virtualTable.uv_ip6_addr = (delegate* unmanaged[Cdecl]<CString, int, sockaddr_in6*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_ip6_addr");
-        _virtualTable.uv_ip4_addr = (delegate* unmanaged[Cdecl]<CString, int, sockaddr_in*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_ip4_addr");
-        _virtualTable.uv_fs_event_getpath = (delegate* unmanaged[Cdecl]<uv_fs_event_t*, CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_event_getpath");
-        _virtualTable.uv_fs_event_stop = (delegate* unmanaged[Cdecl]<uv_fs_event_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_event_stop");
-        _virtualTable.uv_fs_event_start = (delegate* unmanaged[Cdecl]<uv_fs_event_t*, uv_fs_event_cb, CString, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_event_start");
-        _virtualTable.uv_fs_event_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_event_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_event_init");
-        _virtualTable.uv_loadavg = (delegate* unmanaged[Cdecl]<double*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_loadavg");
-        _virtualTable.uv_signal_stop = (delegate* unmanaged[Cdecl]<uv_signal_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_signal_stop");
-        _virtualTable.uv_signal_start_oneshot = (delegate* unmanaged[Cdecl]<uv_signal_t*, uv_signal_cb, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_signal_start_oneshot");
-        _virtualTable.uv_signal_start = (delegate* unmanaged[Cdecl]<uv_signal_t*, uv_signal_cb, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_signal_start");
-        _virtualTable.uv_signal_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_signal_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_signal_init");
-        _virtualTable.uv_fs_poll_getpath = (delegate* unmanaged[Cdecl]<uv_fs_poll_t*, CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_poll_getpath");
-        _virtualTable.uv_fs_poll_stop = (delegate* unmanaged[Cdecl]<uv_fs_poll_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_poll_stop");
-        _virtualTable.uv_fs_poll_start = (delegate* unmanaged[Cdecl]<uv_fs_poll_t*, uv_fs_poll_cb, CString, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_poll_start");
-        _virtualTable.uv_fs_poll_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_poll_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_poll_init");
-        _virtualTable.uv_fs_statfs = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_statfs");
-        _virtualTable.uv_fs_lchown = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_uid_t, uv_gid_t, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_lchown");
-        _virtualTable.uv_fs_fchown = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_uid_t, uv_gid_t, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_fchown");
-        _virtualTable.uv_fs_chown = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_uid_t, uv_gid_t, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_chown");
-        _virtualTable.uv_fs_fchmod = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, int, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_fchmod");
-        _virtualTable.uv_fs_realpath = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_realpath");
-        _virtualTable.uv_fs_readlink = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_readlink");
-        _virtualTable.uv_fs_symlink = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, int, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_symlink");
-        _virtualTable.uv_fs_link = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_link");
-        _virtualTable.uv_fs_lstat = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_lstat");
-        _virtualTable.uv_fs_lutime = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, double, double, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_lutime");
-        _virtualTable.uv_fs_futime = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, double, double, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_futime");
-        _virtualTable.uv_fs_utime = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, double, double, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_utime");
-        _virtualTable.uv_fs_chmod = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_chmod");
-        _virtualTable.uv_fs_access = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_access");
-        _virtualTable.uv_fs_sendfile = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_file, long, ulong, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_sendfile");
-        _virtualTable.uv_fs_ftruncate = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, long, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_ftruncate");
-        _virtualTable.uv_fs_fdatasync = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_fdatasync");
-        _virtualTable.uv_fs_fsync = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_fsync");
-        _virtualTable.uv_fs_rename = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_rename");
-        _virtualTable.uv_fs_fstat = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_fstat");
-        _virtualTable.uv_fs_stat = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_stat");
-        _virtualTable.uv_fs_closedir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_dir_t*, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_closedir");
-        _virtualTable.uv_fs_readdir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_dir_t*, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_readdir");
-        _virtualTable.uv_fs_opendir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_opendir");
-        _virtualTable.uv_fs_scandir_next = (delegate* unmanaged[Cdecl]<uv_fs_t*, uv_dirent_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_scandir_next");
-        _virtualTable.uv_fs_scandir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_scandir");
-        _virtualTable.uv_fs_rmdir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_rmdir");
-        _virtualTable.uv_fs_mkstemp = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_mkstemp");
-        _virtualTable.uv_fs_mkdtemp = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_mkdtemp");
-        _virtualTable.uv_fs_mkdir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_mkdir");
-        _virtualTable.uv_fs_copyfile = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, int, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_copyfile");
-        _virtualTable.uv_fs_write = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_buf_t*, uint, long, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_write");
-        _virtualTable.uv_fs_unlink = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_unlink");
-        _virtualTable.uv_fs_read = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_buf_t*, uint, long, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_read");
-        _virtualTable.uv_fs_open = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, int, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_open");
-        _virtualTable.uv_fs_close = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_close");
-        _virtualTable.uv_fs_req_cleanup = (delegate* unmanaged[Cdecl]<uv_fs_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_req_cleanup");
-        _virtualTable.uv_fs_get_statbuf = (delegate* unmanaged[Cdecl]<uv_fs_t*, uv_stat_t*>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_get_statbuf");
-        _virtualTable.uv_fs_get_path = (delegate* unmanaged[Cdecl]<uv_fs_t*, CString>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_get_path");
-        _virtualTable.uv_fs_get_ptr = (delegate* unmanaged[Cdecl]<uv_fs_t*, void*>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_get_ptr");
-        _virtualTable.uv_fs_get_system_error = (delegate* unmanaged[Cdecl]<uv_fs_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_get_system_error");
-        _virtualTable.uv_fs_get_result = (delegate* unmanaged[Cdecl]<uv_fs_t*, ssize_t>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_get_result");
-        _virtualTable.uv_fs_get_type = (delegate* unmanaged[Cdecl]<uv_fs_t*, uv_fs_type>)Runtime.LibraryGetExport(_libraryHandle, "uv_fs_get_type");
-        _virtualTable.uv_metrics_idle_time = (delegate* unmanaged[Cdecl]<uv_loop_t*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_metrics_idle_time");
-        _virtualTable.uv_os_uname = (delegate* unmanaged[Cdecl]<uv_utsname_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_uname");
-        _virtualTable.uv_os_gethostname = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_gethostname");
-        _virtualTable.uv_os_unsetenv = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_unsetenv");
-        _virtualTable.uv_os_setenv = (delegate* unmanaged[Cdecl]<CString, CString, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_setenv");
-        _virtualTable.uv_os_getenv = (delegate* unmanaged[Cdecl]<CString, CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_getenv");
-        _virtualTable.uv_os_free_environ = (delegate* unmanaged[Cdecl]<uv_env_item_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_free_environ");
-        _virtualTable.uv_os_environ = (delegate* unmanaged[Cdecl]<uv_env_item_t**, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_environ");
-        _virtualTable.uv_free_interface_addresses = (delegate* unmanaged[Cdecl]<uv_interface_address_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_free_interface_addresses");
-        _virtualTable.uv_interface_addresses = (delegate* unmanaged[Cdecl]<uv_interface_address_t**, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_interface_addresses");
-        _virtualTable.uv_free_cpu_info = (delegate* unmanaged[Cdecl]<uv_cpu_info_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_free_cpu_info");
-        _virtualTable.uv_cpu_info = (delegate* unmanaged[Cdecl]<uv_cpu_info_t**, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_cpu_info");
-        _virtualTable.uv_os_setpriority = (delegate* unmanaged[Cdecl]<uv_pid_t, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_setpriority");
-        _virtualTable.uv_os_getpriority = (delegate* unmanaged[Cdecl]<uv_pid_t, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_getpriority");
-        _virtualTable.uv_os_getppid = (delegate* unmanaged[Cdecl]<uv_pid_t>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_getppid");
-        _virtualTable.uv_os_getpid = (delegate* unmanaged[Cdecl]<uv_pid_t>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_getpid");
-        _virtualTable.uv_os_free_passwd = (delegate* unmanaged[Cdecl]<uv_passwd_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_free_passwd");
-        _virtualTable.uv_os_get_passwd = (delegate* unmanaged[Cdecl]<uv_passwd_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_get_passwd");
-        _virtualTable.uv_os_tmpdir = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_tmpdir");
-        _virtualTable.uv_os_homedir = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_os_homedir");
-        _virtualTable.uv_getrusage = (delegate* unmanaged[Cdecl]<uv_rusage_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_getrusage");
-        _virtualTable.uv_open_osfhandle = (delegate* unmanaged[Cdecl]<uv_os_fd_t, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_open_osfhandle");
-        _virtualTable.uv_get_osfhandle = (delegate* unmanaged[Cdecl]<int, uv_os_fd_t>)Runtime.LibraryGetExport(_libraryHandle, "uv_get_osfhandle");
-        _virtualTable.uv_uptime = (delegate* unmanaged[Cdecl]<double*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_uptime");
-        _virtualTable.uv_resident_set_memory = (delegate* unmanaged[Cdecl]<ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_resident_set_memory");
-        _virtualTable.uv_set_process_title = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_set_process_title");
-        _virtualTable.uv_get_process_title = (delegate* unmanaged[Cdecl]<CString, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_get_process_title");
-        _virtualTable.uv_setup_args = (delegate* unmanaged[Cdecl]<int, CString*, CString*>)Runtime.LibraryGetExport(_libraryHandle, "uv_setup_args");
-        _virtualTable.uv_cancel = (delegate* unmanaged[Cdecl]<uv_req_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_cancel");
-        _virtualTable.uv_queue_work = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_work_t*, uv_work_cb, uv_after_work_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_queue_work");
-        _virtualTable.uv_process_get_pid = (delegate* unmanaged[Cdecl]<uv_process_t*, uv_pid_t>)Runtime.LibraryGetExport(_libraryHandle, "uv_process_get_pid");
-        _virtualTable.uv_kill = (delegate* unmanaged[Cdecl]<int, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_kill");
-        _virtualTable.uv_process_kill = (delegate* unmanaged[Cdecl]<uv_process_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_process_kill");
-        _virtualTable.uv_spawn = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_process_t*, uv_process_options_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_spawn");
-        _virtualTable.uv_getnameinfo = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_getnameinfo_t*, uv_getnameinfo_cb, sockaddr*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_getnameinfo");
-        _virtualTable.uv_freeaddrinfo = (delegate* unmanaged[Cdecl]<addrinfo*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_freeaddrinfo");
-        _virtualTable.uv_getaddrinfo = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_getaddrinfo_t*, uv_getaddrinfo_cb, CString, CString, addrinfo*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_getaddrinfo");
-        _virtualTable.uv_timer_get_due_in = (delegate* unmanaged[Cdecl]<uv_timer_t*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_timer_get_due_in");
-        _virtualTable.uv_timer_get_repeat = (delegate* unmanaged[Cdecl]<uv_timer_t*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_timer_get_repeat");
-        _virtualTable.uv_timer_set_repeat = (delegate* unmanaged[Cdecl]<uv_timer_t*, ulong, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_timer_set_repeat");
-        _virtualTable.uv_timer_again = (delegate* unmanaged[Cdecl]<uv_timer_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_timer_again");
-        _virtualTable.uv_timer_stop = (delegate* unmanaged[Cdecl]<uv_timer_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_timer_stop");
-        _virtualTable.uv_timer_start = (delegate* unmanaged[Cdecl]<uv_timer_t*, uv_timer_cb, ulong, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_timer_start");
-        _virtualTable.uv_timer_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_timer_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_timer_init");
-        _virtualTable.uv_async_send = (delegate* unmanaged[Cdecl]<uv_async_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_async_send");
-        _virtualTable.uv_async_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_async_t*, uv_async_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_async_init");
-        _virtualTable.uv_idle_stop = (delegate* unmanaged[Cdecl]<uv_idle_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_idle_stop");
-        _virtualTable.uv_idle_start = (delegate* unmanaged[Cdecl]<uv_idle_t*, uv_idle_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_idle_start");
-        _virtualTable.uv_idle_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_idle_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_idle_init");
-        _virtualTable.uv_check_stop = (delegate* unmanaged[Cdecl]<uv_check_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_check_stop");
-        _virtualTable.uv_check_start = (delegate* unmanaged[Cdecl]<uv_check_t*, uv_check_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_check_start");
-        _virtualTable.uv_check_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_check_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_check_init");
-        _virtualTable.uv_prepare_stop = (delegate* unmanaged[Cdecl]<uv_prepare_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_prepare_stop");
-        _virtualTable.uv_prepare_start = (delegate* unmanaged[Cdecl]<uv_prepare_t*, uv_prepare_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_prepare_start");
-        _virtualTable.uv_prepare_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_prepare_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_prepare_init");
-        _virtualTable.uv_poll_stop = (delegate* unmanaged[Cdecl]<uv_poll_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_poll_stop");
-        _virtualTable.uv_poll_start = (delegate* unmanaged[Cdecl]<uv_poll_t*, int, uv_poll_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_poll_start");
-        _virtualTable.uv_poll_init_socket = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_poll_t*, uv_os_sock_t, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_poll_init_socket");
-        _virtualTable.uv_poll_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_poll_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_poll_init");
-        _virtualTable.uv_pipe_chmod = (delegate* unmanaged[Cdecl]<uv_pipe_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_chmod");
-        _virtualTable.uv_pipe_pending_type = (delegate* unmanaged[Cdecl]<uv_pipe_t*, uv_handle_type>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_pending_type");
-        _virtualTable.uv_pipe_pending_count = (delegate* unmanaged[Cdecl]<uv_pipe_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_pending_count");
-        _virtualTable.uv_pipe_pending_instances = (delegate* unmanaged[Cdecl]<uv_pipe_t*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_pending_instances");
-        _virtualTable.uv_pipe_getpeername = (delegate* unmanaged[Cdecl]<uv_pipe_t*, CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_getpeername");
-        _virtualTable.uv_pipe_getsockname = (delegate* unmanaged[Cdecl]<uv_pipe_t*, CString, ulong*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_getsockname");
-        _virtualTable.uv_pipe_connect = (delegate* unmanaged[Cdecl]<uv_connect_t*, uv_pipe_t*, CString, uv_connect_cb, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_connect");
-        _virtualTable.uv_pipe_bind = (delegate* unmanaged[Cdecl]<uv_pipe_t*, CString, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_bind");
-        _virtualTable.uv_pipe_open = (delegate* unmanaged[Cdecl]<uv_pipe_t*, uv_file, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_open");
-        _virtualTable.uv_pipe_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_pipe_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe_init");
-        _virtualTable.uv_guess_handle = (delegate* unmanaged[Cdecl]<uv_file, uv_handle_type>)Runtime.LibraryGetExport(_libraryHandle, "uv_guess_handle");
-        _virtualTable.uv_tty_get_vterm_state = (delegate* unmanaged[Cdecl]<uv_tty_vtermstate_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tty_get_vterm_state");
-        _virtualTable.uv_tty_set_vterm_state = (delegate* unmanaged[Cdecl]<uv_tty_vtermstate_t, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_tty_set_vterm_state");
-        _virtualTable.uv_tty_get_winsize = (delegate* unmanaged[Cdecl]<uv_tty_t*, long*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tty_get_winsize");
-        _virtualTable.uv_tty_reset_mode = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tty_reset_mode");
-        _virtualTable.uv_tty_set_mode = (delegate* unmanaged[Cdecl]<uv_tty_t*, uv_tty_mode_t, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tty_set_mode");
-        _virtualTable.uv_tty_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_tty_t*, uv_file, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tty_init");
-        _virtualTable.uv_udp_get_send_queue_count = (delegate* unmanaged[Cdecl]<uv_udp_t*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_get_send_queue_count");
-        _virtualTable.uv_udp_get_send_queue_size = (delegate* unmanaged[Cdecl]<uv_udp_t*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_get_send_queue_size");
-        _virtualTable.uv_udp_recv_stop = (delegate* unmanaged[Cdecl]<uv_udp_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_recv_stop");
-        _virtualTable.uv_udp_using_recvmmsg = (delegate* unmanaged[Cdecl]<uv_udp_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_using_recvmmsg");
-        _virtualTable.uv_udp_recv_start = (delegate* unmanaged[Cdecl]<uv_udp_t*, uv_alloc_cb, uv_udp_recv_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_recv_start");
-        _virtualTable.uv_udp_try_send = (delegate* unmanaged[Cdecl]<uv_udp_t*, uv_buf_t*, uint, sockaddr*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_try_send");
-        _virtualTable.uv_udp_send = (delegate* unmanaged[Cdecl]<uv_udp_send_t*, uv_udp_t*, uv_buf_t*, uint, sockaddr*, uv_udp_send_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_send");
-        _virtualTable.uv_udp_set_ttl = (delegate* unmanaged[Cdecl]<uv_udp_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_set_ttl");
-        _virtualTable.uv_udp_set_broadcast = (delegate* unmanaged[Cdecl]<uv_udp_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_set_broadcast");
-        _virtualTable.uv_udp_set_multicast_interface = (delegate* unmanaged[Cdecl]<uv_udp_t*, CString, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_set_multicast_interface");
-        _virtualTable.uv_udp_set_multicast_ttl = (delegate* unmanaged[Cdecl]<uv_udp_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_set_multicast_ttl");
-        _virtualTable.uv_udp_set_multicast_loop = (delegate* unmanaged[Cdecl]<uv_udp_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_set_multicast_loop");
-        _virtualTable.uv_udp_set_source_membership = (delegate* unmanaged[Cdecl]<uv_udp_t*, CString, CString, CString, uv_membership, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_set_source_membership");
-        _virtualTable.uv_udp_set_membership = (delegate* unmanaged[Cdecl]<uv_udp_t*, CString, CString, uv_membership, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_set_membership");
-        _virtualTable.uv_udp_getsockname = (delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_getsockname");
-        _virtualTable.uv_udp_getpeername = (delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_getpeername");
-        _virtualTable.uv_udp_connect = (delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_connect");
-        _virtualTable.uv_udp_bind = (delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_bind");
-        _virtualTable.uv_udp_open = (delegate* unmanaged[Cdecl]<uv_udp_t*, uv_os_sock_t, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_open");
-        _virtualTable.uv_udp_init_ex = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_udp_t*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_init_ex");
-        _virtualTable.uv_udp_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_udp_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_udp_init");
-        _virtualTable.uv_tcp_connect = (delegate* unmanaged[Cdecl]<uv_connect_t*, uv_tcp_t*, sockaddr*, uv_connect_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_connect");
-        _virtualTable.uv_tcp_close_reset = (delegate* unmanaged[Cdecl]<uv_tcp_t*, uv_close_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_close_reset");
-        _virtualTable.uv_tcp_getpeername = (delegate* unmanaged[Cdecl]<uv_tcp_t*, sockaddr*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_getpeername");
-        _virtualTable.uv_tcp_getsockname = (delegate* unmanaged[Cdecl]<uv_tcp_t*, sockaddr*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_getsockname");
-        _virtualTable.uv_tcp_bind = (delegate* unmanaged[Cdecl]<uv_tcp_t*, sockaddr*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_bind");
-        _virtualTable.uv_tcp_simultaneous_accepts = (delegate* unmanaged[Cdecl]<uv_tcp_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_simultaneous_accepts");
-        _virtualTable.uv_tcp_keepalive = (delegate* unmanaged[Cdecl]<uv_tcp_t*, int, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_keepalive");
-        _virtualTable.uv_tcp_nodelay = (delegate* unmanaged[Cdecl]<uv_tcp_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_nodelay");
-        _virtualTable.uv_tcp_open = (delegate* unmanaged[Cdecl]<uv_tcp_t*, uv_os_sock_t, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_open");
-        _virtualTable.uv_tcp_init_ex = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_tcp_t*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_init_ex");
-        _virtualTable.uv_tcp_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_tcp_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_tcp_init");
-        _virtualTable.uv_is_closing = (delegate* unmanaged[Cdecl]<uv_handle_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_is_closing");
-        _virtualTable.uv_stream_set_blocking = (delegate* unmanaged[Cdecl]<uv_stream_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_stream_set_blocking");
-        _virtualTable.uv_is_writable = (delegate* unmanaged[Cdecl]<uv_stream_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_is_writable");
-        _virtualTable.uv_is_readable = (delegate* unmanaged[Cdecl]<uv_stream_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_is_readable");
-        _virtualTable.uv_try_write = (delegate* unmanaged[Cdecl]<uv_stream_t*, uv_buf_t*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_try_write");
-        _virtualTable.uv_write2 = (delegate* unmanaged[Cdecl]<uv_write_t*, uv_stream_t*, uv_buf_t*, uint, uv_stream_t*, uv_write_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_write2");
-        _virtualTable.uv_write = (delegate* unmanaged[Cdecl]<uv_write_t*, uv_stream_t*, uv_buf_t*, uint, uv_write_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_write");
-        _virtualTable.uv_read_stop = (delegate* unmanaged[Cdecl]<uv_stream_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_read_stop");
-        _virtualTable.uv_read_start = (delegate* unmanaged[Cdecl]<uv_stream_t*, uv_alloc_cb, uv_read_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_read_start");
-        _virtualTable.uv_accept = (delegate* unmanaged[Cdecl]<uv_stream_t*, uv_stream_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_accept");
-        _virtualTable.uv_listen = (delegate* unmanaged[Cdecl]<uv_stream_t*, int, uv_connection_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_listen");
-        _virtualTable.uv_stream_get_write_queue_size = (delegate* unmanaged[Cdecl]<uv_stream_t*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_stream_get_write_queue_size");
-        _virtualTable.uv_socketpair = (delegate* unmanaged[Cdecl]<int, int, uv_os_sock_t*, int, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_socketpair");
-        _virtualTable.uv_pipe = (delegate* unmanaged[Cdecl]<uv_file*, int, int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_pipe");
-        _virtualTable.uv_buf_init = (delegate* unmanaged[Cdecl]<CString, uint, uv_buf_t>)Runtime.LibraryGetExport(_libraryHandle, "uv_buf_init");
-        _virtualTable.uv_fileno = (delegate* unmanaged[Cdecl]<uv_handle_t*, uv_os_fd_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_fileno");
-        _virtualTable.uv_recv_buffer_size = (delegate* unmanaged[Cdecl]<uv_handle_t*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_recv_buffer_size");
-        _virtualTable.uv_send_buffer_size = (delegate* unmanaged[Cdecl]<uv_handle_t*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_send_buffer_size");
-        _virtualTable.uv_close = (delegate* unmanaged[Cdecl]<uv_handle_t*, uv_close_cb, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_close");
-        _virtualTable.uv_print_active_handles = (delegate* unmanaged[Cdecl]<uv_loop_t*, FILE*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_print_active_handles");
-        _virtualTable.uv_print_all_handles = (delegate* unmanaged[Cdecl]<uv_loop_t*, FILE*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_print_all_handles");
-        _virtualTable.uv_walk = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_walk_cb, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_walk");
-        _virtualTable.uv_is_active = (delegate* unmanaged[Cdecl]<uv_handle_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_is_active");
-        _virtualTable.uv_req_type_name = (delegate* unmanaged[Cdecl]<uv_req_type, CString>)Runtime.LibraryGetExport(_libraryHandle, "uv_req_type_name");
-        _virtualTable.uv_req_get_type = (delegate* unmanaged[Cdecl]<uv_req_t*, uv_req_type>)Runtime.LibraryGetExport(_libraryHandle, "uv_req_get_type");
-        _virtualTable.uv_req_set_data = (delegate* unmanaged[Cdecl]<uv_req_t*, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_req_set_data");
-        _virtualTable.uv_req_get_data = (delegate* unmanaged[Cdecl]<uv_req_t*, void*>)Runtime.LibraryGetExport(_libraryHandle, "uv_req_get_data");
-        _virtualTable.uv_req_size = (delegate* unmanaged[Cdecl]<uv_req_type, ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_req_size");
-        _virtualTable.uv_handle_set_data = (delegate* unmanaged[Cdecl]<uv_handle_t*, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_handle_set_data");
-        _virtualTable.uv_handle_get_loop = (delegate* unmanaged[Cdecl]<uv_handle_t*, uv_loop_t*>)Runtime.LibraryGetExport(_libraryHandle, "uv_handle_get_loop");
-        _virtualTable.uv_handle_get_data = (delegate* unmanaged[Cdecl]<uv_handle_t*, void*>)Runtime.LibraryGetExport(_libraryHandle, "uv_handle_get_data");
-        _virtualTable.uv_handle_type_name = (delegate* unmanaged[Cdecl]<uv_handle_type, CString>)Runtime.LibraryGetExport(_libraryHandle, "uv_handle_type_name");
-        _virtualTable.uv_handle_get_type = (delegate* unmanaged[Cdecl]<uv_handle_t*, uv_handle_type>)Runtime.LibraryGetExport(_libraryHandle, "uv_handle_get_type");
-        _virtualTable.uv_handle_size = (delegate* unmanaged[Cdecl]<uv_handle_type, ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_handle_size");
-        _virtualTable.uv_shutdown = (delegate* unmanaged[Cdecl]<uv_shutdown_t*, uv_stream_t*, uv_shutdown_cb, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_shutdown");
-        _virtualTable.uv_err_name_r = (delegate* unmanaged[Cdecl]<int, CString, ulong, CString>)Runtime.LibraryGetExport(_libraryHandle, "uv_err_name_r");
-        _virtualTable.uv_err_name = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "uv_err_name");
-        _virtualTable.uv_strerror_r = (delegate* unmanaged[Cdecl]<int, CString, ulong, CString>)Runtime.LibraryGetExport(_libraryHandle, "uv_strerror_r");
-        _virtualTable.uv_strerror = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "uv_strerror");
-        _virtualTable.uv_translate_sys_error = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_translate_sys_error");
-        _virtualTable.uv_backend_timeout = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_backend_timeout");
-        _virtualTable.uv_backend_fd = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_backend_fd");
-        _virtualTable.uv_now = (delegate* unmanaged[Cdecl]<uv_loop_t*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_now");
-        _virtualTable.uv_update_time = (delegate* unmanaged[Cdecl]<uv_loop_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_update_time");
-        _virtualTable.uv_has_ref = (delegate* unmanaged[Cdecl]<uv_handle_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_has_ref");
-        _virtualTable.uv_unref = (delegate* unmanaged[Cdecl]<uv_handle_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_unref");
-        _virtualTable.uv_ref = (delegate* unmanaged[Cdecl]<uv_handle_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_ref");
-        _virtualTable.uv_stop = (delegate* unmanaged[Cdecl]<uv_loop_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_stop");
-        _virtualTable.uv_run = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_run_mode, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_run");
-        _virtualTable.uv_loop_fork = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_fork");
-        _virtualTable.uv_loop_configure = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_loop_option, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_configure");
-        _virtualTable.uv_loop_alive = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_alive");
-        _virtualTable.uv_loop_size = (delegate* unmanaged[Cdecl]<ulong>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_size");
-        _virtualTable.uv_loop_delete = (delegate* unmanaged[Cdecl]<uv_loop_t*, void>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_delete");
-        _virtualTable.uv_loop_new = (delegate* unmanaged[Cdecl]<uv_loop_t*>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_new");
-        _virtualTable.uv_loop_close = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_close");
-        _virtualTable.uv_loop_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_loop_init");
-        _virtualTable.uv_default_loop = (delegate* unmanaged[Cdecl]<uv_loop_t*>)Runtime.LibraryGetExport(_libraryHandle, "uv_default_loop");
-        _virtualTable.uv_replace_allocator = (delegate* unmanaged[Cdecl]<uv_malloc_func, uv_realloc_func, uv_calloc_func, uv_free_func, int>)Runtime.LibraryGetExport(_libraryHandle, "uv_replace_allocator");
-        _virtualTable.uv_library_shutdown = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "uv_library_shutdown");
-        _virtualTable.uv_version_string = (delegate* unmanaged[Cdecl]<CString>)Runtime.LibraryGetExport(_libraryHandle, "uv_version_string");
-        _virtualTable.uv_version = (delegate* unmanaged[Cdecl]<uint>)Runtime.LibraryGetExport(_libraryHandle, "uv_version");
-        #endregion
-
-        #region "Variables"
-
-        #endregion
-    }
-
-    private static void _UnloadVirtualTable()
-    {
-        #region "Functions"
-
-        _virtualTable.uv_loop_set_data = (delegate* unmanaged[Cdecl]<uv_loop_t*, void*, void>)IntPtr.Zero;
-        _virtualTable.uv_loop_get_data = (delegate* unmanaged[Cdecl]<uv_loop_t*, void*>)IntPtr.Zero;
-        _virtualTable.uv_thread_equal = (delegate* unmanaged[Cdecl]<uv_thread_t*, uv_thread_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_thread_join = (delegate* unmanaged[Cdecl]<uv_thread_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_thread_self = (delegate* unmanaged[Cdecl]<uv_thread_t>)IntPtr.Zero;
-        _virtualTable.uv_thread_create_ex = (delegate* unmanaged[Cdecl]<uv_thread_t*, uv_thread_options_t*, uv_thread_cb, void*, int>)IntPtr.Zero;
-        _virtualTable.uv_thread_create = (delegate* unmanaged[Cdecl]<uv_thread_t*, uv_thread_cb, void*, int>)IntPtr.Zero;
-        _virtualTable.uv_gettimeofday = (delegate* unmanaged[Cdecl]<uv_timeval64_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_key_set = (delegate* unmanaged[Cdecl]<uv_key_t*, void*, void>)IntPtr.Zero;
-        _virtualTable.uv_key_get = (delegate* unmanaged[Cdecl]<uv_key_t*, void*>)IntPtr.Zero;
-        _virtualTable.uv_key_delete = (delegate* unmanaged[Cdecl]<uv_key_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_key_create = (delegate* unmanaged[Cdecl]<uv_key_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_once = (delegate* unmanaged[Cdecl]<uv_once_t*, FnPtr_UV_Void, void>)IntPtr.Zero;
-        _virtualTable.uv_cond_timedwait = (delegate* unmanaged[Cdecl]<uv_cond_t*, uv_mutex_t*, ulong, int>)IntPtr.Zero;
-        _virtualTable.uv_cond_wait = (delegate* unmanaged[Cdecl]<uv_cond_t*, uv_mutex_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_barrier_wait = (delegate* unmanaged[Cdecl]<uv_barrier_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_barrier_destroy = (delegate* unmanaged[Cdecl]<uv_barrier_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_barrier_init = (delegate* unmanaged[Cdecl]<uv_barrier_t*, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_cond_broadcast = (delegate* unmanaged[Cdecl]<uv_cond_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_cond_signal = (delegate* unmanaged[Cdecl]<uv_cond_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_cond_destroy = (delegate* unmanaged[Cdecl]<uv_cond_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_cond_init = (delegate* unmanaged[Cdecl]<uv_cond_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_sem_trywait = (delegate* unmanaged[Cdecl]<uv_sem_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_sem_wait = (delegate* unmanaged[Cdecl]<uv_sem_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_sem_post = (delegate* unmanaged[Cdecl]<uv_sem_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_sem_destroy = (delegate* unmanaged[Cdecl]<uv_sem_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_sem_init = (delegate* unmanaged[Cdecl]<uv_sem_t*, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_rwlock_wrunlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_rwlock_trywrlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_rwlock_wrlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_rwlock_rdunlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_rwlock_tryrdlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_rwlock_rdlock = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_rwlock_destroy = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_rwlock_init = (delegate* unmanaged[Cdecl]<uv_rwlock_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_mutex_unlock = (delegate* unmanaged[Cdecl]<uv_mutex_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_mutex_trylock = (delegate* unmanaged[Cdecl]<uv_mutex_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_mutex_lock = (delegate* unmanaged[Cdecl]<uv_mutex_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_mutex_destroy = (delegate* unmanaged[Cdecl]<uv_mutex_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_mutex_init_recursive = (delegate* unmanaged[Cdecl]<uv_mutex_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_mutex_init = (delegate* unmanaged[Cdecl]<uv_mutex_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_dlerror = (delegate* unmanaged[Cdecl]<uv_lib_t*, CString>)IntPtr.Zero;
-        _virtualTable.uv_dlsym = (delegate* unmanaged[Cdecl]<uv_lib_t*, CString, void**, int>)IntPtr.Zero;
-        _virtualTable.uv_dlclose = (delegate* unmanaged[Cdecl]<uv_lib_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_dlopen = (delegate* unmanaged[Cdecl]<CString, uv_lib_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_disable_stdio_inheritance = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.uv_sleep = (delegate* unmanaged[Cdecl]<uint, void>)IntPtr.Zero;
-        _virtualTable.uv_hrtime = (delegate* unmanaged[Cdecl]<ulong>)IntPtr.Zero;
-        _virtualTable.uv_get_constrained_memory = (delegate* unmanaged[Cdecl]<ulong>)IntPtr.Zero;
-        _virtualTable.uv_get_total_memory = (delegate* unmanaged[Cdecl]<ulong>)IntPtr.Zero;
-        _virtualTable.uv_get_free_memory = (delegate* unmanaged[Cdecl]<ulong>)IntPtr.Zero;
-        _virtualTable.uv_chdir = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.uv_cwd = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_exepath = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_if_indextoiid = (delegate* unmanaged[Cdecl]<uint, CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_if_indextoname = (delegate* unmanaged[Cdecl]<uint, CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_random = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_random_t*, void*, ulong, uint, uv_random_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_inet_pton = (delegate* unmanaged[Cdecl]<int, CString, void*, int>)IntPtr.Zero;
-        _virtualTable.uv_inet_ntop = (delegate* unmanaged[Cdecl]<int, void*, CString, ulong, int>)IntPtr.Zero;
-        _virtualTable.uv_ip6_name = (delegate* unmanaged[Cdecl]<sockaddr_in6*, CString, ulong, int>)IntPtr.Zero;
-        _virtualTable.uv_ip4_name = (delegate* unmanaged[Cdecl]<sockaddr_in*, CString, ulong, int>)IntPtr.Zero;
-        _virtualTable.uv_ip6_addr = (delegate* unmanaged[Cdecl]<CString, int, sockaddr_in6*, int>)IntPtr.Zero;
-        _virtualTable.uv_ip4_addr = (delegate* unmanaged[Cdecl]<CString, int, sockaddr_in*, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_event_getpath = (delegate* unmanaged[Cdecl]<uv_fs_event_t*, CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_event_stop = (delegate* unmanaged[Cdecl]<uv_fs_event_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_event_start = (delegate* unmanaged[Cdecl]<uv_fs_event_t*, uv_fs_event_cb, CString, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_event_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_event_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_loadavg = (delegate* unmanaged[Cdecl]<double*, void>)IntPtr.Zero;
-        _virtualTable.uv_signal_stop = (delegate* unmanaged[Cdecl]<uv_signal_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_signal_start_oneshot = (delegate* unmanaged[Cdecl]<uv_signal_t*, uv_signal_cb, int, int>)IntPtr.Zero;
-        _virtualTable.uv_signal_start = (delegate* unmanaged[Cdecl]<uv_signal_t*, uv_signal_cb, int, int>)IntPtr.Zero;
-        _virtualTable.uv_signal_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_signal_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_poll_getpath = (delegate* unmanaged[Cdecl]<uv_fs_poll_t*, CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_poll_stop = (delegate* unmanaged[Cdecl]<uv_fs_poll_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_poll_start = (delegate* unmanaged[Cdecl]<uv_fs_poll_t*, uv_fs_poll_cb, CString, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_poll_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_poll_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_statfs = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_lchown = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_uid_t, uv_gid_t, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_fchown = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_uid_t, uv_gid_t, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_chown = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_uid_t, uv_gid_t, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_fchmod = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, int, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_realpath = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_readlink = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_symlink = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, int, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_link = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_lstat = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_lutime = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, double, double, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_futime = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, double, double, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_utime = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, double, double, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_chmod = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_access = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_sendfile = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_file, long, ulong, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_ftruncate = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, long, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_fdatasync = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_fsync = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_rename = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_fstat = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_stat = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_closedir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_dir_t*, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_readdir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_dir_t*, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_opendir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_scandir_next = (delegate* unmanaged[Cdecl]<uv_fs_t*, uv_dirent_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_scandir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_rmdir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_mkstemp = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_mkdtemp = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_mkdir = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_copyfile = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, int, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_write = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_buf_t*, uint, long, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_unlink = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_read = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_buf_t*, uint, long, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_open = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, int, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_close = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_req_cleanup = (delegate* unmanaged[Cdecl]<uv_fs_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_fs_get_statbuf = (delegate* unmanaged[Cdecl]<uv_fs_t*, uv_stat_t*>)IntPtr.Zero;
-        _virtualTable.uv_fs_get_path = (delegate* unmanaged[Cdecl]<uv_fs_t*, CString>)IntPtr.Zero;
-        _virtualTable.uv_fs_get_ptr = (delegate* unmanaged[Cdecl]<uv_fs_t*, void*>)IntPtr.Zero;
-        _virtualTable.uv_fs_get_system_error = (delegate* unmanaged[Cdecl]<uv_fs_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_fs_get_result = (delegate* unmanaged[Cdecl]<uv_fs_t*, ssize_t>)IntPtr.Zero;
-        _virtualTable.uv_fs_get_type = (delegate* unmanaged[Cdecl]<uv_fs_t*, uv_fs_type>)IntPtr.Zero;
-        _virtualTable.uv_metrics_idle_time = (delegate* unmanaged[Cdecl]<uv_loop_t*, ulong>)IntPtr.Zero;
-        _virtualTable.uv_os_uname = (delegate* unmanaged[Cdecl]<uv_utsname_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_os_gethostname = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_os_unsetenv = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.uv_os_setenv = (delegate* unmanaged[Cdecl]<CString, CString, int>)IntPtr.Zero;
-        _virtualTable.uv_os_getenv = (delegate* unmanaged[Cdecl]<CString, CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_os_free_environ = (delegate* unmanaged[Cdecl]<uv_env_item_t*, int, void>)IntPtr.Zero;
-        _virtualTable.uv_os_environ = (delegate* unmanaged[Cdecl]<uv_env_item_t**, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_free_interface_addresses = (delegate* unmanaged[Cdecl]<uv_interface_address_t*, int, void>)IntPtr.Zero;
-        _virtualTable.uv_interface_addresses = (delegate* unmanaged[Cdecl]<uv_interface_address_t**, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_free_cpu_info = (delegate* unmanaged[Cdecl]<uv_cpu_info_t*, int, void>)IntPtr.Zero;
-        _virtualTable.uv_cpu_info = (delegate* unmanaged[Cdecl]<uv_cpu_info_t**, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_os_setpriority = (delegate* unmanaged[Cdecl]<uv_pid_t, int, int>)IntPtr.Zero;
-        _virtualTable.uv_os_getpriority = (delegate* unmanaged[Cdecl]<uv_pid_t, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_os_getppid = (delegate* unmanaged[Cdecl]<uv_pid_t>)IntPtr.Zero;
-        _virtualTable.uv_os_getpid = (delegate* unmanaged[Cdecl]<uv_pid_t>)IntPtr.Zero;
-        _virtualTable.uv_os_free_passwd = (delegate* unmanaged[Cdecl]<uv_passwd_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_os_get_passwd = (delegate* unmanaged[Cdecl]<uv_passwd_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_os_tmpdir = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_os_homedir = (delegate* unmanaged[Cdecl]<CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_getrusage = (delegate* unmanaged[Cdecl]<uv_rusage_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_open_osfhandle = (delegate* unmanaged[Cdecl]<uv_os_fd_t, int>)IntPtr.Zero;
-        _virtualTable.uv_get_osfhandle = (delegate* unmanaged[Cdecl]<int, uv_os_fd_t>)IntPtr.Zero;
-        _virtualTable.uv_uptime = (delegate* unmanaged[Cdecl]<double*, int>)IntPtr.Zero;
-        _virtualTable.uv_resident_set_memory = (delegate* unmanaged[Cdecl]<ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_set_process_title = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.uv_get_process_title = (delegate* unmanaged[Cdecl]<CString, ulong, int>)IntPtr.Zero;
-        _virtualTable.uv_setup_args = (delegate* unmanaged[Cdecl]<int, CString*, CString*>)IntPtr.Zero;
-        _virtualTable.uv_cancel = (delegate* unmanaged[Cdecl]<uv_req_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_queue_work = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_work_t*, uv_work_cb, uv_after_work_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_process_get_pid = (delegate* unmanaged[Cdecl]<uv_process_t*, uv_pid_t>)IntPtr.Zero;
-        _virtualTable.uv_kill = (delegate* unmanaged[Cdecl]<int, int, int>)IntPtr.Zero;
-        _virtualTable.uv_process_kill = (delegate* unmanaged[Cdecl]<uv_process_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_spawn = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_process_t*, uv_process_options_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_getnameinfo = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_getnameinfo_t*, uv_getnameinfo_cb, sockaddr*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_freeaddrinfo = (delegate* unmanaged[Cdecl]<addrinfo*, void>)IntPtr.Zero;
-        _virtualTable.uv_getaddrinfo = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_getaddrinfo_t*, uv_getaddrinfo_cb, CString, CString, addrinfo*, int>)IntPtr.Zero;
-        _virtualTable.uv_timer_get_due_in = (delegate* unmanaged[Cdecl]<uv_timer_t*, ulong>)IntPtr.Zero;
-        _virtualTable.uv_timer_get_repeat = (delegate* unmanaged[Cdecl]<uv_timer_t*, ulong>)IntPtr.Zero;
-        _virtualTable.uv_timer_set_repeat = (delegate* unmanaged[Cdecl]<uv_timer_t*, ulong, void>)IntPtr.Zero;
-        _virtualTable.uv_timer_again = (delegate* unmanaged[Cdecl]<uv_timer_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_timer_stop = (delegate* unmanaged[Cdecl]<uv_timer_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_timer_start = (delegate* unmanaged[Cdecl]<uv_timer_t*, uv_timer_cb, ulong, ulong, int>)IntPtr.Zero;
-        _virtualTable.uv_timer_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_timer_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_async_send = (delegate* unmanaged[Cdecl]<uv_async_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_async_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_async_t*, uv_async_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_idle_stop = (delegate* unmanaged[Cdecl]<uv_idle_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_idle_start = (delegate* unmanaged[Cdecl]<uv_idle_t*, uv_idle_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_idle_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_idle_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_check_stop = (delegate* unmanaged[Cdecl]<uv_check_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_check_start = (delegate* unmanaged[Cdecl]<uv_check_t*, uv_check_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_check_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_check_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_prepare_stop = (delegate* unmanaged[Cdecl]<uv_prepare_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_prepare_start = (delegate* unmanaged[Cdecl]<uv_prepare_t*, uv_prepare_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_prepare_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_prepare_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_poll_stop = (delegate* unmanaged[Cdecl]<uv_poll_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_poll_start = (delegate* unmanaged[Cdecl]<uv_poll_t*, int, uv_poll_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_poll_init_socket = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_poll_t*, uv_os_sock_t, int>)IntPtr.Zero;
-        _virtualTable.uv_poll_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_poll_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_pipe_chmod = (delegate* unmanaged[Cdecl]<uv_pipe_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_pipe_pending_type = (delegate* unmanaged[Cdecl]<uv_pipe_t*, uv_handle_type>)IntPtr.Zero;
-        _virtualTable.uv_pipe_pending_count = (delegate* unmanaged[Cdecl]<uv_pipe_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_pipe_pending_instances = (delegate* unmanaged[Cdecl]<uv_pipe_t*, int, void>)IntPtr.Zero;
-        _virtualTable.uv_pipe_getpeername = (delegate* unmanaged[Cdecl]<uv_pipe_t*, CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_pipe_getsockname = (delegate* unmanaged[Cdecl]<uv_pipe_t*, CString, ulong*, int>)IntPtr.Zero;
-        _virtualTable.uv_pipe_connect = (delegate* unmanaged[Cdecl]<uv_connect_t*, uv_pipe_t*, CString, uv_connect_cb, void>)IntPtr.Zero;
-        _virtualTable.uv_pipe_bind = (delegate* unmanaged[Cdecl]<uv_pipe_t*, CString, int>)IntPtr.Zero;
-        _virtualTable.uv_pipe_open = (delegate* unmanaged[Cdecl]<uv_pipe_t*, uv_file, int>)IntPtr.Zero;
-        _virtualTable.uv_pipe_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_pipe_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_guess_handle = (delegate* unmanaged[Cdecl]<uv_file, uv_handle_type>)IntPtr.Zero;
-        _virtualTable.uv_tty_get_vterm_state = (delegate* unmanaged[Cdecl]<uv_tty_vtermstate_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_tty_set_vterm_state = (delegate* unmanaged[Cdecl]<uv_tty_vtermstate_t, void>)IntPtr.Zero;
-        _virtualTable.uv_tty_get_winsize = (delegate* unmanaged[Cdecl]<uv_tty_t*, long*, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_tty_reset_mode = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.uv_tty_set_mode = (delegate* unmanaged[Cdecl]<uv_tty_t*, uv_tty_mode_t, int>)IntPtr.Zero;
-        _virtualTable.uv_tty_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_tty_t*, uv_file, int, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_get_send_queue_count = (delegate* unmanaged[Cdecl]<uv_udp_t*, ulong>)IntPtr.Zero;
-        _virtualTable.uv_udp_get_send_queue_size = (delegate* unmanaged[Cdecl]<uv_udp_t*, ulong>)IntPtr.Zero;
-        _virtualTable.uv_udp_recv_stop = (delegate* unmanaged[Cdecl]<uv_udp_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_using_recvmmsg = (delegate* unmanaged[Cdecl]<uv_udp_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_recv_start = (delegate* unmanaged[Cdecl]<uv_udp_t*, uv_alloc_cb, uv_udp_recv_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_try_send = (delegate* unmanaged[Cdecl]<uv_udp_t*, uv_buf_t*, uint, sockaddr*, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_send = (delegate* unmanaged[Cdecl]<uv_udp_send_t*, uv_udp_t*, uv_buf_t*, uint, sockaddr*, uv_udp_send_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_set_ttl = (delegate* unmanaged[Cdecl]<uv_udp_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_set_broadcast = (delegate* unmanaged[Cdecl]<uv_udp_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_set_multicast_interface = (delegate* unmanaged[Cdecl]<uv_udp_t*, CString, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_set_multicast_ttl = (delegate* unmanaged[Cdecl]<uv_udp_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_set_multicast_loop = (delegate* unmanaged[Cdecl]<uv_udp_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_set_source_membership = (delegate* unmanaged[Cdecl]<uv_udp_t*, CString, CString, CString, uv_membership, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_set_membership = (delegate* unmanaged[Cdecl]<uv_udp_t*, CString, CString, uv_membership, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_getsockname = (delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_getpeername = (delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_connect = (delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_bind = (delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_open = (delegate* unmanaged[Cdecl]<uv_udp_t*, uv_os_sock_t, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_init_ex = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_udp_t*, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_udp_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_udp_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_connect = (delegate* unmanaged[Cdecl]<uv_connect_t*, uv_tcp_t*, sockaddr*, uv_connect_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_close_reset = (delegate* unmanaged[Cdecl]<uv_tcp_t*, uv_close_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_getpeername = (delegate* unmanaged[Cdecl]<uv_tcp_t*, sockaddr*, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_getsockname = (delegate* unmanaged[Cdecl]<uv_tcp_t*, sockaddr*, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_bind = (delegate* unmanaged[Cdecl]<uv_tcp_t*, sockaddr*, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_simultaneous_accepts = (delegate* unmanaged[Cdecl]<uv_tcp_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_keepalive = (delegate* unmanaged[Cdecl]<uv_tcp_t*, int, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_nodelay = (delegate* unmanaged[Cdecl]<uv_tcp_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_open = (delegate* unmanaged[Cdecl]<uv_tcp_t*, uv_os_sock_t, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_init_ex = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_tcp_t*, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_tcp_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_tcp_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_is_closing = (delegate* unmanaged[Cdecl]<uv_handle_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_stream_set_blocking = (delegate* unmanaged[Cdecl]<uv_stream_t*, int, int>)IntPtr.Zero;
-        _virtualTable.uv_is_writable = (delegate* unmanaged[Cdecl]<uv_stream_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_is_readable = (delegate* unmanaged[Cdecl]<uv_stream_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_try_write = (delegate* unmanaged[Cdecl]<uv_stream_t*, uv_buf_t*, uint, int>)IntPtr.Zero;
-        _virtualTable.uv_write2 = (delegate* unmanaged[Cdecl]<uv_write_t*, uv_stream_t*, uv_buf_t*, uint, uv_stream_t*, uv_write_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_write = (delegate* unmanaged[Cdecl]<uv_write_t*, uv_stream_t*, uv_buf_t*, uint, uv_write_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_read_stop = (delegate* unmanaged[Cdecl]<uv_stream_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_read_start = (delegate* unmanaged[Cdecl]<uv_stream_t*, uv_alloc_cb, uv_read_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_accept = (delegate* unmanaged[Cdecl]<uv_stream_t*, uv_stream_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_listen = (delegate* unmanaged[Cdecl]<uv_stream_t*, int, uv_connection_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_stream_get_write_queue_size = (delegate* unmanaged[Cdecl]<uv_stream_t*, ulong>)IntPtr.Zero;
-        _virtualTable.uv_socketpair = (delegate* unmanaged[Cdecl]<int, int, uv_os_sock_t*, int, int, int>)IntPtr.Zero;
-        _virtualTable.uv_pipe = (delegate* unmanaged[Cdecl]<uv_file*, int, int, int>)IntPtr.Zero;
-        _virtualTable.uv_buf_init = (delegate* unmanaged[Cdecl]<CString, uint, uv_buf_t>)IntPtr.Zero;
-        _virtualTable.uv_fileno = (delegate* unmanaged[Cdecl]<uv_handle_t*, uv_os_fd_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_recv_buffer_size = (delegate* unmanaged[Cdecl]<uv_handle_t*, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_send_buffer_size = (delegate* unmanaged[Cdecl]<uv_handle_t*, long*, int>)IntPtr.Zero;
-        _virtualTable.uv_close = (delegate* unmanaged[Cdecl]<uv_handle_t*, uv_close_cb, void>)IntPtr.Zero;
-        _virtualTable.uv_print_active_handles = (delegate* unmanaged[Cdecl]<uv_loop_t*, FILE*, void>)IntPtr.Zero;
-        _virtualTable.uv_print_all_handles = (delegate* unmanaged[Cdecl]<uv_loop_t*, FILE*, void>)IntPtr.Zero;
-        _virtualTable.uv_walk = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_walk_cb, void*, void>)IntPtr.Zero;
-        _virtualTable.uv_is_active = (delegate* unmanaged[Cdecl]<uv_handle_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_req_type_name = (delegate* unmanaged[Cdecl]<uv_req_type, CString>)IntPtr.Zero;
-        _virtualTable.uv_req_get_type = (delegate* unmanaged[Cdecl]<uv_req_t*, uv_req_type>)IntPtr.Zero;
-        _virtualTable.uv_req_set_data = (delegate* unmanaged[Cdecl]<uv_req_t*, void*, void>)IntPtr.Zero;
-        _virtualTable.uv_req_get_data = (delegate* unmanaged[Cdecl]<uv_req_t*, void*>)IntPtr.Zero;
-        _virtualTable.uv_req_size = (delegate* unmanaged[Cdecl]<uv_req_type, ulong>)IntPtr.Zero;
-        _virtualTable.uv_handle_set_data = (delegate* unmanaged[Cdecl]<uv_handle_t*, void*, void>)IntPtr.Zero;
-        _virtualTable.uv_handle_get_loop = (delegate* unmanaged[Cdecl]<uv_handle_t*, uv_loop_t*>)IntPtr.Zero;
-        _virtualTable.uv_handle_get_data = (delegate* unmanaged[Cdecl]<uv_handle_t*, void*>)IntPtr.Zero;
-        _virtualTable.uv_handle_type_name = (delegate* unmanaged[Cdecl]<uv_handle_type, CString>)IntPtr.Zero;
-        _virtualTable.uv_handle_get_type = (delegate* unmanaged[Cdecl]<uv_handle_t*, uv_handle_type>)IntPtr.Zero;
-        _virtualTable.uv_handle_size = (delegate* unmanaged[Cdecl]<uv_handle_type, ulong>)IntPtr.Zero;
-        _virtualTable.uv_shutdown = (delegate* unmanaged[Cdecl]<uv_shutdown_t*, uv_stream_t*, uv_shutdown_cb, int>)IntPtr.Zero;
-        _virtualTable.uv_err_name_r = (delegate* unmanaged[Cdecl]<int, CString, ulong, CString>)IntPtr.Zero;
-        _virtualTable.uv_err_name = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.uv_strerror_r = (delegate* unmanaged[Cdecl]<int, CString, ulong, CString>)IntPtr.Zero;
-        _virtualTable.uv_strerror = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.uv_translate_sys_error = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.uv_backend_timeout = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_backend_fd = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_now = (delegate* unmanaged[Cdecl]<uv_loop_t*, ulong>)IntPtr.Zero;
-        _virtualTable.uv_update_time = (delegate* unmanaged[Cdecl]<uv_loop_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_has_ref = (delegate* unmanaged[Cdecl]<uv_handle_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_unref = (delegate* unmanaged[Cdecl]<uv_handle_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_ref = (delegate* unmanaged[Cdecl]<uv_handle_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_stop = (delegate* unmanaged[Cdecl]<uv_loop_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_run = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_run_mode, int>)IntPtr.Zero;
-        _virtualTable.uv_loop_fork = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_loop_configure = (delegate* unmanaged[Cdecl]<uv_loop_t*, uv_loop_option, int>)IntPtr.Zero;
-        _virtualTable.uv_loop_alive = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_loop_size = (delegate* unmanaged[Cdecl]<ulong>)IntPtr.Zero;
-        _virtualTable.uv_loop_delete = (delegate* unmanaged[Cdecl]<uv_loop_t*, void>)IntPtr.Zero;
-        _virtualTable.uv_loop_new = (delegate* unmanaged[Cdecl]<uv_loop_t*>)IntPtr.Zero;
-        _virtualTable.uv_loop_close = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_loop_init = (delegate* unmanaged[Cdecl]<uv_loop_t*, int>)IntPtr.Zero;
-        _virtualTable.uv_default_loop = (delegate* unmanaged[Cdecl]<uv_loop_t*>)IntPtr.Zero;
-        _virtualTable.uv_replace_allocator = (delegate* unmanaged[Cdecl]<uv_malloc_func, uv_realloc_func, uv_calloc_func, uv_free_func, int>)IntPtr.Zero;
-        _virtualTable.uv_library_shutdown = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.uv_version_string = (delegate* unmanaged[Cdecl]<CString>)IntPtr.Zero;
-        _virtualTable.uv_version = (delegate* unmanaged[Cdecl]<uint>)IntPtr.Zero;
-
-        #endregion
-
-        #region "Variables"
-
-
-
-        #endregion
-    }
-
-    // The virtual table represents a list of pointers to functions or variables which are resolved in a late manner.
-    //	This allows for flexibility in swapping implementations at runtime.
-    //	You can think of it in traditional OOP terms in C# as the locations of the virtual methods and/or properties of an object.
-    public struct _VirtualTable
-    {
-        #region "Function Pointers"
-        // These pointers hold the locations in the native library where functions are located at runtime.
-        // See: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
-
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, void*, void> uv_loop_set_data;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, void*> uv_loop_get_data;
-        public delegate* unmanaged[Cdecl]<uv_thread_t*, uv_thread_t*, int> uv_thread_equal;
-        public delegate* unmanaged[Cdecl]<uv_thread_t*, int> uv_thread_join;
-        public delegate* unmanaged[Cdecl]<uv_thread_t> uv_thread_self;
-        public delegate* unmanaged[Cdecl]<uv_thread_t*, uv_thread_options_t*, uv_thread_cb, void*, int> uv_thread_create_ex;
-        public delegate* unmanaged[Cdecl]<uv_thread_t*, uv_thread_cb, void*, int> uv_thread_create;
-        public delegate* unmanaged[Cdecl]<uv_timeval64_t*, int> uv_gettimeofday;
-        public delegate* unmanaged[Cdecl]<uv_key_t*, void*, void> uv_key_set;
-        public delegate* unmanaged[Cdecl]<uv_key_t*, void*> uv_key_get;
-        public delegate* unmanaged[Cdecl]<uv_key_t*, void> uv_key_delete;
-        public delegate* unmanaged[Cdecl]<uv_key_t*, int> uv_key_create;
-        public delegate* unmanaged[Cdecl]<uv_once_t*, FnPtr_UV_Void, void> uv_once;
-        public delegate* unmanaged[Cdecl]<uv_cond_t*, uv_mutex_t*, ulong, int> uv_cond_timedwait;
-        public delegate* unmanaged[Cdecl]<uv_cond_t*, uv_mutex_t*, void> uv_cond_wait;
-        public delegate* unmanaged[Cdecl]<uv_barrier_t*, int> uv_barrier_wait;
-        public delegate* unmanaged[Cdecl]<uv_barrier_t*, void> uv_barrier_destroy;
-        public delegate* unmanaged[Cdecl]<uv_barrier_t*, uint, int> uv_barrier_init;
-        public delegate* unmanaged[Cdecl]<uv_cond_t*, void> uv_cond_broadcast;
-        public delegate* unmanaged[Cdecl]<uv_cond_t*, void> uv_cond_signal;
-        public delegate* unmanaged[Cdecl]<uv_cond_t*, void> uv_cond_destroy;
-        public delegate* unmanaged[Cdecl]<uv_cond_t*, int> uv_cond_init;
-        public delegate* unmanaged[Cdecl]<uv_sem_t*, int> uv_sem_trywait;
-        public delegate* unmanaged[Cdecl]<uv_sem_t*, void> uv_sem_wait;
-        public delegate* unmanaged[Cdecl]<uv_sem_t*, void> uv_sem_post;
-        public delegate* unmanaged[Cdecl]<uv_sem_t*, void> uv_sem_destroy;
-        public delegate* unmanaged[Cdecl]<uv_sem_t*, uint, int> uv_sem_init;
-        public delegate* unmanaged[Cdecl]<uv_rwlock_t*, void> uv_rwlock_wrunlock;
-        public delegate* unmanaged[Cdecl]<uv_rwlock_t*, int> uv_rwlock_trywrlock;
-        public delegate* unmanaged[Cdecl]<uv_rwlock_t*, void> uv_rwlock_wrlock;
-        public delegate* unmanaged[Cdecl]<uv_rwlock_t*, void> uv_rwlock_rdunlock;
-        public delegate* unmanaged[Cdecl]<uv_rwlock_t*, int> uv_rwlock_tryrdlock;
-        public delegate* unmanaged[Cdecl]<uv_rwlock_t*, void> uv_rwlock_rdlock;
-        public delegate* unmanaged[Cdecl]<uv_rwlock_t*, void> uv_rwlock_destroy;
-        public delegate* unmanaged[Cdecl]<uv_rwlock_t*, int> uv_rwlock_init;
-        public delegate* unmanaged[Cdecl]<uv_mutex_t*, void> uv_mutex_unlock;
-        public delegate* unmanaged[Cdecl]<uv_mutex_t*, int> uv_mutex_trylock;
-        public delegate* unmanaged[Cdecl]<uv_mutex_t*, void> uv_mutex_lock;
-        public delegate* unmanaged[Cdecl]<uv_mutex_t*, void> uv_mutex_destroy;
-        public delegate* unmanaged[Cdecl]<uv_mutex_t*, int> uv_mutex_init_recursive;
-        public delegate* unmanaged[Cdecl]<uv_mutex_t*, int> uv_mutex_init;
-        public delegate* unmanaged[Cdecl]<uv_lib_t*, CString> uv_dlerror;
-        public delegate* unmanaged[Cdecl]<uv_lib_t*, CString, void**, int> uv_dlsym;
-        public delegate* unmanaged[Cdecl]<uv_lib_t*, void> uv_dlclose;
-        public delegate* unmanaged[Cdecl]<CString, uv_lib_t*, int> uv_dlopen;
-        public delegate* unmanaged[Cdecl]<void> uv_disable_stdio_inheritance;
-        public delegate* unmanaged[Cdecl]<uint, void> uv_sleep;
-        public delegate* unmanaged[Cdecl]<ulong> uv_hrtime;
-        public delegate* unmanaged[Cdecl]<ulong> uv_get_constrained_memory;
-        public delegate* unmanaged[Cdecl]<ulong> uv_get_total_memory;
-        public delegate* unmanaged[Cdecl]<ulong> uv_get_free_memory;
-        public delegate* unmanaged[Cdecl]<CString, int> uv_chdir;
-        public delegate* unmanaged[Cdecl]<CString, ulong*, int> uv_cwd;
-        public delegate* unmanaged[Cdecl]<CString, ulong*, int> uv_exepath;
-        public delegate* unmanaged[Cdecl]<uint, CString, ulong*, int> uv_if_indextoiid;
-        public delegate* unmanaged[Cdecl]<uint, CString, ulong*, int> uv_if_indextoname;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_random_t*, void*, ulong, uint, uv_random_cb, int> uv_random;
-        public delegate* unmanaged[Cdecl]<int, CString, void*, int> uv_inet_pton;
-        public delegate* unmanaged[Cdecl]<int, void*, CString, ulong, int> uv_inet_ntop;
-        public delegate* unmanaged[Cdecl]<sockaddr_in6*, CString, ulong, int> uv_ip6_name;
-        public delegate* unmanaged[Cdecl]<sockaddr_in*, CString, ulong, int> uv_ip4_name;
-        public delegate* unmanaged[Cdecl]<CString, int, sockaddr_in6*, int> uv_ip6_addr;
-        public delegate* unmanaged[Cdecl]<CString, int, sockaddr_in*, int> uv_ip4_addr;
-        public delegate* unmanaged[Cdecl]<uv_fs_event_t*, CString, ulong*, int> uv_fs_event_getpath;
-        public delegate* unmanaged[Cdecl]<uv_fs_event_t*, int> uv_fs_event_stop;
-        public delegate* unmanaged[Cdecl]<uv_fs_event_t*, uv_fs_event_cb, CString, uint, int> uv_fs_event_start;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_event_t*, int> uv_fs_event_init;
-        public delegate* unmanaged[Cdecl]<double*, void> uv_loadavg;
-        public delegate* unmanaged[Cdecl]<uv_signal_t*, int> uv_signal_stop;
-        public delegate* unmanaged[Cdecl]<uv_signal_t*, uv_signal_cb, int, int> uv_signal_start_oneshot;
-        public delegate* unmanaged[Cdecl]<uv_signal_t*, uv_signal_cb, int, int> uv_signal_start;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_signal_t*, int> uv_signal_init;
-        public delegate* unmanaged[Cdecl]<uv_fs_poll_t*, CString, ulong*, int> uv_fs_poll_getpath;
-        public delegate* unmanaged[Cdecl]<uv_fs_poll_t*, int> uv_fs_poll_stop;
-        public delegate* unmanaged[Cdecl]<uv_fs_poll_t*, uv_fs_poll_cb, CString, uint, int> uv_fs_poll_start;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_poll_t*, int> uv_fs_poll_init;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_statfs;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_uid_t, uv_gid_t, uv_fs_cb, int> uv_fs_lchown;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_uid_t, uv_gid_t, uv_fs_cb, int> uv_fs_fchown;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_uid_t, uv_gid_t, uv_fs_cb, int> uv_fs_chown;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, int, uv_fs_cb, int> uv_fs_fchmod;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_realpath;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_readlink;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, int, uv_fs_cb, int> uv_fs_symlink;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, uv_fs_cb, int> uv_fs_link;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_lstat;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, double, double, uv_fs_cb, int> uv_fs_lutime;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, double, double, uv_fs_cb, int> uv_fs_futime;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, double, double, uv_fs_cb, int> uv_fs_utime;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int> uv_fs_chmod;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int> uv_fs_access;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_file, long, ulong, uv_fs_cb, int> uv_fs_sendfile;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, long, uv_fs_cb, int> uv_fs_ftruncate;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int> uv_fs_fdatasync;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int> uv_fs_fsync;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, uv_fs_cb, int> uv_fs_rename;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int> uv_fs_fstat;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_stat;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_dir_t*, uv_fs_cb, int> uv_fs_closedir;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_dir_t*, uv_fs_cb, int> uv_fs_readdir;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_opendir;
-        public delegate* unmanaged[Cdecl]<uv_fs_t*, uv_dirent_t*, int> uv_fs_scandir_next;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int> uv_fs_scandir;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_rmdir;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_mkstemp;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_mkdtemp;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, uv_fs_cb, int> uv_fs_mkdir;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, CString, int, uv_fs_cb, int> uv_fs_copyfile;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_buf_t*, uint, long, uv_fs_cb, int> uv_fs_write;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, uv_fs_cb, int> uv_fs_unlink;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_buf_t*, uint, long, uv_fs_cb, int> uv_fs_read;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, CString, int, int, uv_fs_cb, int> uv_fs_open;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_fs_t*, uv_file, uv_fs_cb, int> uv_fs_close;
-        public delegate* unmanaged[Cdecl]<uv_fs_t*, void> uv_fs_req_cleanup;
-        public delegate* unmanaged[Cdecl]<uv_fs_t*, uv_stat_t*> uv_fs_get_statbuf;
-        public delegate* unmanaged[Cdecl]<uv_fs_t*, CString> uv_fs_get_path;
-        public delegate* unmanaged[Cdecl]<uv_fs_t*, void*> uv_fs_get_ptr;
-        public delegate* unmanaged[Cdecl]<uv_fs_t*, int> uv_fs_get_system_error;
-        public delegate* unmanaged[Cdecl]<uv_fs_t*, ssize_t> uv_fs_get_result;
-        public delegate* unmanaged[Cdecl]<uv_fs_t*, uv_fs_type> uv_fs_get_type;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, ulong> uv_metrics_idle_time;
-        public delegate* unmanaged[Cdecl]<uv_utsname_t*, int> uv_os_uname;
-        public delegate* unmanaged[Cdecl]<CString, ulong*, int> uv_os_gethostname;
-        public delegate* unmanaged[Cdecl]<CString, int> uv_os_unsetenv;
-        public delegate* unmanaged[Cdecl]<CString, CString, int> uv_os_setenv;
-        public delegate* unmanaged[Cdecl]<CString, CString, ulong*, int> uv_os_getenv;
-        public delegate* unmanaged[Cdecl]<uv_env_item_t*, int, void> uv_os_free_environ;
-        public delegate* unmanaged[Cdecl]<uv_env_item_t**, long*, int> uv_os_environ;
-        public delegate* unmanaged[Cdecl]<uv_interface_address_t*, int, void> uv_free_interface_addresses;
-        public delegate* unmanaged[Cdecl]<uv_interface_address_t**, long*, int> uv_interface_addresses;
-        public delegate* unmanaged[Cdecl]<uv_cpu_info_t*, int, void> uv_free_cpu_info;
-        public delegate* unmanaged[Cdecl]<uv_cpu_info_t**, long*, int> uv_cpu_info;
-        public delegate* unmanaged[Cdecl]<uv_pid_t, int, int> uv_os_setpriority;
-        public delegate* unmanaged[Cdecl]<uv_pid_t, long*, int> uv_os_getpriority;
-        public delegate* unmanaged[Cdecl]<uv_pid_t> uv_os_getppid;
-        public delegate* unmanaged[Cdecl]<uv_pid_t> uv_os_getpid;
-        public delegate* unmanaged[Cdecl]<uv_passwd_t*, void> uv_os_free_passwd;
-        public delegate* unmanaged[Cdecl]<uv_passwd_t*, int> uv_os_get_passwd;
-        public delegate* unmanaged[Cdecl]<CString, ulong*, int> uv_os_tmpdir;
-        public delegate* unmanaged[Cdecl]<CString, ulong*, int> uv_os_homedir;
-        public delegate* unmanaged[Cdecl]<uv_rusage_t*, int> uv_getrusage;
-        public delegate* unmanaged[Cdecl]<uv_os_fd_t, int> uv_open_osfhandle;
-        public delegate* unmanaged[Cdecl]<int, uv_os_fd_t> uv_get_osfhandle;
-        public delegate* unmanaged[Cdecl]<double*, int> uv_uptime;
-        public delegate* unmanaged[Cdecl]<ulong*, int> uv_resident_set_memory;
-        public delegate* unmanaged[Cdecl]<CString, int> uv_set_process_title;
-        public delegate* unmanaged[Cdecl]<CString, ulong, int> uv_get_process_title;
-        public delegate* unmanaged[Cdecl]<int, CString*, CString*> uv_setup_args;
-        public delegate* unmanaged[Cdecl]<uv_req_t*, int> uv_cancel;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_work_t*, uv_work_cb, uv_after_work_cb, int> uv_queue_work;
-        public delegate* unmanaged[Cdecl]<uv_process_t*, uv_pid_t> uv_process_get_pid;
-        public delegate* unmanaged[Cdecl]<int, int, int> uv_kill;
-        public delegate* unmanaged[Cdecl]<uv_process_t*, int, int> uv_process_kill;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_process_t*, uv_process_options_t*, int> uv_spawn;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_getnameinfo_t*, uv_getnameinfo_cb, sockaddr*, int, int> uv_getnameinfo;
-        public delegate* unmanaged[Cdecl]<addrinfo*, void> uv_freeaddrinfo;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_getaddrinfo_t*, uv_getaddrinfo_cb, CString, CString, addrinfo*, int> uv_getaddrinfo;
-        public delegate* unmanaged[Cdecl]<uv_timer_t*, ulong> uv_timer_get_due_in;
-        public delegate* unmanaged[Cdecl]<uv_timer_t*, ulong> uv_timer_get_repeat;
-        public delegate* unmanaged[Cdecl]<uv_timer_t*, ulong, void> uv_timer_set_repeat;
-        public delegate* unmanaged[Cdecl]<uv_timer_t*, int> uv_timer_again;
-        public delegate* unmanaged[Cdecl]<uv_timer_t*, int> uv_timer_stop;
-        public delegate* unmanaged[Cdecl]<uv_timer_t*, uv_timer_cb, ulong, ulong, int> uv_timer_start;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_timer_t*, int> uv_timer_init;
-        public delegate* unmanaged[Cdecl]<uv_async_t*, int> uv_async_send;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_async_t*, uv_async_cb, int> uv_async_init;
-        public delegate* unmanaged[Cdecl]<uv_idle_t*, int> uv_idle_stop;
-        public delegate* unmanaged[Cdecl]<uv_idle_t*, uv_idle_cb, int> uv_idle_start;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_idle_t*, int> uv_idle_init;
-        public delegate* unmanaged[Cdecl]<uv_check_t*, int> uv_check_stop;
-        public delegate* unmanaged[Cdecl]<uv_check_t*, uv_check_cb, int> uv_check_start;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_check_t*, int> uv_check_init;
-        public delegate* unmanaged[Cdecl]<uv_prepare_t*, int> uv_prepare_stop;
-        public delegate* unmanaged[Cdecl]<uv_prepare_t*, uv_prepare_cb, int> uv_prepare_start;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_prepare_t*, int> uv_prepare_init;
-        public delegate* unmanaged[Cdecl]<uv_poll_t*, int> uv_poll_stop;
-        public delegate* unmanaged[Cdecl]<uv_poll_t*, int, uv_poll_cb, int> uv_poll_start;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_poll_t*, uv_os_sock_t, int> uv_poll_init_socket;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_poll_t*, int, int> uv_poll_init;
-        public delegate* unmanaged[Cdecl]<uv_pipe_t*, int, int> uv_pipe_chmod;
-        public delegate* unmanaged[Cdecl]<uv_pipe_t*, uv_handle_type> uv_pipe_pending_type;
-        public delegate* unmanaged[Cdecl]<uv_pipe_t*, int> uv_pipe_pending_count;
-        public delegate* unmanaged[Cdecl]<uv_pipe_t*, int, void> uv_pipe_pending_instances;
-        public delegate* unmanaged[Cdecl]<uv_pipe_t*, CString, ulong*, int> uv_pipe_getpeername;
-        public delegate* unmanaged[Cdecl]<uv_pipe_t*, CString, ulong*, int> uv_pipe_getsockname;
-        public delegate* unmanaged[Cdecl]<uv_connect_t*, uv_pipe_t*, CString, uv_connect_cb, void> uv_pipe_connect;
-        public delegate* unmanaged[Cdecl]<uv_pipe_t*, CString, int> uv_pipe_bind;
-        public delegate* unmanaged[Cdecl]<uv_pipe_t*, uv_file, int> uv_pipe_open;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_pipe_t*, int, int> uv_pipe_init;
-        public delegate* unmanaged[Cdecl]<uv_file, uv_handle_type> uv_guess_handle;
-        public delegate* unmanaged[Cdecl]<uv_tty_vtermstate_t*, int> uv_tty_get_vterm_state;
-        public delegate* unmanaged[Cdecl]<uv_tty_vtermstate_t, void> uv_tty_set_vterm_state;
-        public delegate* unmanaged[Cdecl]<uv_tty_t*, long*, long*, int> uv_tty_get_winsize;
-        public delegate* unmanaged[Cdecl]<int> uv_tty_reset_mode;
-        public delegate* unmanaged[Cdecl]<uv_tty_t*, uv_tty_mode_t, int> uv_tty_set_mode;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_tty_t*, uv_file, int, int> uv_tty_init;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, ulong> uv_udp_get_send_queue_count;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, ulong> uv_udp_get_send_queue_size;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, int> uv_udp_recv_stop;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, int> uv_udp_using_recvmmsg;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, uv_alloc_cb, uv_udp_recv_cb, int> uv_udp_recv_start;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, uv_buf_t*, uint, sockaddr*, int> uv_udp_try_send;
-        public delegate* unmanaged[Cdecl]<uv_udp_send_t*, uv_udp_t*, uv_buf_t*, uint, sockaddr*, uv_udp_send_cb, int> uv_udp_send;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, int, int> uv_udp_set_ttl;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, int, int> uv_udp_set_broadcast;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, CString, int> uv_udp_set_multicast_interface;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, int, int> uv_udp_set_multicast_ttl;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, int, int> uv_udp_set_multicast_loop;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, CString, CString, CString, uv_membership, int> uv_udp_set_source_membership;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, CString, CString, uv_membership, int> uv_udp_set_membership;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, long*, int> uv_udp_getsockname;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, long*, int> uv_udp_getpeername;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, int> uv_udp_connect;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, sockaddr*, uint, int> uv_udp_bind;
-        public delegate* unmanaged[Cdecl]<uv_udp_t*, uv_os_sock_t, int> uv_udp_open;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_udp_t*, uint, int> uv_udp_init_ex;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_udp_t*, int> uv_udp_init;
-        public delegate* unmanaged[Cdecl]<uv_connect_t*, uv_tcp_t*, sockaddr*, uv_connect_cb, int> uv_tcp_connect;
-        public delegate* unmanaged[Cdecl]<uv_tcp_t*, uv_close_cb, int> uv_tcp_close_reset;
-        public delegate* unmanaged[Cdecl]<uv_tcp_t*, sockaddr*, long*, int> uv_tcp_getpeername;
-        public delegate* unmanaged[Cdecl]<uv_tcp_t*, sockaddr*, long*, int> uv_tcp_getsockname;
-        public delegate* unmanaged[Cdecl]<uv_tcp_t*, sockaddr*, uint, int> uv_tcp_bind;
-        public delegate* unmanaged[Cdecl]<uv_tcp_t*, int, int> uv_tcp_simultaneous_accepts;
-        public delegate* unmanaged[Cdecl]<uv_tcp_t*, int, uint, int> uv_tcp_keepalive;
-        public delegate* unmanaged[Cdecl]<uv_tcp_t*, int, int> uv_tcp_nodelay;
-        public delegate* unmanaged[Cdecl]<uv_tcp_t*, uv_os_sock_t, int> uv_tcp_open;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_tcp_t*, uint, int> uv_tcp_init_ex;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_tcp_t*, int> uv_tcp_init;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, int> uv_is_closing;
-        public delegate* unmanaged[Cdecl]<uv_stream_t*, int, int> uv_stream_set_blocking;
-        public delegate* unmanaged[Cdecl]<uv_stream_t*, int> uv_is_writable;
-        public delegate* unmanaged[Cdecl]<uv_stream_t*, int> uv_is_readable;
-        public delegate* unmanaged[Cdecl]<uv_stream_t*, uv_buf_t*, uint, int> uv_try_write;
-        public delegate* unmanaged[Cdecl]<uv_write_t*, uv_stream_t*, uv_buf_t*, uint, uv_stream_t*, uv_write_cb, int> uv_write2;
-        public delegate* unmanaged[Cdecl]<uv_write_t*, uv_stream_t*, uv_buf_t*, uint, uv_write_cb, int> uv_write;
-        public delegate* unmanaged[Cdecl]<uv_stream_t*, int> uv_read_stop;
-        public delegate* unmanaged[Cdecl]<uv_stream_t*, uv_alloc_cb, uv_read_cb, int> uv_read_start;
-        public delegate* unmanaged[Cdecl]<uv_stream_t*, uv_stream_t*, int> uv_accept;
-        public delegate* unmanaged[Cdecl]<uv_stream_t*, int, uv_connection_cb, int> uv_listen;
-        public delegate* unmanaged[Cdecl]<uv_stream_t*, ulong> uv_stream_get_write_queue_size;
-        public delegate* unmanaged[Cdecl]<int, int, uv_os_sock_t*, int, int, int> uv_socketpair;
-        public delegate* unmanaged[Cdecl]<uv_file*, int, int, int> uv_pipe;
-        public delegate* unmanaged[Cdecl]<CString, uint, uv_buf_t> uv_buf_init;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, uv_os_fd_t*, int> uv_fileno;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, long*, int> uv_recv_buffer_size;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, long*, int> uv_send_buffer_size;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, uv_close_cb, void> uv_close;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, FILE*, void> uv_print_active_handles;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, FILE*, void> uv_print_all_handles;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_walk_cb, void*, void> uv_walk;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, int> uv_is_active;
-        public delegate* unmanaged[Cdecl]<uv_req_type, CString> uv_req_type_name;
-        public delegate* unmanaged[Cdecl]<uv_req_t*, uv_req_type> uv_req_get_type;
-        public delegate* unmanaged[Cdecl]<uv_req_t*, void*, void> uv_req_set_data;
-        public delegate* unmanaged[Cdecl]<uv_req_t*, void*> uv_req_get_data;
-        public delegate* unmanaged[Cdecl]<uv_req_type, ulong> uv_req_size;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, void*, void> uv_handle_set_data;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, uv_loop_t*> uv_handle_get_loop;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, void*> uv_handle_get_data;
-        public delegate* unmanaged[Cdecl]<uv_handle_type, CString> uv_handle_type_name;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, uv_handle_type> uv_handle_get_type;
-        public delegate* unmanaged[Cdecl]<uv_handle_type, ulong> uv_handle_size;
-        public delegate* unmanaged[Cdecl]<uv_shutdown_t*, uv_stream_t*, uv_shutdown_cb, int> uv_shutdown;
-        public delegate* unmanaged[Cdecl]<int, CString, ulong, CString> uv_err_name_r;
-        public delegate* unmanaged[Cdecl]<int, CString> uv_err_name;
-        public delegate* unmanaged[Cdecl]<int, CString, ulong, CString> uv_strerror_r;
-        public delegate* unmanaged[Cdecl]<int, CString> uv_strerror;
-        public delegate* unmanaged[Cdecl]<int, int> uv_translate_sys_error;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, int> uv_backend_timeout;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, int> uv_backend_fd;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, ulong> uv_now;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, void> uv_update_time;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, int> uv_has_ref;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, void> uv_unref;
-        public delegate* unmanaged[Cdecl]<uv_handle_t*, void> uv_ref;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, void> uv_stop;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_run_mode, int> uv_run;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, int> uv_loop_fork;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, uv_loop_option, int> uv_loop_configure;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, int> uv_loop_alive;
-        public delegate* unmanaged[Cdecl]<ulong> uv_loop_size;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, void> uv_loop_delete;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*> uv_loop_new;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, int> uv_loop_close;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*, int> uv_loop_init;
-        public delegate* unmanaged[Cdecl]<uv_loop_t*> uv_default_loop;
-        public delegate* unmanaged[Cdecl]<uv_malloc_func, uv_realloc_func, uv_calloc_func, uv_free_func, int> uv_replace_allocator;
-        public delegate* unmanaged[Cdecl]<void> uv_library_shutdown;
-        public delegate* unmanaged[Cdecl]<CString> uv_version_string;
-        public delegate* unmanaged[Cdecl]<uint> uv_version;
-
-        #endregion
-
-        #region "Variables"
-        // These pointers hold the locations in the native library where global variables are located at runtime.
-        //	The value pointed by these pointers are updated by reading/writing memory.
-
-
-
-        #endregion
-    }
-
-    private static _VirtualTable _virtualTable;
 }

--- a/src/cs/examples/sdl/sdl-c/ast.json
+++ b/src/cs/examples/sdl/sdl-c/ast.json
@@ -3346,9 +3346,9 @@
           "name": "ap",
           "type": "va_list",
           "location": {
-            "file": "vadefs.h",
-            "line": 72,
-            "column": 23,
+            "file": "stdarg.h",
+            "line": 14,
+            "column": 27,
             "isSystem": true
           }
         }
@@ -12692,84 +12692,6 @@
       }
     },
     {
-      "name": "SDL_RectEquals",
-      "returnType": "SDL_bool",
-      "parameters": [
-        {
-          "name": "a",
-          "type": "SDL_Rect*",
-          "location": {
-            "file": "SDL_rect.h",
-            "line": 81,
-            "column": 3
-          }
-        },
-        {
-          "name": "b",
-          "type": "SDL_Rect*",
-          "location": {
-            "file": "SDL_rect.h",
-            "line": 81,
-            "column": 3
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_rect.h",
-        "line": 116,
-        "column": 27
-      }
-    },
-    {
-      "name": "SDL_RectEmpty",
-      "returnType": "SDL_bool",
-      "parameters": [
-        {
-          "name": "r",
-          "type": "SDL_Rect*",
-          "location": {
-            "file": "SDL_rect.h",
-            "line": 81,
-            "column": 3
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_rect.h",
-        "line": 108,
-        "column": 27
-      }
-    },
-    {
-      "name": "SDL_PointInRect",
-      "returnType": "SDL_bool",
-      "parameters": [
-        {
-          "name": "p",
-          "type": "SDL_Point*",
-          "location": {
-            "file": "SDL_rect.h",
-            "line": 52,
-            "column": 3
-          }
-        },
-        {
-          "name": "r",
-          "type": "SDL_Rect*",
-          "location": {
-            "file": "SDL_rect.h",
-            "line": 81,
-            "column": 3
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_rect.h",
-        "line": 99,
-        "column": 27
-      }
-    },
-    {
       "name": "SDL_CalculateGammaRamp",
       "returnType": "void",
       "parameters": [
@@ -13356,9 +13278,9 @@
           "name": "len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -13377,9 +13299,9 @@
           "name": "len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -14991,9 +14913,9 @@
           "name": "datasize",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -15021,9 +14943,9 @@
           "name": "datasize",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -15089,9 +15011,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -15099,9 +15021,9 @@
           "name": "num",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -15138,9 +15060,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -15148,9 +15070,9 @@
           "name": "maxnum",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -15333,11 +15255,12 @@
       "parameters": [
         {
           "name": "fp",
-          "type": "void*",
+          "type": "FILE*",
           "location": {
-            "file": "SDL_rwops.h",
-            "line": 166,
-            "column": 56
+            "file": "_stdio.h",
+            "line": 157,
+            "column": 3,
+            "isSystem": true
           }
         },
         {
@@ -15352,7 +15275,7 @@
       ],
       "location": {
         "file": "SDL_rwops.h",
-        "line": 166,
+        "line": 163,
         "column": 36
       }
     },
@@ -15588,11 +15511,11 @@
       "parameters": [
         {
           "name": "fn",
-          "type": "int (void *)",
+          "type": "SDL_ThreadFunction",
           "location": {
             "file": "SDL_thread.h",
-            "line": 135,
-            "column": 46
+            "line": 88,
+            "column": 24
           }
         },
         {
@@ -15600,17 +15523,17 @@
           "type": "char*",
           "location": {
             "file": "SDL_thread.h",
-            "line": 136,
-            "column": 30
+            "line": 257,
+            "column": 66
           }
         },
         {
           "name": "stacksize",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -15619,32 +15542,14 @@
           "type": "void*",
           "location": {
             "file": "SDL_thread.h",
-            "line": 136,
-            "column": 66
-          }
-        },
-        {
-          "name": "pfnBeginThread",
-          "type": "pfnSDL_CurrentBeginThread",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 114,
-            "column": 30
-          }
-        },
-        {
-          "name": "pfnEndThread",
-          "type": "pfnSDL_CurrentEndThread",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 117,
-            "column": 25
+            "line": 257,
+            "column": 102
           }
         }
       ],
       "location": {
         "file": "SDL_thread.h",
-        "line": 135,
+        "line": 257,
         "column": 1
       }
     },
@@ -15666,7 +15571,7 @@
           "type": "char*",
           "location": {
             "file": "SDL_thread.h",
-            "line": 130,
+            "line": 212,
             "column": 53
           }
         },
@@ -15675,32 +15580,14 @@
           "type": "void*",
           "location": {
             "file": "SDL_thread.h",
-            "line": 130,
+            "line": 212,
             "column": 65
-          }
-        },
-        {
-          "name": "pfnBeginThread",
-          "type": "pfnSDL_CurrentBeginThread",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 114,
-            "column": 30
-          }
-        },
-        {
-          "name": "pfnEndThread",
-          "type": "pfnSDL_CurrentEndThread",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 117,
-            "column": 25
           }
         }
       ],
       "location": {
         "file": "SDL_thread.h",
-        "line": 130,
+        "line": 212,
         "column": 1
       }
     },
@@ -16078,26 +15965,6 @@
         "file": "SDL_mutex.h",
         "line": 79,
         "column": 36
-      }
-    },
-    {
-      "name": "SDL_SwapFloat",
-      "returnType": "float",
-      "parameters": [
-        {
-          "name": "x",
-          "type": "float",
-          "location": {
-            "file": "SDL_endian.h",
-            "line": 270,
-            "column": 21
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_endian.h",
-        "line": 270,
-        "column": 1
       }
     },
     {
@@ -16599,55 +16466,6 @@
       }
     },
     {
-      "name": "__debugbreak",
-      "returnType": "void",
-      "parameters": [],
-      "location": {
-        "file": "SDL_assert.h",
-        "line": 52,
-        "column": 25
-      }
-    },
-    {
-      "name": "SDL_memcpy4",
-      "returnType": "void*",
-      "parameters": [
-        {
-          "name": "dst",
-          "type": "void*",
-          "location": {
-            "file": "SDL_stdinc.h",
-            "line": 674,
-            "column": 68
-          }
-        },
-        {
-          "name": "src",
-          "type": "void*",
-          "location": {
-            "file": "SDL_stdinc.h",
-            "line": 674,
-            "column": 110
-          }
-        },
-        {
-          "name": "dwords",
-          "type": "size_t",
-          "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
-            "isSystem": true
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_stdinc.h",
-        "line": 674,
-        "column": 24
-      }
-    },
-    {
       "name": "SDL_iconv_string",
       "returnType": "char*",
       "parameters": [
@@ -16682,9 +16500,9 @@
           "name": "inbytesleft",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -16721,9 +16539,9 @@
           "name": "inbytesleft",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -16740,9 +16558,9 @@
           "name": "outbytesleft",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -17749,9 +17567,9 @@
           "name": "maxlen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -17768,9 +17586,9 @@
           "name": "ap",
           "type": "va_list",
           "location": {
-            "file": "vadefs.h",
-            "line": 72,
-            "column": 23,
+            "file": "stdarg.h",
+            "line": 14,
+            "column": 27,
             "isSystem": true
           }
         }
@@ -17798,9 +17616,9 @@
           "name": "maxlen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -17846,9 +17664,9 @@
           "name": "ap",
           "type": "va_list",
           "location": {
-            "file": "vadefs.h",
-            "line": 72,
-            "column": 23,
+            "file": "stdarg.h",
+            "line": 14,
+            "column": 27,
             "isSystem": true
           }
         }
@@ -17914,9 +17732,9 @@
           "name": "len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -17982,9 +17800,9 @@
           "name": "maxlen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -18724,9 +18542,9 @@
           "name": "maxlen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -18763,9 +18581,9 @@
           "name": "dst_bytes",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -18802,9 +18620,9 @@
           "name": "maxlen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -18843,9 +18661,9 @@
           "name": "str1",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -18853,9 +18671,9 @@
           "name": "str2",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -18863,9 +18681,9 @@
           "name": "len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -18884,9 +18702,9 @@
           "name": "str1",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -18894,9 +18712,9 @@
           "name": "str2",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         }
@@ -18915,9 +18733,9 @@
           "name": "str1",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -18925,9 +18743,9 @@
           "name": "str2",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -18935,9 +18753,9 @@
           "name": "maxlen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -18956,9 +18774,9 @@
           "name": "str1",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -18966,9 +18784,9 @@
           "name": "str2",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         }
@@ -18987,9 +18805,9 @@
           "name": "haystack",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -18997,9 +18815,9 @@
           "name": "needle",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         }
@@ -19018,9 +18836,9 @@
           "name": "wstr",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         }
@@ -19039,9 +18857,9 @@
           "name": "dst",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -19049,9 +18867,9 @@
           "name": "src",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -19059,9 +18877,9 @@
           "name": "maxlen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -19080,9 +18898,9 @@
           "name": "dst",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -19090,9 +18908,9 @@
           "name": "src",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         },
@@ -19100,9 +18918,9 @@
           "name": "maxlen",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -19121,9 +18939,9 @@
           "name": "wstr",
           "type": "wchar_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 228,
-            "column": 28,
+            "file": "_wchar_t.h",
+            "line": 34,
+            "column": 26,
             "isSystem": true
           }
         }
@@ -19160,9 +18978,9 @@
           "name": "len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -19199,9 +19017,9 @@
           "name": "len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -19238,9 +19056,9 @@
           "name": "len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -19249,45 +19067,6 @@
         "file": "SDL_stdinc.h",
         "line": 497,
         "column": 31
-      }
-    },
-    {
-      "name": "SDL_memset4",
-      "returnType": "void",
-      "parameters": [
-        {
-          "name": "dst",
-          "type": "void*",
-          "location": {
-            "file": "SDL_stdinc.h",
-            "line": 467,
-            "column": 41
-          }
-        },
-        {
-          "name": "val",
-          "type": "Uint32",
-          "location": {
-            "file": "SDL_stdinc.h",
-            "line": 209,
-            "column": 18
-          }
-        },
-        {
-          "name": "dwords",
-          "type": "size_t",
-          "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
-            "isSystem": true
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_stdinc.h",
-        "line": 467,
-        "column": 23
       }
     },
     {
@@ -19316,9 +19095,9 @@
           "name": "len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -19355,9 +19134,9 @@
           "name": "len",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -19685,9 +19464,9 @@
           "name": "nmemb",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -19695,9 +19474,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -19916,9 +19695,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -19937,9 +19716,9 @@
           "name": "nmemb",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -19947,9 +19726,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -19968,9 +19747,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -20279,135 +20058,6 @@
       }
     },
     {
-      "name": "pfnSDL_CurrentEndThread",
-      "type": "void (unsigned int)",
-      "returnType": "void",
-      "parameters": [
-        {
-          "name": "code",
-          "type": "unsigned int",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 117,
-            "column": 60
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_thread.h",
-        "line": 117,
-        "column": 25
-      }
-    },
-    {
-      "name": "pfnSDL_CurrentBeginThread",
-      "type": "uintptr_t (void *, unsigned int, unsigned int (*)(void *) __attribute__((stdcall)), void *, unsigned int, unsigned int *)",
-      "returnType": "uintptr_t",
-      "parameters": [
-        {
-          "name": "",
-          "type": "void*",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 115,
-            "column": 27
-          }
-        },
-        {
-          "name": "",
-          "type": "unsigned int",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 115,
-            "column": 37
-          }
-        },
-        {
-          "name": "func",
-          "type": "unsigned int (void *)",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 115,
-            "column": 60
-          }
-        },
-        {
-          "name": "",
-          "type": "void*",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 116,
-            "column": 35
-          }
-        },
-        {
-          "name": "",
-          "type": "unsigned int",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 116,
-            "column": 45
-          }
-        },
-        {
-          "name": "",
-          "type": "unsigned int*",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 116,
-            "column": 72
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_thread.h",
-        "line": 114,
-        "column": 30
-      }
-    },
-    {
-      "name": "",
-      "type": "unsigned int (void *)",
-      "returnType": "unsigned int",
-      "parameters": [
-        {
-          "name": "",
-          "type": "void*",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 115,
-            "column": 72
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_thread.h",
-        "line": 115,
-        "column": 60
-      }
-    },
-    {
-      "name": "",
-      "type": "int (void *)",
-      "returnType": "int",
-      "parameters": [
-        {
-          "name": "",
-          "type": "void*",
-          "location": {
-            "file": "SDL_thread.h",
-            "line": 135,
-            "column": 57
-          }
-        }
-      ],
-      "location": {
-        "file": "SDL_thread.h",
-        "line": 135,
-        "column": 46
-      }
-    },
-    {
       "name": "SDL_ThreadFunction",
       "type": "int (void *)",
       "returnType": "int",
@@ -20527,9 +20177,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -20549,9 +20199,9 @@
           "name": "nmemb",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         },
@@ -20559,9 +20209,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -20581,9 +20231,9 @@
           "name": "size",
           "type": "size_t",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -25172,7 +24822,6 @@
           "name": "len_mult",
           "type": "int",
           "offset": 32,
-          "padding": 4,
           "location": {
             "file": "SDL_audio.h",
             "line": 237,
@@ -25182,7 +24831,7 @@
         {
           "name": "len_ratio",
           "type": "double",
-          "offset": 40,
+          "offset": 36,
           "location": {
             "file": "SDL_audio.h",
             "line": 238,
@@ -25192,7 +24841,7 @@
         {
           "name": "filters",
           "type": "SDL_AudioFilter[10]",
-          "offset": 48,
+          "offset": 44,
           "location": {
             "file": "SDL_audio.h",
             "line": 239,
@@ -25202,8 +24851,7 @@
         {
           "name": "filter_index",
           "type": "int",
-          "offset": 128,
-          "padding": 4,
+          "offset": 124,
           "location": {
             "file": "SDL_audio.h",
             "line": 240,
@@ -25424,7 +25072,7 @@
     {
       "name": "SDL_bool",
       "type": "SDL_bool",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_FALSE",
@@ -25453,7 +25101,7 @@
     {
       "name": "WindowShapeMode",
       "type": "WindowShapeMode",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "ShapeModeDefault",
@@ -25500,7 +25148,7 @@
     {
       "name": "SDL_RendererFlip",
       "type": "SDL_RendererFlip",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_FLIP_NONE",
@@ -25538,7 +25186,7 @@
     {
       "name": "SDL_BlendMode",
       "type": "SDL_BlendMode",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_BLENDMODE_NONE",
@@ -25603,7 +25251,7 @@
     {
       "name": "SDL_ScaleMode",
       "type": "SDL_ScaleMode",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_ScaleModeNearest",
@@ -25641,7 +25289,7 @@
     {
       "name": "SDL_PowerState",
       "type": "SDL_PowerState",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_POWERSTATE_UNKNOWN",
@@ -25697,7 +25345,7 @@
     {
       "name": "SDL_LogPriority",
       "type": "SDL_LogPriority",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_LOG_PRIORITY_VERBOSE",
@@ -25772,7 +25420,7 @@
     {
       "name": "SDL_HintPriority",
       "type": "SDL_HintPriority",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_HINT_DEFAULT",
@@ -25810,7 +25458,7 @@
     {
       "name": "SDL_Scancode",
       "type": "SDL_Scancode",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_SCANCODE_UNKNOWN",
@@ -28017,7 +27665,7 @@
     {
       "name": "SDL_eventaction",
       "type": "SDL_eventaction",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_ADDEVENT",
@@ -28367,7 +28015,7 @@
     {
       "name": "SDL_GameControllerBindType",
       "type": "SDL_GameControllerBindType",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_CONTROLLER_BINDTYPE_NONE",
@@ -28497,7 +28145,7 @@
     {
       "name": "SDL_GameControllerType",
       "type": "SDL_GameControllerType",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_CONTROLLER_TYPE_UNKNOWN",
@@ -28654,7 +28302,7 @@
     {
       "name": "SDL_JoystickType",
       "type": "SDL_JoystickType",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_JOYSTICK_TYPE_UNKNOWN",
@@ -28755,7 +28403,7 @@
     {
       "name": "SDL_SystemCursor",
       "type": "SDL_SystemCursor",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_SYSTEM_CURSOR_ARROW",
@@ -28883,7 +28531,7 @@
     {
       "name": "SDL_Keymod",
       "type": "SDL_Keymod",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "KMOD_NONE",
@@ -29047,7 +28695,7 @@
     {
       "name": "SDL_GLattr",
       "type": "SDL_GLattr",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_GL_RED_SIZE",
@@ -29301,7 +28949,7 @@
     {
       "name": "SDL_HitTestResult",
       "type": "SDL_HitTestResult",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_HITTEST_NORMAL",
@@ -29402,7 +29050,7 @@
     {
       "name": "SDL_DisplayOrientation",
       "type": "SDL_DisplayOrientation",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_ORIENTATION_UNKNOWN",
@@ -29458,7 +29106,7 @@
     {
       "name": "SDL_YUV_CONVERSION_MODE",
       "type": "SDL_YUV_CONVERSION_MODE",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_YUV_CONVERSION_JPEG",
@@ -29505,7 +29153,7 @@
     {
       "name": "SDL_BlendOperation",
       "type": "SDL_BlendOperation",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_BLENDOPERATION_ADD",
@@ -29562,7 +29210,7 @@
     {
       "name": "SDL_BlendFactor",
       "type": "SDL_BlendFactor",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_BLENDFACTOR_ZERO",
@@ -29664,7 +29312,7 @@
     {
       "name": "SDL_AudioStatus",
       "type": "SDL_AudioStatus",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_AUDIO_STOPPED",
@@ -29702,7 +29350,7 @@
     {
       "name": "SDL_ThreadPriority",
       "type": "SDL_ThreadPriority",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_THREAD_PRIORITY_LOW",
@@ -29749,7 +29397,7 @@
     {
       "name": "SDL_errorcode",
       "type": "SDL_errorcode",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_ENOMEM",
@@ -29814,7 +29462,7 @@
     {
       "name": "SDL_AssertState",
       "type": "SDL_AssertState",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "SDL_ASSERTION_RETRY",
@@ -30207,11 +29855,21 @@
     },
     {
       "name": "wchar_t",
-      "underlyingType": "unsigned short",
+      "underlyingType": "__darwin_wchar_t",
       "location": {
-        "file": "vcruntime.h",
-        "line": 228,
-        "column": 28,
+        "file": "_wchar_t.h",
+        "line": 34,
+        "column": 26,
+        "isSystem": true
+      }
+    },
+    {
+      "name": "__darwin_wchar_t",
+      "underlyingType": "int",
+      "location": {
+        "file": "_types.h",
+        "line": 104,
+        "column": 33,
         "isSystem": true
       }
     }
@@ -30345,6 +30003,13 @@
         "line": 116,
         "column": 13
       }
+    },
+    {
+      "name": "unsigned int",
+      "kind": "primitive",
+      "sizeOf": 4,
+      "alignOf": 4,
+      "isSystem": true
     },
     {
       "name": "SDL_TimerCallback",
@@ -30577,13 +30242,6 @@
         "line": 310,
         "column": 3
       }
-    },
-    {
-      "name": "unsigned int",
-      "kind": "primitive",
-      "sizeOf": 4,
-      "alignOf": 4,
-      "isSystem": true
     },
     {
       "name": "SDL_Renderer*",
@@ -31030,7 +30688,7 @@
     {
       "name": "va_list",
       "kind": "typedef",
-      "sizeOf": 8,
+      "sizeOf": 24,
       "alignOf": 8,
       "isSystem": true
     },
@@ -31831,7 +31489,7 @@
     {
       "name": "SDL_RWops",
       "kind": "typedef",
-      "sizeOf": 88,
+      "sizeOf": 72,
       "alignOf": 8,
       "location": {
         "file": "SDL_rwops.h",
@@ -32283,8 +31941,8 @@
     {
       "name": "SDL_AudioCVT",
       "kind": "typedef",
-      "sizeOf": 136,
-      "alignOf": 8,
+      "sizeOf": 128,
+      "alignOf": 1,
       "location": {
         "file": "SDL_audio.h",
         "line": 241,
@@ -32378,6 +32036,20 @@
       "isSystem": true
     },
     {
+      "name": "FILE*",
+      "kind": "pointer",
+      "sizeOf": 8,
+      "alignOf": 8,
+      "isSystem": true
+    },
+    {
+      "name": "FILE",
+      "kind": "typedef",
+      "sizeOf": 152,
+      "alignOf": 8,
+      "isSystem": true
+    },
+    {
       "name": "SDL_TLSID",
       "kind": "typedef",
       "sizeOf": 4,
@@ -32433,8 +32105,8 @@
     {
       "name": "SDL_threadID",
       "kind": "typedef",
-      "sizeOf": 4,
-      "alignOf": 4,
+      "sizeOf": 8,
+      "alignOf": 8,
       "location": {
         "file": "SDL_thread.h",
         "line": 60,
@@ -32444,64 +32116,6 @@
     {
       "name": "unsigned long",
       "kind": "primitive",
-      "sizeOf": 4,
-      "alignOf": 4,
-      "isSystem": true
-    },
-    {
-      "name": "int (void *)",
-      "kind": "functionPointer",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "location": {
-        "file": "SDL_thread.h",
-        "line": 135,
-        "column": 46
-      }
-    },
-    {
-      "name": "pfnSDL_CurrentBeginThread",
-      "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "location": {
-        "file": "SDL_thread.h",
-        "line": 114,
-        "column": 30
-      }
-    },
-    {
-      "name": "pfnSDL_CurrentEndThread",
-      "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "location": {
-        "file": "SDL_thread.h",
-        "line": 117,
-        "column": 25
-      }
-    },
-    {
-      "name": "unsigned int (void *)",
-      "kind": "functionPointer",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "location": {
-        "file": "SDL_thread.h",
-        "line": 115,
-        "column": 60
-      }
-    },
-    {
-      "name": "unsigned int*",
-      "kind": "pointer",
-      "sizeOf": 8,
-      "alignOf": 8,
-      "isSystem": true
-    },
-    {
-      "name": "uintptr_t",
-      "kind": "typedef",
       "sizeOf": 8,
       "alignOf": 8,
       "isSystem": true
@@ -32717,8 +32331,8 @@
     {
       "name": "long",
       "kind": "primitive",
-      "sizeOf": 4,
-      "alignOf": 4,
+      "sizeOf": 8,
+      "alignOf": 8,
       "isSystem": true
     },
     {
@@ -32731,15 +32345,15 @@
     {
       "name": "wchar_t",
       "kind": "typedef",
-      "sizeOf": 2,
-      "alignOf": 2,
+      "sizeOf": 4,
+      "alignOf": 4,
       "isSystem": true
     },
     {
-      "name": "unsigned short",
-      "kind": "primitive",
-      "sizeOf": 2,
-      "alignOf": 2,
+      "name": "__darwin_wchar_t",
+      "kind": "typedef",
+      "sizeOf": 4,
+      "alignOf": 4,
       "isSystem": true
     },
     {

--- a/src/cs/examples/sdl/sdl-cs/sdl.cs
+++ b/src/cs/examples/sdl/sdl-cs/sdl.cs
@@ -20,4492 +20,2954 @@ using C2CS;
 public static unsafe partial class SDL
 {
     private const string LibraryName = "SDL2";
-    private static IntPtr _libraryHandle;
-
-    static SDL()
-    {
-        TryLoadApi();
-    }
-
-    public static bool TryLoadApi(string? libraryName = LibraryName)
-    {
-        UnloadApi();
-        _libraryHandle = Runtime.LibraryLoad(libraryName!);
-        if (_libraryHandle == IntPtr.Zero) return false;
-        _LoadVirtualTable();
-        return true;
-    }
-
-    public static void UnloadApi()
-    {
-        if (_libraryHandle == IntPtr.Zero) return;
-        _UnloadVirtualTable();
-        Runtime.LibraryUnload(_libraryHandle);
-    }
 
     // Function @ SDL.h:212:30
-    public static void SDL_Quit()
-    {
-        _virtualTable.SDL_Quit();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_Quit();
 
     // Function @ SDL.h:190:32
-    public static uint SDL_WasInit(uint flags)
-    {
-        return _virtualTable.SDL_WasInit(flags);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_WasInit(uint flags);
 
     // Function @ SDL.h:175:30
-    public static void SDL_QuitSubSystem(uint flags)
-    {
-        _virtualTable.SDL_QuitSubSystem(flags);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_QuitSubSystem(uint flags);
 
     // Function @ SDL.h:155:29
-    public static int SDL_InitSubSystem(uint flags)
-    {
-        return _virtualTable.SDL_InitSubSystem(flags);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_InitSubSystem(uint flags);
 
     // Function @ SDL.h:140:29
-    public static int SDL_Init(uint flags)
-    {
-        return _virtualTable.SDL_Init(flags);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_Init(uint flags);
 
     // Function @ SDL_misc.h:69:29
-    public static int SDL_OpenURL(CString url)
-    {
-        return _virtualTable.SDL_OpenURL(url);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_OpenURL(CString url);
 
     // Function @ SDL_locale.h:89:38
-    public static SDL_Locale* SDL_GetPreferredLocales()
-    {
-        return _virtualTable.SDL_GetPreferredLocales();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Locale* SDL_GetPreferredLocales();
 
     // Function @ SDL_version.h:161:44
-    public static int SDL_GetRevisionNumber()
-    {
-        return _virtualTable.SDL_GetRevisionNumber();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetRevisionNumber();
 
     // Function @ SDL_version.h:150:37
-    public static CString SDL_GetRevision()
-    {
-        return _virtualTable.SDL_GetRevision();
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetRevision();
 
     // Function @ SDL_version.h:123:30
-    public static void SDL_GetVersion(SDL_version* ver)
-    {
-        _virtualTable.SDL_GetVersion(ver);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GetVersion(SDL_version* ver);
 
     // Function @ SDL_timer.h:161:34
-    public static CBool SDL_RemoveTimer(SDL_TimerID id)
-    {
-        return _virtualTable.SDL_RemoveTimer(id);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_RemoveTimer(SDL_TimerID id);
 
     // Function @ SDL_timer.h:148:37
-    public static SDL_TimerID SDL_AddTimer(uint interval, SDL_TimerCallback callback, void* param)
-    {
-        return _virtualTable.SDL_AddTimer(interval, callback, param);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_TimerID SDL_AddTimer(uint interval, SDL_TimerCallback callback, void* param);
 
     // Function @ SDL_timer.h:101:30
-    public static void SDL_Delay(uint ms)
-    {
-        _virtualTable.SDL_Delay(ms);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_Delay(uint ms);
 
     // Function @ SDL_timer.h:90:32
-    public static ulong SDL_GetPerformanceFrequency()
-    {
-        return _virtualTable.SDL_GetPerformanceFrequency();
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_GetPerformanceFrequency();
 
     // Function @ SDL_timer.h:79:32
-    public static ulong SDL_GetPerformanceCounter()
-    {
-        return _virtualTable.SDL_GetPerformanceCounter();
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_GetPerformanceCounter();
 
     // Function @ SDL_timer.h:50:32
-    public static uint SDL_GetTicks()
-    {
-        return _virtualTable.SDL_GetTicks();
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_GetTicks();
 
     // Function @ SDL_shape.h:136:29
-    public static int SDL_GetShapedWindowMode(SDL_Window* window, SDL_WindowShapeMode* shape_mode)
-    {
-        return _virtualTable.SDL_GetShapedWindowMode(window, shape_mode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetShapedWindowMode(SDL_Window* window, SDL_WindowShapeMode* shape_mode);
 
     // Function @ SDL_shape.h:121:29
-    public static int SDL_SetWindowShape(SDL_Window* window, SDL_Surface* shape, SDL_WindowShapeMode* shape_mode)
-    {
-        return _virtualTable.SDL_SetWindowShape(window, shape, shape_mode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetWindowShape(SDL_Window* window, SDL_Surface* shape, SDL_WindowShapeMode* shape_mode);
 
     // Function @ SDL_shape.h:77:34
-    public static CBool SDL_IsShapedWindow(SDL_Window* window)
-    {
-        return _virtualTable.SDL_IsShapedWindow(window);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_IsShapedWindow(SDL_Window* window);
 
     // Function @ SDL_shape.h:66:38
-    public static SDL_Window* SDL_CreateShapedWindow(CString title, uint x, uint y, uint w, uint h, uint flags)
-    {
-        return _virtualTable.SDL_CreateShapedWindow(title, x, y, w, h, flags);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Window* SDL_CreateShapedWindow(CString title, uint x, uint y, uint w, uint h, uint flags);
 
     // Function @ SDL_render.h:1611:31
-    public static void* SDL_RenderGetMetalCommandEncoder(SDL_Renderer* renderer)
-    {
-        return _virtualTable.SDL_RenderGetMetalCommandEncoder(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_RenderGetMetalCommandEncoder(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:1597:31
-    public static void* SDL_RenderGetMetalLayer(SDL_Renderer* renderer)
-    {
-        return _virtualTable.SDL_RenderGetMetalLayer(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_RenderGetMetalLayer(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:1583:29
-    public static int SDL_GL_UnbindTexture(SDL_Texture* texture)
-    {
-        return _virtualTable.SDL_GL_UnbindTexture(texture);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GL_UnbindTexture(SDL_Texture* texture);
 
     // Function @ SDL_render.h:1570:29
-    public static int SDL_GL_BindTexture(SDL_Texture* texture, float* texw, float* texh)
-    {
-        return _virtualTable.SDL_GL_BindTexture(texture, texw, texh);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GL_BindTexture(SDL_Texture* texture, float* texw, float* texh);
 
     // Function @ SDL_render.h:1532:29
-    public static int SDL_RenderFlush(SDL_Renderer* renderer)
-    {
-        return _virtualTable.SDL_RenderFlush(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderFlush(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:1501:30
-    public static void SDL_DestroyRenderer(SDL_Renderer* renderer)
-    {
-        _virtualTable.SDL_DestroyRenderer(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DestroyRenderer(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:1492:30
-    public static void SDL_DestroyTexture(SDL_Texture* texture)
-    {
-        _virtualTable.SDL_DestroyTexture(texture);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DestroyTexture(SDL_Texture* texture);
 
     // Function @ SDL_render.h:1479:30
-    public static void SDL_RenderPresent(SDL_Renderer* renderer)
-    {
-        _virtualTable.SDL_RenderPresent(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_RenderPresent(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:1440:29
-    public static int SDL_RenderReadPixels(SDL_Renderer* renderer, SDL_Rect* rect, uint format, void* pixels, int pitch)
-    {
-        return _virtualTable.SDL_RenderReadPixels(renderer, rect, format, pixels, pitch);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderReadPixels(SDL_Renderer* renderer, SDL_Rect* rect, uint format, void* pixels, int pitch);
 
     // Function @ SDL_render.h:1409:29
-    public static int SDL_RenderCopyExF(SDL_Renderer* renderer, SDL_Texture* texture, SDL_Rect* srcrect, SDL_FRect* dstrect, double angle, SDL_FPoint* center, SDL_RendererFlip flip)
-    {
-        return _virtualTable.SDL_RenderCopyExF(renderer, texture, srcrect, dstrect, angle, center, flip);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderCopyExF(SDL_Renderer* renderer, SDL_Texture* texture, SDL_Rect* srcrect, SDL_FRect* dstrect, double angle, SDL_FPoint* center, SDL_RendererFlip flip);
 
     // Function @ SDL_render.h:1388:29
-    public static int SDL_RenderCopyF(SDL_Renderer* renderer, SDL_Texture* texture, SDL_Rect* srcrect, SDL_FRect* dstrect)
-    {
-        return _virtualTable.SDL_RenderCopyF(renderer, texture, srcrect, dstrect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderCopyF(SDL_Renderer* renderer, SDL_Texture* texture, SDL_Rect* srcrect, SDL_FRect* dstrect);
 
     // Function @ SDL_render.h:1372:29
-    public static int SDL_RenderFillRectsF(SDL_Renderer* renderer, SDL_FRect* rects, int count)
-    {
-        return _virtualTable.SDL_RenderFillRectsF(renderer, rects, count);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderFillRectsF(SDL_Renderer* renderer, SDL_FRect* rects, int count);
 
     // Function @ SDL_render.h:1360:29
-    public static int SDL_RenderFillRectF(SDL_Renderer* renderer, SDL_FRect* rect)
-    {
-        return _virtualTable.SDL_RenderFillRectF(renderer, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderFillRectF(SDL_Renderer* renderer, SDL_FRect* rect);
 
     // Function @ SDL_render.h:1347:29
-    public static int SDL_RenderDrawRectsF(SDL_Renderer* renderer, SDL_FRect* rects, int count)
-    {
-        return _virtualTable.SDL_RenderDrawRectsF(renderer, rects, count);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawRectsF(SDL_Renderer* renderer, SDL_FRect* rects, int count);
 
     // Function @ SDL_render.h:1335:29
-    public static int SDL_RenderDrawRectF(SDL_Renderer* renderer, SDL_FRect* rect)
-    {
-        return _virtualTable.SDL_RenderDrawRectF(renderer, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawRectF(SDL_Renderer* renderer, SDL_FRect* rect);
 
     // Function @ SDL_render.h:1324:29
-    public static int SDL_RenderDrawLinesF(SDL_Renderer* renderer, SDL_FPoint* points, int count)
-    {
-        return _virtualTable.SDL_RenderDrawLinesF(renderer, points, count);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawLinesF(SDL_Renderer* renderer, SDL_FPoint* points, int count);
 
     // Function @ SDL_render.h:1312:29
-    public static int SDL_RenderDrawLineF(SDL_Renderer* renderer, float x1, float y1, float x2, float y2)
-    {
-        return _virtualTable.SDL_RenderDrawLineF(renderer, x1, y1, x2, y2);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawLineF(SDL_Renderer* renderer, float x1, float y1, float x2, float y2);
 
     // Function @ SDL_render.h:1298:29
-    public static int SDL_RenderDrawPointsF(SDL_Renderer* renderer, SDL_FPoint* points, int count)
-    {
-        return _virtualTable.SDL_RenderDrawPointsF(renderer, points, count);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawPointsF(SDL_Renderer* renderer, SDL_FPoint* points, int count);
 
     // Function @ SDL_render.h:1287:29
-    public static int SDL_RenderDrawPointF(SDL_Renderer* renderer, float x, float y)
-    {
-        return _virtualTable.SDL_RenderDrawPointF(renderer, x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawPointF(SDL_Renderer* renderer, float x, float y);
 
     // Function @ SDL_render.h:1270:29
-    public static int SDL_RenderCopyEx(SDL_Renderer* renderer, SDL_Texture* texture, SDL_Rect* srcrect, SDL_Rect* dstrect, double angle, SDL_Point* center, SDL_RendererFlip flip)
-    {
-        return _virtualTable.SDL_RenderCopyEx(renderer, texture, srcrect, dstrect, angle, center, flip);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderCopyEx(SDL_Renderer* renderer, SDL_Texture* texture, SDL_Rect* srcrect, SDL_Rect* dstrect, double angle, SDL_Point* center, SDL_RendererFlip flip);
 
     // Function @ SDL_render.h:1228:29
-    public static int SDL_RenderCopy(SDL_Renderer* renderer, SDL_Texture* texture, SDL_Rect* srcrect, SDL_Rect* dstrect)
-    {
-        return _virtualTable.SDL_RenderCopy(renderer, texture, srcrect, dstrect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderCopy(SDL_Renderer* renderer, SDL_Texture* texture, SDL_Rect* srcrect, SDL_Rect* dstrect);
 
     // Function @ SDL_render.h:1198:29
-    public static int SDL_RenderFillRects(SDL_Renderer* renderer, SDL_Rect* rects, int count)
-    {
-        return _virtualTable.SDL_RenderFillRects(renderer, rects, count);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderFillRects(SDL_Renderer* renderer, SDL_Rect* rects, int count);
 
     // Function @ SDL_render.h:1175:29
-    public static int SDL_RenderFillRect(SDL_Renderer* renderer, SDL_Rect* rect)
-    {
-        return _virtualTable.SDL_RenderFillRect(renderer, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderFillRect(SDL_Renderer* renderer, SDL_Rect* rect);
 
     // Function @ SDL_render.h:1147:29
-    public static int SDL_RenderDrawRects(SDL_Renderer* renderer, SDL_Rect* rects, int count)
-    {
-        return _virtualTable.SDL_RenderDrawRects(renderer, rects, count);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawRects(SDL_Renderer* renderer, SDL_Rect* rects, int count);
 
     // Function @ SDL_render.h:1123:29
-    public static int SDL_RenderDrawRect(SDL_Renderer* renderer, SDL_Rect* rect)
-    {
-        return _virtualTable.SDL_RenderDrawRect(renderer, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawRect(SDL_Renderer* renderer, SDL_Rect* rect);
 
     // Function @ SDL_render.h:1099:29
-    public static int SDL_RenderDrawLines(SDL_Renderer* renderer, SDL_Point* points, int count)
-    {
-        return _virtualTable.SDL_RenderDrawLines(renderer, points, count);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawLines(SDL_Renderer* renderer, SDL_Point* points, int count);
 
     // Function @ SDL_render.h:1073:29
-    public static int SDL_RenderDrawLine(SDL_Renderer* renderer, int x1, int y1, int x2, int y2)
-    {
-        return _virtualTable.SDL_RenderDrawLine(renderer, x1, y1, x2, y2);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawLine(SDL_Renderer* renderer, int x1, int y1, int x2, int y2);
 
     // Function @ SDL_render.h:1042:29
-    public static int SDL_RenderDrawPoints(SDL_Renderer* renderer, SDL_Point* points, int count)
-    {
-        return _virtualTable.SDL_RenderDrawPoints(renderer, points, count);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawPoints(SDL_Renderer* renderer, SDL_Point* points, int count);
 
     // Function @ SDL_render.h:1018:29
-    public static int SDL_RenderDrawPoint(SDL_Renderer* renderer, int x, int y)
-    {
-        return _virtualTable.SDL_RenderDrawPoint(renderer, x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderDrawPoint(SDL_Renderer* renderer, int x, int y);
 
     // Function @ SDL_render.h:993:29
-    public static int SDL_RenderClear(SDL_Renderer* renderer)
-    {
-        return _virtualTable.SDL_RenderClear(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderClear(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:976:29
-    public static int SDL_GetRenderDrawBlendMode(SDL_Renderer* renderer, SDL_BlendMode* blendMode)
-    {
-        return _virtualTable.SDL_GetRenderDrawBlendMode(renderer, blendMode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetRenderDrawBlendMode(SDL_Renderer* renderer, SDL_BlendMode* blendMode);
 
     // Function @ SDL_render.h:963:29
-    public static int SDL_SetRenderDrawBlendMode(SDL_Renderer* renderer, SDL_BlendMode blendMode)
-    {
-        return _virtualTable.SDL_SetRenderDrawBlendMode(renderer, blendMode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetRenderDrawBlendMode(SDL_Renderer* renderer, SDL_BlendMode blendMode);
 
     // Function @ SDL_render.h:939:29
-    public static int SDL_GetRenderDrawColor(SDL_Renderer* renderer, byte* r, byte* g, byte* b, byte* a)
-    {
-        return _virtualTable.SDL_GetRenderDrawColor(renderer, r, g, b, a);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetRenderDrawColor(SDL_Renderer* renderer, byte* r, byte* g, byte* b, byte* a);
 
     // Function @ SDL_render.h:918:29
-    public static int SDL_SetRenderDrawColor(SDL_Renderer* renderer, byte r, byte g, byte b, byte a)
-    {
-        return _virtualTable.SDL_SetRenderDrawColor(renderer, r, g, b, a);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetRenderDrawColor(SDL_Renderer* renderer, byte r, byte g, byte b, byte a);
 
     // Function @ SDL_render.h:888:30
-    public static void SDL_RenderGetScale(SDL_Renderer* renderer, float* scaleX, float* scaleY)
-    {
-        _virtualTable.SDL_RenderGetScale(renderer, scaleX, scaleY);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_RenderGetScale(SDL_Renderer* renderer, float* scaleX, float* scaleY);
 
     // Function @ SDL_render.h:874:29
-    public static int SDL_RenderSetScale(SDL_Renderer* renderer, float scaleX, float scaleY)
-    {
-        return _virtualTable.SDL_RenderSetScale(renderer, scaleX, scaleY);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderSetScale(SDL_Renderer* renderer, float scaleX, float scaleY);
 
     // Function @ SDL_render.h:849:34
-    public static CBool SDL_RenderIsClipEnabled(SDL_Renderer* renderer)
-    {
-        return _virtualTable.SDL_RenderIsClipEnabled(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_RenderIsClipEnabled(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:834:30
-    public static void SDL_RenderGetClipRect(SDL_Renderer* renderer, SDL_Rect* rect)
-    {
-        _virtualTable.SDL_RenderGetClipRect(renderer, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_RenderGetClipRect(SDL_Renderer* renderer, SDL_Rect* rect);
 
     // Function @ SDL_render.h:820:29
-    public static int SDL_RenderSetClipRect(SDL_Renderer* renderer, SDL_Rect* rect)
-    {
-        return _virtualTable.SDL_RenderSetClipRect(renderer, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderSetClipRect(SDL_Renderer* renderer, SDL_Rect* rect);
 
     // Function @ SDL_render.h:804:30
-    public static void SDL_RenderGetViewport(SDL_Renderer* renderer, SDL_Rect* rect)
-    {
-        _virtualTable.SDL_RenderGetViewport(renderer, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_RenderGetViewport(SDL_Renderer* renderer, SDL_Rect* rect);
 
     // Function @ SDL_render.h:793:29
-    public static int SDL_RenderSetViewport(SDL_Renderer* renderer, SDL_Rect* rect)
-    {
-        return _virtualTable.SDL_RenderSetViewport(renderer, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderSetViewport(SDL_Renderer* renderer, SDL_Rect* rect);
 
     // Function @ SDL_render.h:777:34
-    public static CBool SDL_RenderGetIntegerScale(SDL_Renderer* renderer)
-    {
-        return _virtualTable.SDL_RenderGetIntegerScale(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_RenderGetIntegerScale(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:763:29
-    public static int SDL_RenderSetIntegerScale(SDL_Renderer* renderer, CBool enable)
-    {
-        return _virtualTable.SDL_RenderSetIntegerScale(renderer, enable);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderSetIntegerScale(SDL_Renderer* renderer, CBool enable);
 
     // Function @ SDL_render.h:744:30
-    public static void SDL_RenderGetLogicalSize(SDL_Renderer* renderer, long* w, long* h)
-    {
-        _virtualTable.SDL_RenderGetLogicalSize(renderer, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_RenderGetLogicalSize(SDL_Renderer* renderer, long* w, long* h);
 
     // Function @ SDL_render.h:727:29
-    public static int SDL_RenderSetLogicalSize(SDL_Renderer* renderer, int w, int h)
-    {
-        return _virtualTable.SDL_RenderSetLogicalSize(renderer, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RenderSetLogicalSize(SDL_Renderer* renderer, int w, int h);
 
     // Function @ SDL_render.h:700:39
-    public static SDL_Texture* SDL_GetRenderTarget(SDL_Renderer* renderer)
-    {
-        return _virtualTable.SDL_GetRenderTarget(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Texture* SDL_GetRenderTarget(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:684:29
-    public static int SDL_SetRenderTarget(SDL_Renderer* renderer, SDL_Texture* texture)
-    {
-        return _virtualTable.SDL_SetRenderTarget(renderer, texture);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetRenderTarget(SDL_Renderer* renderer, SDL_Texture* texture);
 
     // Function @ SDL_render.h:660:34
-    public static CBool SDL_RenderTargetSupported(SDL_Renderer* renderer)
-    {
-        return _virtualTable.SDL_RenderTargetSupported(renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_RenderTargetSupported(SDL_Renderer* renderer);
 
     // Function @ SDL_render.h:648:30
-    public static void SDL_UnlockTexture(SDL_Texture* texture)
-    {
-        _virtualTable.SDL_UnlockTexture(texture);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_UnlockTexture(SDL_Texture* texture);
 
     // Function @ SDL_render.h:629:29
-    public static int SDL_LockTextureToSurface(SDL_Texture* texture, SDL_Rect* rect, SDL_Surface** surface)
-    {
-        return _virtualTable.SDL_LockTextureToSurface(texture, rect, surface);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_LockTextureToSurface(SDL_Texture* texture, SDL_Rect* rect, SDL_Surface** surface);
 
     // Function @ SDL_render.h:595:29
-    public static int SDL_LockTexture(SDL_Texture* texture, SDL_Rect* rect, void** pixels, long* pitch)
-    {
-        return _virtualTable.SDL_LockTexture(texture, rect, pixels, pitch);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_LockTexture(SDL_Texture* texture, SDL_Rect* rect, void** pixels, long* pitch);
 
     // Function @ SDL_render.h:565:29
-    public static int SDL_UpdateNVTexture(SDL_Texture* texture, SDL_Rect* rect, byte* Yplane, int Ypitch, byte* UVplane, int UVpitch)
-    {
-        return _virtualTable.SDL_UpdateNVTexture(texture, rect, Yplane, Ypitch, UVplane, UVpitch);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_UpdateNVTexture(SDL_Texture* texture, SDL_Rect* rect, byte* Yplane, int Ypitch, byte* UVplane, int UVpitch);
 
     // Function @ SDL_render.h:543:29
-    public static int SDL_UpdateYUVTexture(SDL_Texture* texture, SDL_Rect* rect, byte* Yplane, int Ypitch, byte* Uplane, int Upitch, byte* Vplane, int Vpitch)
-    {
-        return _virtualTable.SDL_UpdateYUVTexture(texture, rect, Yplane, Ypitch, Uplane, Upitch, Vplane, Vpitch);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_UpdateYUVTexture(SDL_Texture* texture, SDL_Rect* rect, byte* Yplane, int Ypitch, byte* Uplane, int Upitch, byte* Vplane, int Vpitch);
 
     // Function @ SDL_render.h:512:29
-    public static int SDL_UpdateTexture(SDL_Texture* texture, SDL_Rect* rect, void* pixels, int pitch)
-    {
-        return _virtualTable.SDL_UpdateTexture(texture, rect, pixels, pitch);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_UpdateTexture(SDL_Texture* texture, SDL_Rect* rect, void* pixels, int pitch);
 
     // Function @ SDL_render.h:482:29
-    public static int SDL_GetTextureScaleMode(SDL_Texture* texture, SDL_ScaleMode* scaleMode)
-    {
-        return _virtualTable.SDL_GetTextureScaleMode(texture, scaleMode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetTextureScaleMode(SDL_Texture* texture, SDL_ScaleMode* scaleMode);
 
     // Function @ SDL_render.h:470:29
-    public static int SDL_SetTextureScaleMode(SDL_Texture* texture, SDL_ScaleMode scaleMode)
-    {
-        return _virtualTable.SDL_SetTextureScaleMode(texture, scaleMode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetTextureScaleMode(SDL_Texture* texture, SDL_ScaleMode scaleMode);
 
     // Function @ SDL_render.h:456:29
-    public static int SDL_GetTextureBlendMode(SDL_Texture* texture, SDL_BlendMode* blendMode)
-    {
-        return _virtualTable.SDL_GetTextureBlendMode(texture, blendMode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetTextureBlendMode(SDL_Texture* texture, SDL_BlendMode* blendMode);
 
     // Function @ SDL_render.h:443:29
-    public static int SDL_SetTextureBlendMode(SDL_Texture* texture, SDL_BlendMode blendMode)
-    {
-        return _virtualTable.SDL_SetTextureBlendMode(texture, blendMode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetTextureBlendMode(SDL_Texture* texture, SDL_BlendMode blendMode);
 
     // Function @ SDL_render.h:425:29
-    public static int SDL_GetTextureAlphaMod(SDL_Texture* texture, byte* alpha)
-    {
-        return _virtualTable.SDL_GetTextureAlphaMod(texture, alpha);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetTextureAlphaMod(SDL_Texture* texture, byte* alpha);
 
     // Function @ SDL_render.h:410:29
-    public static int SDL_SetTextureAlphaMod(SDL_Texture* texture, byte alpha)
-    {
-        return _virtualTable.SDL_SetTextureAlphaMod(texture, alpha);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetTextureAlphaMod(SDL_Texture* texture, byte alpha);
 
     // Function @ SDL_render.h:387:29
-    public static int SDL_GetTextureColorMod(SDL_Texture* texture, byte* r, byte* g, byte* b)
-    {
-        return _virtualTable.SDL_GetTextureColorMod(texture, r, g, b);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetTextureColorMod(SDL_Texture* texture, byte* r, byte* g, byte* b);
 
     // Function @ SDL_render.h:370:29
-    public static int SDL_SetTextureColorMod(SDL_Texture* texture, byte r, byte g, byte b)
-    {
-        return _virtualTable.SDL_SetTextureColorMod(texture, r, g, b);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetTextureColorMod(SDL_Texture* texture, byte r, byte g, byte b);
 
     // Function @ SDL_render.h:344:29
-    public static int SDL_QueryTexture(SDL_Texture* texture, uint* format, long* access, long* w, long* h)
-    {
-        return _virtualTable.SDL_QueryTexture(texture, format, access, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_QueryTexture(SDL_Texture* texture, uint* format, long* access, long* w, long* h);
 
     // Function @ SDL_render.h:326:39
-    public static SDL_Texture* SDL_CreateTextureFromSurface(SDL_Renderer* renderer, SDL_Surface* surface)
-    {
-        return _virtualTable.SDL_CreateTextureFromSurface(renderer, surface);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Texture* SDL_CreateTextureFromSurface(SDL_Renderer* renderer, SDL_Surface* surface);
 
     // Function @ SDL_render.h:299:39
-    public static SDL_Texture* SDL_CreateTexture(SDL_Renderer* renderer, uint format, int access, int w, int h)
-    {
-        return _virtualTable.SDL_CreateTexture(renderer, format, access, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Texture* SDL_CreateTexture(SDL_Renderer* renderer, uint format, int access, int w, int h);
 
     // Function @ SDL_render.h:276:29
-    public static int SDL_GetRendererOutputSize(SDL_Renderer* renderer, long* w, long* h)
-    {
-        return _virtualTable.SDL_GetRendererOutputSize(renderer, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetRendererOutputSize(SDL_Renderer* renderer, long* w, long* h);
 
     // Function @ SDL_render.h:256:29
-    public static int SDL_GetRendererInfo(SDL_Renderer* renderer, SDL_RendererInfo* info)
-    {
-        return _virtualTable.SDL_GetRendererInfo(renderer, info);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetRendererInfo(SDL_Renderer* renderer, SDL_RendererInfo* info);
 
     // Function @ SDL_render.h:243:40
-    public static SDL_Renderer* SDL_GetRenderer(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetRenderer(window);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Renderer* SDL_GetRenderer(SDL_Window* window);
 
     // Function @ SDL_render.h:232:40
-    public static SDL_Renderer* SDL_CreateSoftwareRenderer(SDL_Surface* surface)
-    {
-        return _virtualTable.SDL_CreateSoftwareRenderer(surface);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Renderer* SDL_CreateSoftwareRenderer(SDL_Surface* surface);
 
     // Function @ SDL_render.h:212:40
-    public static SDL_Renderer* SDL_CreateRenderer(SDL_Window* window, int index, uint flags)
-    {
-        return _virtualTable.SDL_CreateRenderer(window, index, flags);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Renderer* SDL_CreateRenderer(SDL_Window* window, int index, uint flags);
 
     // Function @ SDL_render.h:192:29
-    public static int SDL_CreateWindowAndRenderer(int width, int height, uint window_flags, SDL_Window** window, SDL_Renderer** renderer)
-    {
-        return _virtualTable.SDL_CreateWindowAndRenderer(width, height, window_flags, window, renderer);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_CreateWindowAndRenderer(int width, int height, uint window_flags, SDL_Window** window, SDL_Renderer** renderer);
 
     // Function @ SDL_render.h:174:29
-    public static int SDL_GetRenderDriverInfo(int index, SDL_RendererInfo* info)
-    {
-        return _virtualTable.SDL_GetRenderDriverInfo(index, info);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetRenderDriverInfo(int index, SDL_RendererInfo* info);
 
     // Function @ SDL_render.h:160:29
-    public static int SDL_GetNumRenderDrivers()
-    {
-        return _virtualTable.SDL_GetNumRenderDrivers();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetNumRenderDrivers();
 
     // Function @ SDL_power.h:76:40
-    public static SDL_PowerState SDL_GetPowerInfo(long* secs, long* pct)
-    {
-        return _virtualTable.SDL_GetPowerInfo(secs, pct);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_PowerState SDL_GetPowerInfo(long* secs, long* pct);
 
     // Function @ SDL_metal.h:106:30
-    public static void SDL_Metal_GetDrawableSize(SDL_Window* window, long* w, long* h)
-    {
-        _virtualTable.SDL_Metal_GetDrawableSize(window, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_Metal_GetDrawableSize(SDL_Window* window, long* w, long* h);
 
     // Function @ SDL_metal.h:83:31
-    public static void* SDL_Metal_GetLayer(SDL_MetalView view)
-    {
-        return _virtualTable.SDL_Metal_GetLayer(view);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_Metal_GetLayer(SDL_MetalView view);
 
     // Function @ SDL_metal.h:76:30
-    public static void SDL_Metal_DestroyView(SDL_MetalView view)
-    {
-        _virtualTable.SDL_Metal_DestroyView(view);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_Metal_DestroyView(SDL_MetalView view);
 
     // Function @ SDL_metal.h:66:39
-    public static SDL_MetalView SDL_Metal_CreateView(SDL_Window* window)
-    {
-        return _virtualTable.SDL_Metal_CreateView(window);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_MetalView SDL_Metal_CreateView(SDL_Window* window);
 
     // Function @ SDL_messagebox.h:180:29
-    public static int SDL_ShowSimpleMessageBox(uint flags, CString title, CString message, SDL_Window* window)
-    {
-        return _virtualTable.SDL_ShowSimpleMessageBox(flags, title, message, window);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_ShowSimpleMessageBox(uint flags, CString title, CString message, SDL_Window* window);
 
     // Function @ SDL_messagebox.h:140:29
-    public static int SDL_ShowMessageBox(SDL_MessageBoxData* messageboxdata, long* buttonid)
-    {
-        return _virtualTable.SDL_ShowMessageBox(messageboxdata, buttonid);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_ShowMessageBox(SDL_MessageBoxData* messageboxdata, long* buttonid);
 
     // Function @ SDL_log.h:364:30
-    public static void SDL_LogSetOutputFunction(SDL_LogOutputFunction callback, void* userdata)
-    {
-        _virtualTable.SDL_LogSetOutputFunction(callback, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogSetOutputFunction(SDL_LogOutputFunction callback, void* userdata);
 
     // Function @ SDL_log.h:354:30
-    public static void SDL_LogGetOutputFunction(SDL_LogOutputFunction* callback, void** userdata)
-    {
-        _virtualTable.SDL_LogGetOutputFunction(callback, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogGetOutputFunction(SDL_LogOutputFunction* callback, void** userdata);
 
     // Function @ SDL_log.h:328:30
-    public static void SDL_LogMessageV(int category, SDL_LogPriority priority, CString fmt, IntPtr ap)
-    {
-        _virtualTable.SDL_LogMessageV(category, priority, fmt, ap);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogMessageV(int category, SDL_LogPriority priority, CString fmt, IntPtr ap);
 
     // Function @ SDL_log.h:305:30
-    public static void SDL_LogMessage(int category, SDL_LogPriority priority, CString fmt)
-    {
-        _virtualTable.SDL_LogMessage(category, priority, fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogMessage(int category, SDL_LogPriority priority, CString fmt);
 
     // Function @ SDL_log.h:285:30
-    public static void SDL_LogCritical(int category, CString fmt)
-    {
-        _virtualTable.SDL_LogCritical(category, fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogCritical(int category, CString fmt);
 
     // Function @ SDL_log.h:266:30
-    public static void SDL_LogError(int category, CString fmt)
-    {
-        _virtualTable.SDL_LogError(category, fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogError(int category, CString fmt);
 
     // Function @ SDL_log.h:247:30
-    public static void SDL_LogWarn(int category, CString fmt)
-    {
-        _virtualTable.SDL_LogWarn(category, fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogWarn(int category, CString fmt);
 
     // Function @ SDL_log.h:228:30
-    public static void SDL_LogInfo(int category, CString fmt)
-    {
-        _virtualTable.SDL_LogInfo(category, fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogInfo(int category, CString fmt);
 
     // Function @ SDL_log.h:209:30
-    public static void SDL_LogDebug(int category, CString fmt)
-    {
-        _virtualTable.SDL_LogDebug(category, fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogDebug(int category, CString fmt);
 
     // Function @ SDL_log.h:190:30
-    public static void SDL_LogVerbose(int category, CString fmt)
-    {
-        _virtualTable.SDL_LogVerbose(category, fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogVerbose(int category, CString fmt);
 
     // Function @ SDL_log.h:171:30
-    public static void SDL_Log(CString fmt)
-    {
-        _virtualTable.SDL_Log(fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_Log(CString fmt);
 
     // Function @ SDL_log.h:153:30
-    public static void SDL_LogResetPriorities()
-    {
-        _virtualTable.SDL_LogResetPriorities();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogResetPriorities();
 
     // Function @ SDL_log.h:143:41
-    public static SDL_LogPriority SDL_LogGetPriority(int category)
-    {
-        return _virtualTable.SDL_LogGetPriority(category);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_LogPriority SDL_LogGetPriority(int category);
 
     // Function @ SDL_log.h:132:30
-    public static void SDL_LogSetPriority(int category, SDL_LogPriority priority)
-    {
-        _virtualTable.SDL_LogSetPriority(category, priority);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogSetPriority(int category, SDL_LogPriority priority);
 
     // Function @ SDL_log.h:121:30
-    public static void SDL_LogSetAllPriority(SDL_LogPriority priority)
-    {
-        _virtualTable.SDL_LogSetAllPriority(priority);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LogSetAllPriority(SDL_LogPriority priority);
 
     // Function @ SDL_loadso.h:99:30
-    public static void SDL_UnloadObject(void* handle)
-    {
-        _virtualTable.SDL_UnloadObject(handle);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_UnloadObject(void* handle);
 
     // Function @ SDL_loadso.h:88:31
-    public static void* SDL_LoadFunction(void* handle, CString name)
-    {
-        return _virtualTable.SDL_LoadFunction(handle, name);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_LoadFunction(void* handle, CString name);
 
     // Function @ SDL_loadso.h:63:31
-    public static void* SDL_LoadObject(CString sofile)
-    {
-        return _virtualTable.SDL_LoadObject(sofile);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_LoadObject(CString sofile);
 
     // Function @ SDL_hints.h:1783:30
-    public static void SDL_ClearHints()
-    {
-        _virtualTable.SDL_ClearHints();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_ClearHints();
 
     // Function @ SDL_hints.h:1774:30
-    public static void SDL_DelHintCallback(CString name, SDL_HintCallback callback, void* userdata)
-    {
-        _virtualTable.SDL_DelHintCallback(name, callback, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DelHintCallback(CString name, SDL_HintCallback callback, void* userdata);
 
     // Function @ SDL_hints.h:1758:30
-    public static void SDL_AddHintCallback(CString name, SDL_HintCallback callback, void* userdata)
-    {
-        _virtualTable.SDL_AddHintCallback(name, callback, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_AddHintCallback(CString name, SDL_HintCallback callback, void* userdata);
 
     // Function @ SDL_hints.h:1734:34
-    public static CBool SDL_GetHintBoolean(CString name, CBool default_value)
-    {
-        return _virtualTable.SDL_GetHintBoolean(name, default_value);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GetHintBoolean(CString name, CBool default_value);
 
     // Function @ SDL_hints.h:1719:38
-    public static CString SDL_GetHint(CString name)
-    {
-        return _virtualTable.SDL_GetHint(name);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetHint(CString name);
 
     // Function @ SDL_hints.h:1707:34
-    public static CBool SDL_SetHint(CString name, CString value)
-    {
-        return _virtualTable.SDL_SetHint(name, value);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_SetHint(CString name, CString value);
 
     // Function @ SDL_hints.h:1689:34
-    public static CBool SDL_SetHintWithPriority(CString name, CString value, SDL_HintPriority priority)
-    {
-        return _virtualTable.SDL_SetHintWithPriority(name, value, priority);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_SetHintWithPriority(CString name, CString value, SDL_HintPriority priority);
 
     // Function @ SDL_haptic.h:1311:29
-    public static int SDL_HapticRumbleStop(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticRumbleStop(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticRumbleStop(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:1298:29
-    public static int SDL_HapticRumblePlay(SDL_Haptic* haptic, float strength, uint length)
-    {
-        return _virtualTable.SDL_HapticRumblePlay(haptic, strength, length);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticRumblePlay(SDL_Haptic* haptic, float strength, uint length);
 
     // Function @ SDL_haptic.h:1283:29
-    public static int SDL_HapticRumbleInit(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticRumbleInit(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticRumbleInit(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:1267:29
-    public static int SDL_HapticRumbleSupported(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticRumbleSupported(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticRumbleSupported(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:1253:29
-    public static int SDL_HapticStopAll(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticStopAll(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticStopAll(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:1244:29
-    public static int SDL_HapticUnpause(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticUnpause(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticUnpause(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:1231:29
-    public static int SDL_HapticPause(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticPause(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticPause(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:1213:29
-    public static int SDL_HapticSetAutocenter(SDL_Haptic* haptic, int autocenter)
-    {
-        return _virtualTable.SDL_HapticSetAutocenter(haptic, autocenter);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticSetAutocenter(SDL_Haptic* haptic, int autocenter);
 
     // Function @ SDL_haptic.h:1196:29
-    public static int SDL_HapticSetGain(SDL_Haptic* haptic, int gain)
-    {
-        return _virtualTable.SDL_HapticSetGain(haptic, gain);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticSetGain(SDL_Haptic* haptic, int gain);
 
     // Function @ SDL_haptic.h:1174:29
-    public static int SDL_HapticGetEffectStatus(SDL_Haptic* haptic, int effect)
-    {
-        return _virtualTable.SDL_HapticGetEffectStatus(haptic, effect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticGetEffectStatus(SDL_Haptic* haptic, int effect);
 
     // Function @ SDL_haptic.h:1155:30
-    public static void SDL_HapticDestroyEffect(SDL_Haptic* haptic, int effect)
-    {
-        _virtualTable.SDL_HapticDestroyEffect(haptic, effect);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_HapticDestroyEffect(SDL_Haptic* haptic, int effect);
 
     // Function @ SDL_haptic.h:1139:29
-    public static int SDL_HapticStopEffect(SDL_Haptic* haptic, int effect)
-    {
-        return _virtualTable.SDL_HapticStopEffect(haptic, effect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticStopEffect(SDL_Haptic* haptic, int effect);
 
     // Function @ SDL_haptic.h:1122:29
-    public static int SDL_HapticRunEffect(SDL_Haptic* haptic, int effect, uint iterations)
-    {
-        return _virtualTable.SDL_HapticRunEffect(haptic, effect, iterations);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticRunEffect(SDL_Haptic* haptic, int effect, uint iterations);
 
     // Function @ SDL_haptic.h:1096:29
-    public static int SDL_HapticUpdateEffect(SDL_Haptic* haptic, int effect, SDL_HapticEffect* data)
-    {
-        return _virtualTable.SDL_HapticUpdateEffect(haptic, effect, data);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticUpdateEffect(SDL_Haptic* haptic, int effect, SDL_HapticEffect* data);
 
     // Function @ SDL_haptic.h:1072:29
-    public static int SDL_HapticNewEffect(SDL_Haptic* haptic, SDL_HapticEffect* effect)
-    {
-        return _virtualTable.SDL_HapticNewEffect(haptic, effect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticNewEffect(SDL_Haptic* haptic, SDL_HapticEffect* effect);
 
     // Function @ SDL_haptic.h:1055:29
-    public static int SDL_HapticEffectSupported(SDL_Haptic* haptic, SDL_HapticEffect* effect)
-    {
-        return _virtualTable.SDL_HapticEffectSupported(haptic, effect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticEffectSupported(SDL_Haptic* haptic, SDL_HapticEffect* effect);
 
     // Function @ SDL_haptic.h:1038:29
-    public static int SDL_HapticNumAxes(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticNumAxes(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticNumAxes(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:1025:38
-    public static uint SDL_HapticQuery(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticQuery(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_HapticQuery(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:1011:29
-    public static int SDL_HapticNumEffectsPlaying(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticNumEffectsPlaying(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticNumEffectsPlaying(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:993:29
-    public static int SDL_HapticNumEffects(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticNumEffects(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticNumEffects(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:975:30
-    public static void SDL_HapticClose(SDL_Haptic* haptic)
-    {
-        _virtualTable.SDL_HapticClose(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_HapticClose(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:965:37
-    public static SDL_Haptic* SDL_HapticOpenFromJoystick(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_HapticOpenFromJoystick(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Haptic* SDL_HapticOpenFromJoystick(SDL_Joystick* joystick);
 
     // Function @ SDL_haptic.h:942:29
-    public static int SDL_JoystickIsHaptic(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickIsHaptic(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickIsHaptic(SDL_Joystick* joystick);
 
     // Function @ SDL_haptic.h:928:37
-    public static SDL_Haptic* SDL_HapticOpenFromMouse()
-    {
-        return _virtualTable.SDL_HapticOpenFromMouse();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Haptic* SDL_HapticOpenFromMouse();
 
     // Function @ SDL_haptic.h:915:29
-    public static int SDL_MouseIsHaptic()
-    {
-        return _virtualTable.SDL_MouseIsHaptic();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_MouseIsHaptic();
 
     // Function @ SDL_haptic.h:904:29
-    public static int SDL_HapticIndex(SDL_Haptic* haptic)
-    {
-        return _virtualTable.SDL_HapticIndex(haptic);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticIndex(SDL_Haptic* haptic);
 
     // Function @ SDL_haptic.h:890:29
-    public static int SDL_HapticOpened(int device_index)
-    {
-        return _virtualTable.SDL_HapticOpened(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_HapticOpened(int device_index);
 
     // Function @ SDL_haptic.h:876:37
-    public static SDL_Haptic* SDL_HapticOpen(int device_index)
-    {
-        return _virtualTable.SDL_HapticOpen(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Haptic* SDL_HapticOpen(int device_index);
 
     // Function @ SDL_haptic.h:849:37
-    public static CString SDL_HapticName(int device_index)
-    {
-        return _virtualTable.SDL_HapticName(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_HapticName(int device_index);
 
     // Function @ SDL_haptic.h:833:29
-    public static int SDL_NumHaptics()
-    {
-        return _virtualTable.SDL_NumHaptics();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_NumHaptics();
 
     // Function @ SDL_filesystem.h:135:31
-    public static CString SDL_GetPrefPath(CString org, CString app)
-    {
-        return _virtualTable.SDL_GetPrefPath(org, app);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetPrefPath(CString org, CString app);
 
     // Function @ SDL_filesystem.h:78:31
-    public static CString SDL_GetBasePath()
-    {
-        return _virtualTable.SDL_GetBasePath();
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetBasePath();
 
     // Function @ SDL_events.h:1084:32
-    public static uint SDL_RegisterEvents(int numevents)
-    {
-        return _virtualTable.SDL_RegisterEvents(numevents);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_RegisterEvents(int numevents);
 
     // Function @ SDL_events.h:1062:31
-    public static byte SDL_EventState(uint type, int state)
-    {
-        return _virtualTable.SDL_EventState(type, state);
-    }
+    [DllImport("SDL2")]
+    public static extern byte SDL_EventState(uint type, int state);
 
     // Function @ SDL_events.h:1036:30
-    public static void SDL_FilterEvents(SDL_EventFilter filter, void* userdata)
-    {
-        _virtualTable.SDL_FilterEvents(filter, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FilterEvents(SDL_EventFilter filter, void* userdata);
 
     // Function @ SDL_events.h:1019:30
-    public static void SDL_DelEventWatch(SDL_EventFilter filter, void* userdata)
-    {
-        _virtualTable.SDL_DelEventWatch(filter, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DelEventWatch(SDL_EventFilter filter, void* userdata);
 
     // Function @ SDL_events.h:1004:30
-    public static void SDL_AddEventWatch(SDL_EventFilter filter, void* userdata)
-    {
-        _virtualTable.SDL_AddEventWatch(filter, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_AddEventWatch(SDL_EventFilter filter, void* userdata);
 
     // Function @ SDL_events.h:977:34
-    public static CBool SDL_GetEventFilter(SDL_EventFilter* filter, void** userdata)
-    {
-        return _virtualTable.SDL_GetEventFilter(filter, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GetEventFilter(SDL_EventFilter* filter, void** userdata);
 
     // Function @ SDL_events.h:961:30
-    public static void SDL_SetEventFilter(SDL_EventFilter filter, void* userdata)
-    {
-        _virtualTable.SDL_SetEventFilter(filter, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetEventFilter(SDL_EventFilter filter, void* userdata);
 
     // Function @ SDL_events.h:904:29
-    public static int SDL_PushEvent(SDL_Event* @event)
-    {
-        return _virtualTable.SDL_PushEvent(@event);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_PushEvent(SDL_Event* @event);
 
     // Function @ SDL_events.h:871:29
-    public static int SDL_WaitEventTimeout(SDL_Event* @event, int timeout)
-    {
-        return _virtualTable.SDL_WaitEventTimeout(@event, timeout);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_WaitEventTimeout(SDL_Event* @event, int timeout);
 
     // Function @ SDL_events.h:847:29
-    public static int SDL_WaitEvent(SDL_Event* @event)
-    {
-        return _virtualTable.SDL_WaitEvent(@event);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_WaitEvent(SDL_Event* @event);
 
     // Function @ SDL_events.h:827:29
-    public static int SDL_PollEvent(SDL_Event* @event)
-    {
-        return _virtualTable.SDL_PollEvent(@event);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_PollEvent(SDL_Event* @event);
 
     // Function @ SDL_events.h:782:30
-    public static void SDL_FlushEvents(uint minType, uint maxType)
-    {
-        _virtualTable.SDL_FlushEvents(minType, maxType);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FlushEvents(uint minType, uint maxType);
 
     // Function @ SDL_events.h:759:30
-    public static void SDL_FlushEvent(uint type)
-    {
-        _virtualTable.SDL_FlushEvent(type);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FlushEvent(uint type);
 
     // Function @ SDL_events.h:739:34
-    public static CBool SDL_HasEvents(uint minType, uint maxType)
-    {
-        return _virtualTable.SDL_HasEvents(minType, maxType);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasEvents(uint minType, uint maxType);
 
     // Function @ SDL_events.h:722:34
-    public static CBool SDL_HasEvent(uint type)
-    {
-        return _virtualTable.SDL_HasEvent(type);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasEvent(uint type);
 
     // Function @ SDL_events.h:705:29
-    public static int SDL_PeepEvents(SDL_Event* events, int numevents, SDL_eventaction action, uint minType, uint maxType)
-    {
-        return _virtualTable.SDL_PeepEvents(events, numevents, action, minType, maxType);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_PeepEvents(SDL_Event* events, int numevents, SDL_eventaction action, uint minType, uint maxType);
 
     // Function @ SDL_events.h:659:30
-    public static void SDL_PumpEvents()
-    {
-        _virtualTable.SDL_PumpEvents();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_PumpEvents();
 
     // Function @ SDL_gesture.h:107:29
-    public static int SDL_LoadDollarTemplates(SDL_TouchID touchId, SDL_RWops* src)
-    {
-        return _virtualTable.SDL_LoadDollarTemplates(touchId, src);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_LoadDollarTemplates(SDL_TouchID touchId, SDL_RWops* src);
 
     // Function @ SDL_gesture.h:91:29
-    public static int SDL_SaveDollarTemplate(SDL_GestureID gestureId, SDL_RWops* dst)
-    {
-        return _virtualTable.SDL_SaveDollarTemplate(gestureId, dst);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SaveDollarTemplate(SDL_GestureID gestureId, SDL_RWops* dst);
 
     // Function @ SDL_gesture.h:76:29
-    public static int SDL_SaveAllDollarTemplates(SDL_RWops* dst)
-    {
-        return _virtualTable.SDL_SaveAllDollarTemplates(dst);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SaveAllDollarTemplates(SDL_RWops* dst);
 
     // Function @ SDL_gesture.h:61:29
-    public static int SDL_RecordGesture(SDL_TouchID touchId)
-    {
-        return _virtualTable.SDL_RecordGesture(touchId);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RecordGesture(SDL_TouchID touchId);
 
     // Function @ SDL_touch.h:128:38
-    public static SDL_Finger* SDL_GetTouchFinger(SDL_TouchID touchID, int index)
-    {
-        return _virtualTable.SDL_GetTouchFinger(touchID, index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Finger* SDL_GetTouchFinger(SDL_TouchID touchID, int index);
 
     // Function @ SDL_touch.h:114:29
-    public static int SDL_GetNumTouchFingers(SDL_TouchID touchID)
-    {
-        return _virtualTable.SDL_GetNumTouchFingers(touchID);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetNumTouchFingers(SDL_TouchID touchID);
 
     // Function @ SDL_touch.h:101:45
-    public static SDL_TouchDeviceType SDL_GetTouchDeviceType(SDL_TouchID touchID)
-    {
-        return _virtualTable.SDL_GetTouchDeviceType(touchID);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_TouchDeviceType SDL_GetTouchDeviceType(SDL_TouchID touchID);
 
     // Function @ SDL_touch.h:96:37
-    public static SDL_TouchID SDL_GetTouchDevice(int index)
-    {
-        return _virtualTable.SDL_GetTouchDevice(index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_TouchID SDL_GetTouchDevice(int index);
 
     // Function @ SDL_touch.h:83:29
-    public static int SDL_GetNumTouchDevices()
-    {
-        return _virtualTable.SDL_GetNumTouchDevices();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetNumTouchDevices();
 
     // Function @ SDL_gamecontroller.h:831:30
-    public static void SDL_GameControllerClose(SDL_GameController* gamecontroller)
-    {
-        _virtualTable.SDL_GameControllerClose(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GameControllerClose(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:821:29
-    public static int SDL_GameControllerSetLED(SDL_GameController* gamecontroller, byte red, byte green, byte blue)
-    {
-        return _virtualTable.SDL_GameControllerSetLED(gamecontroller, red, green, blue);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerSetLED(SDL_GameController* gamecontroller, byte red, byte green, byte blue);
 
     // Function @ SDL_gamecontroller.h:810:34
-    public static CBool SDL_GameControllerHasLED(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerHasLED(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GameControllerHasLED(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:801:29
-    public static int SDL_GameControllerRumbleTriggers(SDL_GameController* gamecontroller, ushort left_rumble, ushort right_rumble, uint duration_ms)
-    {
-        return _virtualTable.SDL_GameControllerRumbleTriggers(gamecontroller, left_rumble, right_rumble, duration_ms);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerRumbleTriggers(SDL_GameController* gamecontroller, ushort left_rumble, ushort right_rumble, uint duration_ms);
 
     // Function @ SDL_gamecontroller.h:781:29
-    public static int SDL_GameControllerRumble(SDL_GameController* gamecontroller, ushort low_frequency_rumble, ushort high_frequency_rumble, uint duration_ms)
-    {
-        return _virtualTable.SDL_GameControllerRumble(gamecontroller, low_frequency_rumble, high_frequency_rumble, duration_ms);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerRumble(SDL_GameController* gamecontroller, ushort low_frequency_rumble, ushort high_frequency_rumble, uint duration_ms);
 
     // Function @ SDL_gamecontroller.h:765:29
-    public static int SDL_GameControllerGetSensorData(SDL_GameController* gamecontroller, SDL_SensorType type, float* data, int num_values)
-    {
-        return _virtualTable.SDL_GameControllerGetSensorData(gamecontroller, type, data, num_values);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerGetSensorData(SDL_GameController* gamecontroller, SDL_SensorType type, float* data, int num_values);
 
     // Function @ SDL_gamecontroller.h:751:34
-    public static CBool SDL_GameControllerIsSensorEnabled(SDL_GameController* gamecontroller, SDL_SensorType type)
-    {
-        return _virtualTable.SDL_GameControllerIsSensorEnabled(gamecontroller, type);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GameControllerIsSensorEnabled(SDL_GameController* gamecontroller, SDL_SensorType type);
 
     // Function @ SDL_gamecontroller.h:741:29
-    public static int SDL_GameControllerSetSensorEnabled(SDL_GameController* gamecontroller, SDL_SensorType type, CBool enabled)
-    {
-        return _virtualTable.SDL_GameControllerSetSensorEnabled(gamecontroller, type, enabled);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerSetSensorEnabled(SDL_GameController* gamecontroller, SDL_SensorType type, CBool enabled);
 
     // Function @ SDL_gamecontroller.h:730:34
-    public static CBool SDL_GameControllerHasSensor(SDL_GameController* gamecontroller, SDL_SensorType type)
-    {
-        return _virtualTable.SDL_GameControllerHasSensor(gamecontroller, type);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GameControllerHasSensor(SDL_GameController* gamecontroller, SDL_SensorType type);
 
     // Function @ SDL_gamecontroller.h:720:29
-    public static int SDL_GameControllerGetTouchpadFinger(SDL_GameController* gamecontroller, int touchpad, int finger, byte* state, float* x, float* y, float* pressure)
-    {
-        return _virtualTable.SDL_GameControllerGetTouchpadFinger(gamecontroller, touchpad, finger, state, x, y, pressure);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerGetTouchpadFinger(SDL_GameController* gamecontroller, int touchpad, int finger, byte* state, float* x, float* y, float* pressure);
 
     // Function @ SDL_gamecontroller.h:715:29
-    public static int SDL_GameControllerGetNumTouchpadFingers(SDL_GameController* gamecontroller, int touchpad)
-    {
-        return _virtualTable.SDL_GameControllerGetNumTouchpadFingers(gamecontroller, touchpad);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerGetNumTouchpadFingers(SDL_GameController* gamecontroller, int touchpad);
 
     // Function @ SDL_gamecontroller.h:710:29
-    public static int SDL_GameControllerGetNumTouchpads(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerGetNumTouchpads(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerGetNumTouchpads(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:704:31
-    public static byte SDL_GameControllerGetButton(SDL_GameController* gamecontroller, SDL_GameControllerButton button)
-    {
-        return _virtualTable.SDL_GameControllerGetButton(gamecontroller, button);
-    }
+    [DllImport("SDL2")]
+    public static extern byte SDL_GameControllerGetButton(SDL_GameController* gamecontroller, SDL_GameControllerButton button);
 
     // Function @ SDL_gamecontroller.h:689:34
-    public static CBool SDL_GameControllerHasButton(SDL_GameController* gamecontroller, SDL_GameControllerButton button)
-    {
-        return _virtualTable.SDL_GameControllerHasButton(gamecontroller, button);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GameControllerHasButton(SDL_GameController* gamecontroller, SDL_GameControllerButton button);
 
     // Function @ SDL_gamecontroller.h:676:1
-    public static SDL_GameControllerButtonBind SDL_GameControllerGetBindForButton(SDL_GameController* gamecontroller, SDL_GameControllerButton button)
-    {
-        return _virtualTable.SDL_GameControllerGetBindForButton(gamecontroller, button);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GameControllerButtonBind SDL_GameControllerGetBindForButton(SDL_GameController* gamecontroller, SDL_GameControllerButton button);
 
     // Function @ SDL_gamecontroller.h:660:37
-    public static CString SDL_GameControllerGetStringForButton(SDL_GameControllerButton button)
-    {
-        return _virtualTable.SDL_GameControllerGetStringForButton(button);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GameControllerGetStringForButton(SDL_GameControllerButton button);
 
     // Function @ SDL_gamecontroller.h:644:50
-    public static SDL_GameControllerButton SDL_GameControllerGetButtonFromString(CString str)
-    {
-        return _virtualTable.SDL_GameControllerGetButtonFromString(str);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GameControllerButton SDL_GameControllerGetButtonFromString(CString str);
 
     // Function @ SDL_gamecontroller.h:599:1
-    public static short SDL_GameControllerGetAxis(SDL_GameController* gamecontroller, SDL_GameControllerAxis axis)
-    {
-        return _virtualTable.SDL_GameControllerGetAxis(gamecontroller, axis);
-    }
+    [DllImport("SDL2")]
+    public static extern short SDL_GameControllerGetAxis(SDL_GameController* gamecontroller, SDL_GameControllerAxis axis);
 
     // Function @ SDL_gamecontroller.h:579:1
-    public static CBool SDL_GameControllerHasAxis(SDL_GameController* gamecontroller, SDL_GameControllerAxis axis)
-    {
-        return _virtualTable.SDL_GameControllerHasAxis(gamecontroller, axis);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GameControllerHasAxis(SDL_GameController* gamecontroller, SDL_GameControllerAxis axis);
 
     // Function @ SDL_gamecontroller.h:565:1
-    public static SDL_GameControllerButtonBind SDL_GameControllerGetBindForAxis(SDL_GameController* gamecontroller, SDL_GameControllerAxis axis)
-    {
-        return _virtualTable.SDL_GameControllerGetBindForAxis(gamecontroller, axis);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GameControllerButtonBind SDL_GameControllerGetBindForAxis(SDL_GameController* gamecontroller, SDL_GameControllerAxis axis);
 
     // Function @ SDL_gamecontroller.h:549:37
-    public static CString SDL_GameControllerGetStringForAxis(SDL_GameControllerAxis axis)
-    {
-        return _virtualTable.SDL_GameControllerGetStringForAxis(axis);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GameControllerGetStringForAxis(SDL_GameControllerAxis axis);
 
     // Function @ SDL_gamecontroller.h:535:48
-    public static SDL_GameControllerAxis SDL_GameControllerGetAxisFromString(CString str)
-    {
-        return _virtualTable.SDL_GameControllerGetAxisFromString(str);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GameControllerAxis SDL_GameControllerGetAxisFromString(CString str);
 
     // Function @ SDL_gamecontroller.h:497:30
-    public static void SDL_GameControllerUpdate()
-    {
-        _virtualTable.SDL_GameControllerUpdate();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GameControllerUpdate();
 
     // Function @ SDL_gamecontroller.h:488:29
-    public static int SDL_GameControllerEventState(int state)
-    {
-        return _virtualTable.SDL_GameControllerEventState(state);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerEventState(int state);
 
     // Function @ SDL_gamecontroller.h:468:39
-    public static SDL_Joystick* SDL_GameControllerGetJoystick(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerGetJoystick(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Joystick* SDL_GameControllerGetJoystick(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:449:34
-    public static CBool SDL_GameControllerGetAttached(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerGetAttached(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GameControllerGetAttached(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:436:38
-    public static CString SDL_GameControllerGetSerial(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerGetSerial(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GameControllerGetSerial(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:426:32
-    public static ushort SDL_GameControllerGetProductVersion(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerGetProductVersion(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_GameControllerGetProductVersion(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:416:32
-    public static ushort SDL_GameControllerGetProduct(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerGetProduct(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_GameControllerGetProduct(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:406:32
-    public static ushort SDL_GameControllerGetVendor(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerGetVendor(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_GameControllerGetVendor(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:396:30
-    public static void SDL_GameControllerSetPlayerIndex(SDL_GameController* gamecontroller, int player_index)
-    {
-        _virtualTable.SDL_GameControllerSetPlayerIndex(gamecontroller, player_index);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GameControllerSetPlayerIndex(SDL_GameController* gamecontroller, int player_index);
 
     // Function @ SDL_gamecontroller.h:388:29
-    public static int SDL_GameControllerGetPlayerIndex(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerGetPlayerIndex(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerGetPlayerIndex(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:378:48
-    public static SDL_GameControllerType SDL_GameControllerGetType(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerGetType(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GameControllerType SDL_GameControllerGetType(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:367:37
-    public static CString SDL_GameControllerName(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerName(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GameControllerName(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:349:45
-    public static SDL_GameController* SDL_GameControllerFromPlayerIndex(int player_index)
-    {
-        return _virtualTable.SDL_GameControllerFromPlayerIndex(player_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GameController* SDL_GameControllerFromPlayerIndex(int player_index);
 
     // Function @ SDL_gamecontroller.h:334:45
-    public static SDL_GameController* SDL_GameControllerFromInstanceID(SDL_JoystickID joyid)
-    {
-        return _virtualTable.SDL_GameControllerFromInstanceID(joyid);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GameController* SDL_GameControllerFromInstanceID(SDL_JoystickID joyid);
 
     // Function @ SDL_gamecontroller.h:323:45
-    public static SDL_GameController* SDL_GameControllerOpen(int joystick_index)
-    {
-        return _virtualTable.SDL_GameControllerOpen(joystick_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GameController* SDL_GameControllerOpen(int joystick_index);
 
     // Function @ SDL_gamecontroller.h:299:31
-    public static CString SDL_GameControllerMappingForDeviceIndex(int joystick_index)
-    {
-        return _virtualTable.SDL_GameControllerMappingForDeviceIndex(joystick_index);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GameControllerMappingForDeviceIndex(int joystick_index);
 
     // Function @ SDL_gamecontroller.h:287:48
-    public static SDL_GameControllerType SDL_GameControllerTypeForIndex(int joystick_index)
-    {
-        return _virtualTable.SDL_GameControllerTypeForIndex(joystick_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GameControllerType SDL_GameControllerTypeForIndex(int joystick_index);
 
     // Function @ SDL_gamecontroller.h:276:37
-    public static CString SDL_GameControllerNameForIndex(int joystick_index)
-    {
-        return _virtualTable.SDL_GameControllerNameForIndex(joystick_index);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GameControllerNameForIndex(int joystick_index);
 
     // Function @ SDL_gamecontroller.h:254:34
-    public static CBool SDL_IsGameController(int joystick_index)
-    {
-        return _virtualTable.SDL_IsGameController(joystick_index);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_IsGameController(int joystick_index);
 
     // Function @ SDL_gamecontroller.h:236:32
-    public static CString SDL_GameControllerMapping(SDL_GameController* gamecontroller)
-    {
-        return _virtualTable.SDL_GameControllerMapping(gamecontroller);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GameControllerMapping(SDL_GameController* gamecontroller);
 
     // Function @ SDL_gamecontroller.h:217:32
-    public static CString SDL_GameControllerMappingForGUID(SDL_JoystickGUID guid)
-    {
-        return _virtualTable.SDL_GameControllerMappingForGUID(guid);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GameControllerMappingForGUID(SDL_JoystickGUID guid);
 
     // Function @ SDL_gamecontroller.h:203:32
-    public static CString SDL_GameControllerMappingForIndex(int mapping_index)
-    {
-        return _virtualTable.SDL_GameControllerMappingForIndex(mapping_index);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GameControllerMappingForIndex(int mapping_index);
 
     // Function @ SDL_gamecontroller.h:195:29
-    public static int SDL_GameControllerNumMappings()
-    {
-        return _virtualTable.SDL_GameControllerNumMappings();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerNumMappings();
 
     // Function @ SDL_gamecontroller.h:188:29
-    public static int SDL_GameControllerAddMapping(CString mappingString)
-    {
-        return _virtualTable.SDL_GameControllerAddMapping(mappingString);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerAddMapping(CString mappingString);
 
     // Function @ SDL_gamecontroller.h:154:29
-    public static int SDL_GameControllerAddMappingsFromRW(SDL_RWops* rw, int freerw)
-    {
-        return _virtualTable.SDL_GameControllerAddMappingsFromRW(rw, freerw);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GameControllerAddMappingsFromRW(SDL_RWops* rw, int freerw);
 
     // Function @ SDL_sensor.h:258:30
-    public static void SDL_SensorUpdate()
-    {
-        _virtualTable.SDL_SensorUpdate();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SensorUpdate();
 
     // Function @ SDL_sensor.h:247:30
-    public static void SDL_SensorClose(SDL_Sensor* sensor)
-    {
-        _virtualTable.SDL_SensorClose(sensor);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SensorClose(SDL_Sensor* sensor);
 
     // Function @ SDL_sensor.h:240:29
-    public static int SDL_SensorGetData(SDL_Sensor* sensor, float* data, int num_values)
-    {
-        return _virtualTable.SDL_SensorGetData(sensor, data, num_values);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SensorGetData(SDL_Sensor* sensor, float* data, int num_values);
 
     // Function @ SDL_sensor.h:228:38
-    public static SDL_SensorID SDL_SensorGetInstanceID(SDL_Sensor* sensor)
-    {
-        return _virtualTable.SDL_SensorGetInstanceID(sensor);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_SensorID SDL_SensorGetInstanceID(SDL_Sensor* sensor);
 
     // Function @ SDL_sensor.h:220:29
-    public static int SDL_SensorGetNonPortableType(SDL_Sensor* sensor)
-    {
-        return _virtualTable.SDL_SensorGetNonPortableType(sensor);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SensorGetNonPortableType(SDL_Sensor* sensor);
 
     // Function @ SDL_sensor.h:212:40
-    public static SDL_SensorType SDL_SensorGetType(SDL_Sensor* sensor)
-    {
-        return _virtualTable.SDL_SensorGetType(sensor);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_SensorType SDL_SensorGetType(SDL_Sensor* sensor);
 
     // Function @ SDL_sensor.h:203:37
-    public static CString SDL_SensorGetName(SDL_Sensor* sensor)
-    {
-        return _virtualTable.SDL_SensorGetName(sensor);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_SensorGetName(SDL_Sensor* sensor);
 
     // Function @ SDL_sensor.h:195:37
-    public static SDL_Sensor* SDL_SensorFromInstanceID(SDL_SensorID instance_id)
-    {
-        return _virtualTable.SDL_SensorFromInstanceID(instance_id);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Sensor* SDL_SensorFromInstanceID(SDL_SensorID instance_id);
 
     // Function @ SDL_sensor.h:187:37
-    public static SDL_Sensor* SDL_SensorOpen(int device_index)
-    {
-        return _virtualTable.SDL_SensorOpen(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Sensor* SDL_SensorOpen(int device_index);
 
     // Function @ SDL_sensor.h:179:38
-    public static SDL_SensorID SDL_SensorGetDeviceInstanceID(int device_index)
-    {
-        return _virtualTable.SDL_SensorGetDeviceInstanceID(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_SensorID SDL_SensorGetDeviceInstanceID(int device_index);
 
     // Function @ SDL_sensor.h:171:29
-    public static int SDL_SensorGetDeviceNonPortableType(int device_index)
-    {
-        return _virtualTable.SDL_SensorGetDeviceNonPortableType(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SensorGetDeviceNonPortableType(int device_index);
 
     // Function @ SDL_sensor.h:162:40
-    public static SDL_SensorType SDL_SensorGetDeviceType(int device_index)
-    {
-        return _virtualTable.SDL_SensorGetDeviceType(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_SensorType SDL_SensorGetDeviceType(int device_index);
 
     // Function @ SDL_sensor.h:153:37
-    public static CString SDL_SensorGetDeviceName(int device_index)
-    {
-        return _virtualTable.SDL_SensorGetDeviceName(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_SensorGetDeviceName(int device_index);
 
     // Function @ SDL_sensor.h:145:29
-    public static int SDL_NumSensors()
-    {
-        return _virtualTable.SDL_NumSensors();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_NumSensors();
 
     // Function @ SDL_sensor.h:138:30
-    public static void SDL_UnlockSensors()
-    {
-        _virtualTable.SDL_UnlockSensors();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_UnlockSensors();
 
     // Function @ SDL_sensor.h:137:30
-    public static void SDL_LockSensors()
-    {
-        _virtualTable.SDL_LockSensors();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LockSensors();
 
     // Function @ SDL_joystick.h:803:48
-    public static SDL_JoystickPowerLevel SDL_JoystickCurrentPowerLevel(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickCurrentPowerLevel(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_JoystickPowerLevel SDL_JoystickCurrentPowerLevel(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:792:30
-    public static void SDL_JoystickClose(SDL_Joystick* joystick)
-    {
-        _virtualTable.SDL_JoystickClose(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_JoystickClose(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:783:29
-    public static int SDL_JoystickSetLED(SDL_Joystick* joystick, byte red, byte green, byte blue)
-    {
-        return _virtualTable.SDL_JoystickSetLED(joystick, red, green, blue);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickSetLED(SDL_Joystick* joystick, byte red, byte green, byte blue);
 
     // Function @ SDL_joystick.h:768:34
-    public static CBool SDL_JoystickHasLED(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickHasLED(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_JoystickHasLED(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:757:29
-    public static int SDL_JoystickRumbleTriggers(SDL_Joystick* joystick, ushort left_rumble, ushort right_rumble, uint duration_ms)
-    {
-        return _virtualTable.SDL_JoystickRumbleTriggers(joystick, left_rumble, right_rumble, duration_ms);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickRumbleTriggers(SDL_Joystick* joystick, ushort left_rumble, ushort right_rumble, uint duration_ms);
 
     // Function @ SDL_joystick.h:736:29
-    public static int SDL_JoystickRumble(SDL_Joystick* joystick, ushort low_frequency_rumble, ushort high_frequency_rumble, uint duration_ms)
-    {
-        return _virtualTable.SDL_JoystickRumble(joystick, low_frequency_rumble, high_frequency_rumble, duration_ms);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickRumble(SDL_Joystick* joystick, ushort low_frequency_rumble, ushort high_frequency_rumble, uint duration_ms);
 
     // Function @ SDL_joystick.h:718:31
-    public static byte SDL_JoystickGetButton(SDL_Joystick* joystick, int button)
-    {
-        return _virtualTable.SDL_JoystickGetButton(joystick, button);
-    }
+    [DllImport("SDL2")]
+    public static extern byte SDL_JoystickGetButton(SDL_Joystick* joystick, int button);
 
     // Function @ SDL_joystick.h:705:29
-    public static int SDL_JoystickGetBall(SDL_Joystick* joystick, int ball, long* dx, long* dy)
-    {
-        return _virtualTable.SDL_JoystickGetBall(joystick, ball, dx, dy);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickGetBall(SDL_Joystick* joystick, int ball, long* dx, long* dy);
 
     // Function @ SDL_joystick.h:684:31
-    public static byte SDL_JoystickGetHat(SDL_Joystick* joystick, int hat)
-    {
-        return _virtualTable.SDL_JoystickGetHat(joystick, hat);
-    }
+    [DllImport("SDL2")]
+    public static extern byte SDL_JoystickGetHat(SDL_Joystick* joystick, int hat);
 
     // Function @ SDL_joystick.h:645:34
-    public static CBool SDL_JoystickGetAxisInitialState(SDL_Joystick* joystick, int axis, short* state)
-    {
-        return _virtualTable.SDL_JoystickGetAxisInitialState(joystick, axis, state);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_JoystickGetAxisInitialState(SDL_Joystick* joystick, int axis, short* state);
 
     // Function @ SDL_joystick.h:630:32
-    public static short SDL_JoystickGetAxis(SDL_Joystick* joystick, int axis)
-    {
-        return _virtualTable.SDL_JoystickGetAxis(joystick, axis);
-    }
+    [DllImport("SDL2")]
+    public static extern short SDL_JoystickGetAxis(SDL_Joystick* joystick, int axis);
 
     // Function @ SDL_joystick.h:605:29
-    public static int SDL_JoystickEventState(int state)
-    {
-        return _virtualTable.SDL_JoystickEventState(state);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickEventState(int state);
 
     // Function @ SDL_joystick.h:582:30
-    public static void SDL_JoystickUpdate()
-    {
-        _virtualTable.SDL_JoystickUpdate();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_JoystickUpdate();
 
     // Function @ SDL_joystick.h:572:29
-    public static int SDL_JoystickNumButtons(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickNumButtons(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickNumButtons(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:560:29
-    public static int SDL_JoystickNumHats(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickNumHats(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickNumHats(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:548:29
-    public static int SDL_JoystickNumBalls(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickNumBalls(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickNumBalls(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:532:29
-    public static int SDL_JoystickNumAxes(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickNumAxes(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickNumAxes(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:515:40
-    public static SDL_JoystickID SDL_JoystickInstanceID(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickInstanceID(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_JoystickID SDL_JoystickInstanceID(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:504:34
-    public static CBool SDL_JoystickGetAttached(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickGetAttached(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_JoystickGetAttached(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:492:42
-    public static SDL_JoystickGUID SDL_JoystickGetGUIDFromString(CString pchGUID)
-    {
-        return _virtualTable.SDL_JoystickGetGUIDFromString(pchGUID);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_JoystickGUID SDL_JoystickGetGUIDFromString(CString pchGUID);
 
     // Function @ SDL_joystick.h:478:30
-    public static void SDL_JoystickGetGUIDString(SDL_JoystickGUID guid, CString pszGUID, int cbGUID)
-    {
-        _virtualTable.SDL_JoystickGetGUIDString(guid, pszGUID, cbGUID);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_JoystickGetGUIDString(SDL_JoystickGUID guid, CString pszGUID, int cbGUID);
 
     // Function @ SDL_joystick.h:463:42
-    public static SDL_JoystickType SDL_JoystickGetType(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickGetType(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_JoystickType SDL_JoystickGetType(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:455:38
-    public static CString SDL_JoystickGetSerial(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickGetSerial(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_JoystickGetSerial(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:445:32
-    public static ushort SDL_JoystickGetProductVersion(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickGetProductVersion(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_JoystickGetProductVersion(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:436:32
-    public static ushort SDL_JoystickGetProduct(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickGetProduct(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_JoystickGetProduct(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:426:32
-    public static ushort SDL_JoystickGetVendor(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickGetVendor(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_JoystickGetVendor(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:416:42
-    public static SDL_JoystickGUID SDL_JoystickGetGUID(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickGetGUID(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_JoystickGUID SDL_JoystickGetGUID(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:401:30
-    public static void SDL_JoystickSetPlayerIndex(SDL_Joystick* joystick, int player_index)
-    {
-        _virtualTable.SDL_JoystickSetPlayerIndex(joystick, player_index);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_JoystickSetPlayerIndex(SDL_Joystick* joystick, int player_index);
 
     // Function @ SDL_joystick.h:393:29
-    public static int SDL_JoystickGetPlayerIndex(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickGetPlayerIndex(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickGetPlayerIndex(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:382:37
-    public static CString SDL_JoystickName(SDL_Joystick* joystick)
-    {
-        return _virtualTable.SDL_JoystickName(joystick);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_JoystickName(SDL_Joystick* joystick);
 
     // Function @ SDL_joystick.h:368:29
-    public static int SDL_JoystickSetVirtualHat(SDL_Joystick* joystick, int hat, byte value)
-    {
-        return _virtualTable.SDL_JoystickSetVirtualHat(joystick, hat, value);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickSetVirtualHat(SDL_Joystick* joystick, int hat, byte value);
 
     // Function @ SDL_joystick.h:352:29
-    public static int SDL_JoystickSetVirtualButton(SDL_Joystick* joystick, int button, byte value)
-    {
-        return _virtualTable.SDL_JoystickSetVirtualButton(joystick, button, value);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickSetVirtualButton(SDL_Joystick* joystick, int button, byte value);
 
     // Function @ SDL_joystick.h:336:29
-    public static int SDL_JoystickSetVirtualAxis(SDL_Joystick* joystick, int axis, short value)
-    {
-        return _virtualTable.SDL_JoystickSetVirtualAxis(joystick, axis, value);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickSetVirtualAxis(SDL_Joystick* joystick, int axis, short value);
 
     // Function @ SDL_joystick.h:320:34
-    public static CBool SDL_JoystickIsVirtual(int device_index)
-    {
-        return _virtualTable.SDL_JoystickIsVirtual(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_JoystickIsVirtual(int device_index);
 
     // Function @ SDL_joystick.h:312:29
-    public static int SDL_JoystickDetachVirtual(int device_index)
-    {
-        return _virtualTable.SDL_JoystickDetachVirtual(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickDetachVirtual(int device_index);
 
     // Function @ SDL_joystick.h:300:29
-    public static int SDL_JoystickAttachVirtual(SDL_JoystickType type, int naxes, int nbuttons, int nhats)
-    {
-        return _virtualTable.SDL_JoystickAttachVirtual(type, naxes, nbuttons, nhats);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickAttachVirtual(SDL_JoystickType type, int naxes, int nbuttons, int nhats);
 
     // Function @ SDL_joystick.h:293:39
-    public static SDL_Joystick* SDL_JoystickFromPlayerIndex(int player_index)
-    {
-        return _virtualTable.SDL_JoystickFromPlayerIndex(player_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Joystick* SDL_JoystickFromPlayerIndex(int player_index);
 
     // Function @ SDL_joystick.h:284:39
-    public static SDL_Joystick* SDL_JoystickFromInstanceID(SDL_JoystickID instance_id)
-    {
-        return _virtualTable.SDL_JoystickFromInstanceID(instance_id);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Joystick* SDL_JoystickFromInstanceID(SDL_JoystickID instance_id);
 
     // Function @ SDL_joystick.h:273:39
-    public static SDL_Joystick* SDL_JoystickOpen(int device_index)
-    {
-        return _virtualTable.SDL_JoystickOpen(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Joystick* SDL_JoystickOpen(int device_index);
 
     // Function @ SDL_joystick.h:253:40
-    public static SDL_JoystickID SDL_JoystickGetDeviceInstanceID(int device_index)
-    {
-        return _virtualTable.SDL_JoystickGetDeviceInstanceID(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_JoystickID SDL_JoystickGetDeviceInstanceID(int device_index);
 
     // Function @ SDL_joystick.h:240:42
-    public static SDL_JoystickType SDL_JoystickGetDeviceType(int device_index)
-    {
-        return _virtualTable.SDL_JoystickGetDeviceType(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_JoystickType SDL_JoystickGetDeviceType(int device_index);
 
     // Function @ SDL_joystick.h:228:32
-    public static ushort SDL_JoystickGetDeviceProductVersion(int device_index)
-    {
-        return _virtualTable.SDL_JoystickGetDeviceProductVersion(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_JoystickGetDeviceProductVersion(int device_index);
 
     // Function @ SDL_joystick.h:215:32
-    public static ushort SDL_JoystickGetDeviceProduct(int device_index)
-    {
-        return _virtualTable.SDL_JoystickGetDeviceProduct(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_JoystickGetDeviceProduct(int device_index);
 
     // Function @ SDL_joystick.h:202:32
-    public static ushort SDL_JoystickGetDeviceVendor(int device_index)
-    {
-        return _virtualTable.SDL_JoystickGetDeviceVendor(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_JoystickGetDeviceVendor(int device_index);
 
     // Function @ SDL_joystick.h:189:42
-    public static SDL_JoystickGUID SDL_JoystickGetDeviceGUID(int device_index)
-    {
-        return _virtualTable.SDL_JoystickGetDeviceGUID(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_JoystickGUID SDL_JoystickGetDeviceGUID(int device_index);
 
     // Function @ SDL_joystick.h:173:29
-    public static int SDL_JoystickGetDevicePlayerIndex(int device_index)
-    {
-        return _virtualTable.SDL_JoystickGetDevicePlayerIndex(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_JoystickGetDevicePlayerIndex(int device_index);
 
     // Function @ SDL_joystick.h:167:37
-    public static CString SDL_JoystickNameForIndex(int device_index)
-    {
-        return _virtualTable.SDL_JoystickNameForIndex(device_index);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_JoystickNameForIndex(int device_index);
 
     // Function @ SDL_joystick.h:152:29
-    public static int SDL_NumJoysticks()
-    {
-        return _virtualTable.SDL_NumJoysticks();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_NumJoysticks();
 
     // Function @ SDL_joystick.h:141:30
-    public static void SDL_UnlockJoysticks()
-    {
-        _virtualTable.SDL_UnlockJoysticks();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_UnlockJoysticks();
 
     // Function @ SDL_joystick.h:128:30
-    public static void SDL_LockJoysticks()
-    {
-        _virtualTable.SDL_LockJoysticks();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LockJoysticks();
 
     // Function @ SDL_mouse.h:394:29
-    public static int SDL_ShowCursor(int toggle)
-    {
-        return _virtualTable.SDL_ShowCursor(toggle);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_ShowCursor(int toggle);
 
     // Function @ SDL_mouse.h:374:30
-    public static void SDL_FreeCursor(SDL_Cursor* cursor)
-    {
-        _virtualTable.SDL_FreeCursor(cursor);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FreeCursor(SDL_Cursor* cursor);
 
     // Function @ SDL_mouse.h:360:37
-    public static SDL_Cursor* SDL_GetDefaultCursor()
-    {
-        return _virtualTable.SDL_GetDefaultCursor();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Cursor* SDL_GetDefaultCursor();
 
     // Function @ SDL_mouse.h:349:37
-    public static SDL_Cursor* SDL_GetCursor()
-    {
-        return _virtualTable.SDL_GetCursor();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Cursor* SDL_GetCursor();
 
     // Function @ SDL_mouse.h:337:30
-    public static void SDL_SetCursor(SDL_Cursor* cursor)
-    {
-        _virtualTable.SDL_SetCursor(cursor);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetCursor(SDL_Cursor* cursor);
 
     // Function @ SDL_mouse.h:321:37
-    public static SDL_Cursor* SDL_CreateSystemCursor(SDL_SystemCursor id)
-    {
-        return _virtualTable.SDL_CreateSystemCursor(id);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Cursor* SDL_CreateSystemCursor(SDL_SystemCursor id);
 
     // Function @ SDL_mouse.h:306:37
-    public static SDL_Cursor* SDL_CreateColorCursor(SDL_Surface* surface, int hot_x, int hot_y)
-    {
-        return _virtualTable.SDL_CreateColorCursor(surface, hot_x, hot_y);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Cursor* SDL_CreateColorCursor(SDL_Surface* surface, int hot_x, int hot_y);
 
     // Function @ SDL_mouse.h:287:37
-    public static SDL_Cursor* SDL_CreateCursor(byte* data, byte* mask, int w, int h, int hot_x, int hot_y)
-    {
-        return _virtualTable.SDL_CreateCursor(data, mask, w, h, hot_x, hot_y);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Cursor* SDL_CreateCursor(byte* data, byte* mask, int w, int h, int hot_x, int hot_y);
 
     // Function @ SDL_mouse.h:245:34
-    public static CBool SDL_GetRelativeMouseMode()
-    {
-        return _virtualTable.SDL_GetRelativeMouseMode();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GetRelativeMouseMode();
 
     // Function @ SDL_mouse.h:236:29
-    public static int SDL_CaptureMouse(CBool enabled)
-    {
-        return _virtualTable.SDL_CaptureMouse(enabled);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_CaptureMouse(CBool enabled);
 
     // Function @ SDL_mouse.h:199:29
-    public static int SDL_SetRelativeMouseMode(CBool enabled)
-    {
-        return _virtualTable.SDL_SetRelativeMouseMode(enabled);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetRelativeMouseMode(CBool enabled);
 
     // Function @ SDL_mouse.h:180:29
-    public static int SDL_WarpMouseGlobal(int x, int y)
-    {
-        return _virtualTable.SDL_WarpMouseGlobal(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_WarpMouseGlobal(int x, int y);
 
     // Function @ SDL_mouse.h:160:30
-    public static void SDL_WarpMouseInWindow(SDL_Window* window, int x, int y)
-    {
-        _virtualTable.SDL_WarpMouseInWindow(window, x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_WarpMouseInWindow(SDL_Window* window, int x, int y);
 
     // Function @ SDL_mouse.h:146:32
-    public static uint SDL_GetRelativeMouseState(long* x, long* y)
-    {
-        return _virtualTable.SDL_GetRelativeMouseState(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_GetRelativeMouseState(long* x, long* y);
 
     // Function @ SDL_mouse.h:129:32
-    public static uint SDL_GetGlobalMouseState(long* x, long* y)
-    {
-        return _virtualTable.SDL_GetGlobalMouseState(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_GetGlobalMouseState(long* x, long* y);
 
     // Function @ SDL_mouse.h:100:32
-    public static uint SDL_GetMouseState(long* x, long* y)
-    {
-        return _virtualTable.SDL_GetMouseState(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_GetMouseState(long* x, long* y);
 
     // Function @ SDL_mouse.h:79:38
-    public static SDL_Window* SDL_GetMouseFocus()
-    {
-        return _virtualTable.SDL_GetMouseFocus();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Window* SDL_GetMouseFocus();
 
     // Function @ SDL_keyboard.h:284:34
-    public static CBool SDL_IsScreenKeyboardShown(SDL_Window* window)
-    {
-        return _virtualTable.SDL_IsScreenKeyboardShown(window);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_IsScreenKeyboardShown(SDL_Window* window);
 
     // Function @ SDL_keyboard.h:272:34
-    public static CBool SDL_HasScreenKeyboardSupport()
-    {
-        return _virtualTable.SDL_HasScreenKeyboardSupport();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasScreenKeyboardSupport();
 
     // Function @ SDL_keyboard.h:259:30
-    public static void SDL_SetTextInputRect(SDL_Rect* rect)
-    {
-        _virtualTable.SDL_SetTextInputRect(rect);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetTextInputRect(SDL_Rect* rect);
 
     // Function @ SDL_keyboard.h:249:30
-    public static void SDL_StopTextInput()
-    {
-        _virtualTable.SDL_StopTextInput();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_StopTextInput();
 
     // Function @ SDL_keyboard.h:242:34
-    public static CBool SDL_IsTextInputActive()
-    {
-        return _virtualTable.SDL_IsTextInputActive();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_IsTextInputActive();
 
     // Function @ SDL_keyboard.h:231:30
-    public static void SDL_StartTextInput()
-    {
-        _virtualTable.SDL_StartTextInput();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_StartTextInput();
 
     // Function @ SDL_keyboard.h:216:37
-    public static SDL_Keycode SDL_GetKeyFromName(CString name)
-    {
-        return _virtualTable.SDL_GetKeyFromName(name);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Keycode SDL_GetKeyFromName(CString name);
 
     // Function @ SDL_keyboard.h:203:37
-    public static CString SDL_GetKeyName(SDL_Keycode key)
-    {
-        return _virtualTable.SDL_GetKeyName(key);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetKeyName(SDL_Keycode key);
 
     // Function @ SDL_keyboard.h:186:38
-    public static SDL_Scancode SDL_GetScancodeFromName(CString name)
-    {
-        return _virtualTable.SDL_GetScancodeFromName(name);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Scancode SDL_GetScancodeFromName(CString name);
 
     // Function @ SDL_keyboard.h:171:37
-    public static CString SDL_GetScancodeName(SDL_Scancode scancode)
-    {
-        return _virtualTable.SDL_GetScancodeName(scancode);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetScancodeName(SDL_Scancode scancode);
 
     // Function @ SDL_keyboard.h:146:38
-    public static SDL_Scancode SDL_GetScancodeFromKey(SDL_Keycode key)
-    {
-        return _virtualTable.SDL_GetScancodeFromKey(key);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Scancode SDL_GetScancodeFromKey(SDL_Keycode key);
 
     // Function @ SDL_keyboard.h:132:37
-    public static SDL_Keycode SDL_GetKeyFromScancode(SDL_Scancode scancode)
-    {
-        return _virtualTable.SDL_GetKeyFromScancode(scancode);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Keycode SDL_GetKeyFromScancode(SDL_Scancode scancode);
 
     // Function @ SDL_keyboard.h:118:30
-    public static void SDL_SetModState(SDL_Keymod modstate)
-    {
-        _virtualTable.SDL_SetModState(modstate);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetModState(SDL_Keymod modstate);
 
     // Function @ SDL_keyboard.h:101:36
-    public static SDL_Keymod SDL_GetModState()
-    {
-        return _virtualTable.SDL_GetModState();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Keymod SDL_GetModState();
 
     // Function @ SDL_keyboard.h:90:38
-    public static byte* SDL_GetKeyboardState(long* numkeys)
-    {
-        return _virtualTable.SDL_GetKeyboardState(numkeys);
-    }
+    [DllImport("SDL2")]
+    public static extern byte* SDL_GetKeyboardState(long* numkeys);
 
     // Function @ SDL_keyboard.h:62:38
-    public static SDL_Window* SDL_GetKeyboardFocus()
-    {
-        return _virtualTable.SDL_GetKeyboardFocus();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Window* SDL_GetKeyboardFocus();
 
     // Function @ SDL_video.h:1869:30
-    public static void SDL_GL_DeleteContext(SDL_GLContext context)
-    {
-        _virtualTable.SDL_GL_DeleteContext(context);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GL_DeleteContext(SDL_GLContext context);
 
     // Function @ SDL_video.h:1860:30
-    public static void SDL_GL_SwapWindow(SDL_Window* window)
-    {
-        _virtualTable.SDL_GL_SwapWindow(window);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GL_SwapWindow(SDL_Window* window);
 
     // Function @ SDL_video.h:1846:29
-    public static int SDL_GL_GetSwapInterval()
-    {
-        return _virtualTable.SDL_GL_GetSwapInterval();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GL_GetSwapInterval();
 
     // Function @ SDL_video.h:1829:29
-    public static int SDL_GL_SetSwapInterval(int interval)
-    {
-        return _virtualTable.SDL_GL_SetSwapInterval(interval);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GL_SetSwapInterval(int interval);
 
     // Function @ SDL_video.h:1794:30
-    public static void SDL_GL_GetDrawableSize(SDL_Window* window, long* w, long* h)
-    {
-        _virtualTable.SDL_GL_GetDrawableSize(window, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GL_GetDrawableSize(SDL_Window* window, long* w, long* h);
 
     // Function @ SDL_video.h:1772:39
-    public static SDL_GLContext SDL_GL_GetCurrentContext()
-    {
-        return _virtualTable.SDL_GL_GetCurrentContext();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GLContext SDL_GL_GetCurrentContext();
 
     // Function @ SDL_video.h:1760:37
-    public static SDL_Window* SDL_GL_GetCurrentWindow()
-    {
-        return _virtualTable.SDL_GL_GetCurrentWindow();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Window* SDL_GL_GetCurrentWindow();
 
     // Function @ SDL_video.h:1749:29
-    public static int SDL_GL_MakeCurrent(SDL_Window* window, SDL_GLContext context)
-    {
-        return _virtualTable.SDL_GL_MakeCurrent(window, context);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GL_MakeCurrent(SDL_Window* window, SDL_GLContext context);
 
     // Function @ SDL_video.h:1734:39
-    public static SDL_GLContext SDL_GL_CreateContext(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GL_CreateContext(window);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_GLContext SDL_GL_CreateContext(SDL_Window* window);
 
     // Function @ SDL_video.h:1714:29
-    public static int SDL_GL_GetAttribute(SDL_GLattr attr, long* value)
-    {
-        return _virtualTable.SDL_GL_GetAttribute(attr, value);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GL_GetAttribute(SDL_GLattr attr, long* value);
 
     // Function @ SDL_video.h:1701:29
-    public static int SDL_GL_SetAttribute(SDL_GLattr attr, int value)
-    {
-        return _virtualTable.SDL_GL_SetAttribute(attr, value);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GL_SetAttribute(SDL_GLattr attr, int value);
 
     // Function @ SDL_video.h:1682:30
-    public static void SDL_GL_ResetAttributes()
-    {
-        _virtualTable.SDL_GL_ResetAttributes();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GL_ResetAttributes();
 
     // Function @ SDL_video.h:1670:34
-    public static CBool SDL_GL_ExtensionSupported(CString extension)
-    {
-        return _virtualTable.SDL_GL_ExtensionSupported(extension);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GL_ExtensionSupported(CString extension);
 
     // Function @ SDL_video.h:1649:30
-    public static void SDL_GL_UnloadLibrary()
-    {
-        _virtualTable.SDL_GL_UnloadLibrary();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GL_UnloadLibrary();
 
     // Function @ SDL_video.h:1642:31
-    public static void* SDL_GL_GetProcAddress(CString proc)
-    {
-        return _virtualTable.SDL_GL_GetProcAddress(proc);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_GL_GetProcAddress(CString proc);
 
     // Function @ SDL_video.h:1591:29
-    public static int SDL_GL_LoadLibrary(CString path)
-    {
-        return _virtualTable.SDL_GL_LoadLibrary(path);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GL_LoadLibrary(CString path);
 
     // Function @ SDL_video.h:1565:30
-    public static void SDL_DisableScreenSaver()
-    {
-        _virtualTable.SDL_DisableScreenSaver();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DisableScreenSaver();
 
     // Function @ SDL_video.h:1552:30
-    public static void SDL_EnableScreenSaver()
-    {
-        _virtualTable.SDL_EnableScreenSaver();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_EnableScreenSaver();
 
     // Function @ SDL_video.h:1542:34
-    public static CBool SDL_IsScreenSaverEnabled()
-    {
-        return _virtualTable.SDL_IsScreenSaverEnabled();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_IsScreenSaverEnabled();
 
     // Function @ SDL_video.h:1523:30
-    public static void SDL_DestroyWindow(SDL_Window* window)
-    {
-        _virtualTable.SDL_DestroyWindow(window);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DestroyWindow(SDL_Window* window);
 
     // Function @ SDL_video.h:1508:29
-    public static int SDL_SetWindowHitTest(SDL_Window* window, SDL_HitTest callback, void* callback_data)
-    {
-        return _virtualTable.SDL_SetWindowHitTest(window, callback, callback_data);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetWindowHitTest(SDL_Window* window, SDL_HitTest callback, void* callback_data);
 
     // Function @ SDL_video.h:1430:29
-    public static int SDL_GetWindowGammaRamp(SDL_Window* window, ushort* red, ushort* green, ushort* blue)
-    {
-        return _virtualTable.SDL_GetWindowGammaRamp(window, red, green, blue);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetWindowGammaRamp(SDL_Window* window, ushort* red, ushort* green, ushort* blue);
 
     // Function @ SDL_video.h:1404:29
-    public static int SDL_SetWindowGammaRamp(SDL_Window* window, ushort* red, ushort* green, ushort* blue)
-    {
-        return _virtualTable.SDL_SetWindowGammaRamp(window, red, green, blue);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetWindowGammaRamp(SDL_Window* window, ushort* red, ushort* green, ushort* blue);
 
     // Function @ SDL_video.h:1375:29
-    public static int SDL_SetWindowInputFocus(SDL_Window* window)
-    {
-        return _virtualTable.SDL_SetWindowInputFocus(window);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetWindowInputFocus(SDL_Window* window);
 
     // Function @ SDL_video.h:1358:29
-    public static int SDL_SetWindowModalFor(SDL_Window* modal_window, SDL_Window* parent_window)
-    {
-        return _virtualTable.SDL_SetWindowModalFor(modal_window, parent_window);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetWindowModalFor(SDL_Window* modal_window, SDL_Window* parent_window);
 
     // Function @ SDL_video.h:1346:29
-    public static int SDL_GetWindowOpacity(SDL_Window* window, float* out_opacity)
-    {
-        return _virtualTable.SDL_GetWindowOpacity(window, out_opacity);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetWindowOpacity(SDL_Window* window, float* out_opacity);
 
     // Function @ SDL_video.h:1325:29
-    public static int SDL_SetWindowOpacity(SDL_Window* window, float opacity)
-    {
-        return _virtualTable.SDL_SetWindowOpacity(window, opacity);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetWindowOpacity(SDL_Window* window, float opacity);
 
     // Function @ SDL_video.h:1306:31
-    public static float SDL_GetWindowBrightness(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowBrightness(window);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_GetWindowBrightness(SDL_Window* window);
 
     // Function @ SDL_video.h:1289:29
-    public static int SDL_SetWindowBrightness(SDL_Window* window, float brightness)
-    {
-        return _virtualTable.SDL_SetWindowBrightness(window, brightness);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetWindowBrightness(SDL_Window* window, float brightness);
 
     // Function @ SDL_video.h:1263:38
-    public static SDL_Window* SDL_GetGrabbedWindow()
-    {
-        return _virtualTable.SDL_GetGrabbedWindow();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Window* SDL_GetGrabbedWindow();
 
     // Function @ SDL_video.h:1251:34
-    public static CBool SDL_GetWindowMouseGrab(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowMouseGrab(window);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GetWindowMouseGrab(SDL_Window* window);
 
     // Function @ SDL_video.h:1240:34
-    public static CBool SDL_GetWindowKeyboardGrab(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowKeyboardGrab(window);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GetWindowKeyboardGrab(SDL_Window* window);
 
     // Function @ SDL_video.h:1229:34
-    public static CBool SDL_GetWindowGrab(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowGrab(window);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_GetWindowGrab(SDL_Window* window);
 
     // Function @ SDL_video.h:1218:30
-    public static void SDL_SetWindowMouseGrab(SDL_Window* window, CBool grabbed)
-    {
-        _virtualTable.SDL_SetWindowMouseGrab(window, grabbed);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowMouseGrab(SDL_Window* window, CBool grabbed);
 
     // Function @ SDL_video.h:1202:30
-    public static void SDL_SetWindowKeyboardGrab(SDL_Window* window, CBool grabbed)
-    {
-        _virtualTable.SDL_SetWindowKeyboardGrab(window, grabbed);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowKeyboardGrab(SDL_Window* window, CBool grabbed);
 
     // Function @ SDL_video.h:1186:30
-    public static void SDL_SetWindowGrab(SDL_Window* window, CBool grabbed)
-    {
-        _virtualTable.SDL_SetWindowGrab(window, grabbed);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowGrab(SDL_Window* window, CBool grabbed);
 
     // Function @ SDL_video.h:1168:29
-    public static int SDL_UpdateWindowSurfaceRects(SDL_Window* window, SDL_Rect* rects, int numrects)
-    {
-        return _virtualTable.SDL_UpdateWindowSurfaceRects(window, rects, numrects);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_UpdateWindowSurfaceRects(SDL_Window* window, SDL_Rect* rects, int numrects);
 
     // Function @ SDL_video.h:1148:29
-    public static int SDL_UpdateWindowSurface(SDL_Window* window)
-    {
-        return _virtualTable.SDL_UpdateWindowSurface(window);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_UpdateWindowSurface(SDL_Window* window);
 
     // Function @ SDL_video.h:1131:39
-    public static SDL_Surface* SDL_GetWindowSurface(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowSurface(window);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Surface* SDL_GetWindowSurface(SDL_Window* window);
 
     // Function @ SDL_video.h:1107:29
-    public static int SDL_SetWindowFullscreen(SDL_Window* window, uint flags)
-    {
-        return _virtualTable.SDL_SetWindowFullscreen(window, flags);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetWindowFullscreen(SDL_Window* window, uint flags);
 
     // Function @ SDL_video.h:1088:30
-    public static void SDL_RestoreWindow(SDL_Window* window)
-    {
-        _virtualTable.SDL_RestoreWindow(window);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_RestoreWindow(SDL_Window* window);
 
     // Function @ SDL_video.h:1078:30
-    public static void SDL_MinimizeWindow(SDL_Window* window)
-    {
-        _virtualTable.SDL_MinimizeWindow(window);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_MinimizeWindow(SDL_Window* window);
 
     // Function @ SDL_video.h:1068:30
-    public static void SDL_MaximizeWindow(SDL_Window* window)
-    {
-        _virtualTable.SDL_MaximizeWindow(window);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_MaximizeWindow(SDL_Window* window);
 
     // Function @ SDL_video.h:1058:30
-    public static void SDL_RaiseWindow(SDL_Window* window)
-    {
-        _virtualTable.SDL_RaiseWindow(window);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_RaiseWindow(SDL_Window* window);
 
     // Function @ SDL_video.h:1051:30
-    public static void SDL_HideWindow(SDL_Window* window)
-    {
-        _virtualTable.SDL_HideWindow(window);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_HideWindow(SDL_Window* window);
 
     // Function @ SDL_video.h:1042:30
-    public static void SDL_ShowWindow(SDL_Window* window)
-    {
-        _virtualTable.SDL_ShowWindow(window);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_ShowWindow(SDL_Window* window);
 
     // Function @ SDL_video.h:1032:30
-    public static void SDL_SetWindowAlwaysOnTop(SDL_Window* window, CBool on_top)
-    {
-        _virtualTable.SDL_SetWindowAlwaysOnTop(window, on_top);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowAlwaysOnTop(SDL_Window* window, CBool on_top);
 
     // Function @ SDL_video.h:1016:30
-    public static void SDL_SetWindowResizable(SDL_Window* window, CBool resizable)
-    {
-        _virtualTable.SDL_SetWindowResizable(window, resizable);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowResizable(SDL_Window* window, CBool resizable);
 
     // Function @ SDL_video.h:997:30
-    public static void SDL_SetWindowBordered(SDL_Window* window, CBool bordered)
-    {
-        _virtualTable.SDL_SetWindowBordered(window, bordered);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowBordered(SDL_Window* window, CBool bordered);
 
     // Function @ SDL_video.h:978:30
-    public static void SDL_GetWindowMaximumSize(SDL_Window* window, long* w, long* h)
-    {
-        _virtualTable.SDL_GetWindowMaximumSize(window, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GetWindowMaximumSize(SDL_Window* window, long* w, long* h);
 
     // Function @ SDL_video.h:963:30
-    public static void SDL_SetWindowMaximumSize(SDL_Window* window, int max_w, int max_h)
-    {
-        _virtualTable.SDL_SetWindowMaximumSize(window, max_w, max_h);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowMaximumSize(SDL_Window* window, int max_w, int max_h);
 
     // Function @ SDL_video.h:950:30
-    public static void SDL_GetWindowMinimumSize(SDL_Window* window, long* w, long* h)
-    {
-        _virtualTable.SDL_GetWindowMinimumSize(window, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GetWindowMinimumSize(SDL_Window* window, long* w, long* h);
 
     // Function @ SDL_video.h:935:30
-    public static void SDL_SetWindowMinimumSize(SDL_Window* window, int min_w, int min_h)
-    {
-        _virtualTable.SDL_SetWindowMinimumSize(window, min_w, min_h);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowMinimumSize(SDL_Window* window, int min_w, int min_h);
 
     // Function @ SDL_video.h:921:29
-    public static int SDL_GetWindowBordersSize(SDL_Window* window, long* top, long* left, long* bottom, long* right)
-    {
-        return _virtualTable.SDL_GetWindowBordersSize(window, top, left, bottom, right);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetWindowBordersSize(SDL_Window* window, long* top, long* left, long* bottom, long* right);
 
     // Function @ SDL_video.h:886:30
-    public static void SDL_GetWindowSize(SDL_Window* window, long* w, long* h)
-    {
-        _virtualTable.SDL_GetWindowSize(window, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GetWindowSize(SDL_Window* window, long* w, long* h);
 
     // Function @ SDL_video.h:861:30
-    public static void SDL_SetWindowSize(SDL_Window* window, int w, int h)
-    {
-        _virtualTable.SDL_SetWindowSize(window, w, h);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowSize(SDL_Window* window, int w, int h);
 
     // Function @ SDL_video.h:838:30
-    public static void SDL_GetWindowPosition(SDL_Window* window, long* x, long* y)
-    {
-        _virtualTable.SDL_GetWindowPosition(window, x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GetWindowPosition(SDL_Window* window, long* x, long* y);
 
     // Function @ SDL_video.h:821:30
-    public static void SDL_SetWindowPosition(SDL_Window* window, int x, int y)
-    {
-        _virtualTable.SDL_SetWindowPosition(window, x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowPosition(SDL_Window* window, int x, int y);
 
     // Function @ SDL_video.h:805:31
-    public static void* SDL_GetWindowData(SDL_Window* window, CString name)
-    {
-        return _virtualTable.SDL_GetWindowData(window, name);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_GetWindowData(SDL_Window* window, CString name);
 
     // Function @ SDL_video.h:792:31
-    public static void* SDL_SetWindowData(SDL_Window* window, CString name, void* userdata)
-    {
-        return _virtualTable.SDL_SetWindowData(window, name, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_SetWindowData(SDL_Window* window, CString name, void* userdata);
 
     // Function @ SDL_video.h:777:30
-    public static void SDL_SetWindowIcon(SDL_Window* window, SDL_Surface* icon)
-    {
-        _virtualTable.SDL_SetWindowIcon(window, icon);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowIcon(SDL_Window* window, SDL_Surface* icon);
 
     // Function @ SDL_video.h:769:37
-    public static CString SDL_GetWindowTitle(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowTitle(window);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetWindowTitle(SDL_Window* window);
 
     // Function @ SDL_video.h:757:30
-    public static void SDL_SetWindowTitle(SDL_Window* window, CString title)
-    {
-        _virtualTable.SDL_SetWindowTitle(window, title);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetWindowTitle(SDL_Window* window, CString title);
 
     // Function @ SDL_video.h:745:32
-    public static uint SDL_GetWindowFlags(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowFlags(window);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_GetWindowFlags(SDL_Window* window);
 
     // Function @ SDL_video.h:729:38
-    public static SDL_Window* SDL_GetWindowFromID(uint id)
-    {
-        return _virtualTable.SDL_GetWindowFromID(id);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Window* SDL_GetWindowFromID(uint id);
 
     // Function @ SDL_video.h:715:32
-    public static uint SDL_GetWindowID(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowID(window);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_GetWindowID(SDL_Window* window);
 
     // Function @ SDL_video.h:699:38
-    public static SDL_Window* SDL_CreateWindowFrom(void* data)
-    {
-        return _virtualTable.SDL_CreateWindowFrom(data);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Window* SDL_CreateWindowFrom(void* data);
 
     // Function @ SDL_video.h:680:38
-    public static SDL_Window* SDL_CreateWindow(CString title, int x, int y, int w, int h, uint flags)
-    {
-        return _virtualTable.SDL_CreateWindow(title, x, y, w, h, flags);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Window* SDL_CreateWindow(CString title, int x, int y, int w, int h, uint flags);
 
     // Function @ SDL_video.h:610:32
-    public static uint SDL_GetWindowPixelFormat(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowPixelFormat(window);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_GetWindowPixelFormat(SDL_Window* window);
 
     // Function @ SDL_video.h:599:29
-    public static int SDL_GetWindowDisplayMode(SDL_Window* window, SDL_DisplayMode* mode)
-    {
-        return _virtualTable.SDL_GetWindowDisplayMode(window, mode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetWindowDisplayMode(SDL_Window* window, SDL_DisplayMode* mode);
 
     // Function @ SDL_video.h:584:29
-    public static int SDL_SetWindowDisplayMode(SDL_Window* window, SDL_DisplayMode* mode)
-    {
-        return _virtualTable.SDL_SetWindowDisplayMode(window, mode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetWindowDisplayMode(SDL_Window* window, SDL_DisplayMode* mode);
 
     // Function @ SDL_video.h:565:29
-    public static int SDL_GetWindowDisplayIndex(SDL_Window* window)
-    {
-        return _virtualTable.SDL_GetWindowDisplayIndex(window);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetWindowDisplayIndex(SDL_Window* window);
 
     // Function @ SDL_video.h:552:43
-    public static SDL_DisplayMode* SDL_GetClosestDisplayMode(int displayIndex, SDL_DisplayMode* mode, SDL_DisplayMode* closest)
-    {
-        return _virtualTable.SDL_GetClosestDisplayMode(displayIndex, mode, closest);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_DisplayMode* SDL_GetClosestDisplayMode(int displayIndex, SDL_DisplayMode* mode, SDL_DisplayMode* closest);
 
     // Function @ SDL_video.h:528:29
-    public static int SDL_GetCurrentDisplayMode(int displayIndex, SDL_DisplayMode* mode)
-    {
-        return _virtualTable.SDL_GetCurrentDisplayMode(displayIndex, mode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetCurrentDisplayMode(int displayIndex, SDL_DisplayMode* mode);
 
     // Function @ SDL_video.h:507:29
-    public static int SDL_GetDesktopDisplayMode(int displayIndex, SDL_DisplayMode* mode)
-    {
-        return _virtualTable.SDL_GetDesktopDisplayMode(displayIndex, mode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetDesktopDisplayMode(int displayIndex, SDL_DisplayMode* mode);
 
     // Function @ SDL_video.h:486:29
-    public static int SDL_GetDisplayMode(int displayIndex, int modeIndex, SDL_DisplayMode* mode)
-    {
-        return _virtualTable.SDL_GetDisplayMode(displayIndex, modeIndex, mode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetDisplayMode(int displayIndex, int modeIndex, SDL_DisplayMode* mode);
 
     // Function @ SDL_video.h:464:29
-    public static int SDL_GetNumDisplayModes(int displayIndex)
-    {
-        return _virtualTable.SDL_GetNumDisplayModes(displayIndex);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetNumDisplayModes(int displayIndex);
 
     // Function @ SDL_video.h:447:48
-    public static SDL_DisplayOrientation SDL_GetDisplayOrientation(int displayIndex)
-    {
-        return _virtualTable.SDL_GetDisplayOrientation(displayIndex);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_DisplayOrientation SDL_GetDisplayOrientation(int displayIndex);
 
     // Function @ SDL_video.h:436:29
-    public static int SDL_GetDisplayDPI(int displayIndex, float* ddpi, float* hdpi, float* vdpi)
-    {
-        return _virtualTable.SDL_GetDisplayDPI(displayIndex, ddpi, hdpi, vdpi);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetDisplayDPI(int displayIndex, float* ddpi, float* hdpi, float* vdpi);
 
     // Function @ SDL_video.h:410:29
-    public static int SDL_GetDisplayUsableBounds(int displayIndex, SDL_Rect* rect)
-    {
-        return _virtualTable.SDL_GetDisplayUsableBounds(displayIndex, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetDisplayUsableBounds(int displayIndex, SDL_Rect* rect);
 
     // Function @ SDL_video.h:379:29
-    public static int SDL_GetDisplayBounds(int displayIndex, SDL_Rect* rect)
-    {
-        return _virtualTable.SDL_GetDisplayBounds(displayIndex, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetDisplayBounds(int displayIndex, SDL_Rect* rect);
 
     // Function @ SDL_video.h:365:38
-    public static CString SDL_GetDisplayName(int displayIndex)
-    {
-        return _virtualTable.SDL_GetDisplayName(displayIndex);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetDisplayName(int displayIndex);
 
     // Function @ SDL_video.h:351:29
-    public static int SDL_GetNumVideoDisplays()
-    {
-        return _virtualTable.SDL_GetNumVideoDisplays();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetNumVideoDisplays();
 
     // Function @ SDL_video.h:339:37
-    public static CString SDL_GetCurrentVideoDriver()
-    {
-        return _virtualTable.SDL_GetCurrentVideoDriver();
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetCurrentVideoDriver();
 
     // Function @ SDL_video.h:326:30
-    public static void SDL_VideoQuit()
-    {
-        _virtualTable.SDL_VideoQuit();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_VideoQuit();
 
     // Function @ SDL_video.h:317:29
-    public static int SDL_VideoInit(CString driver_name)
-    {
-        return _virtualTable.SDL_VideoInit(driver_name);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_VideoInit(CString driver_name);
 
     // Function @ SDL_video.h:288:37
-    public static CString SDL_GetVideoDriver(int index)
-    {
-        return _virtualTable.SDL_GetVideoDriver(index);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetVideoDriver(int index);
 
     // Function @ SDL_video.h:275:29
-    public static int SDL_GetNumVideoDrivers()
-    {
-        return _virtualTable.SDL_GetNumVideoDrivers();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetNumVideoDrivers();
 
     // Function @ SDL_surface.h:875:49
-    public static SDL_YUV_CONVERSION_MODE SDL_GetYUVConversionModeForResolution(int width, int height)
-    {
-        return _virtualTable.SDL_GetYUVConversionModeForResolution(width, height);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_YUV_CONVERSION_MODE SDL_GetYUVConversionModeForResolution(int width, int height);
 
     // Function @ SDL_surface.h:870:49
-    public static SDL_YUV_CONVERSION_MODE SDL_GetYUVConversionMode()
-    {
-        return _virtualTable.SDL_GetYUVConversionMode();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_YUV_CONVERSION_MODE SDL_GetYUVConversionMode();
 
     // Function @ SDL_surface.h:865:30
-    public static void SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_MODE mode)
-    {
-        _virtualTable.SDL_SetYUVConversionMode(mode);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetYUVConversionMode(SDL_YUV_CONVERSION_MODE mode);
 
     // Function @ SDL_surface.h:858:29
-    public static int SDL_LowerBlitScaled(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect)
-    {
-        return _virtualTable.SDL_LowerBlitScaled(src, srcrect, dst, dstrect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_LowerBlitScaled(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect);
 
     // Function @ SDL_surface.h:837:29
-    public static int SDL_UpperBlitScaled(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect)
-    {
-        return _virtualTable.SDL_UpperBlitScaled(src, srcrect, dst, dstrect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_UpperBlitScaled(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect);
 
     // Function @ SDL_surface.h:821:29
-    public static int SDL_SoftStretchLinear(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect)
-    {
-        return _virtualTable.SDL_SoftStretchLinear(src, srcrect, dst, dstrect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SoftStretchLinear(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect);
 
     // Function @ SDL_surface.h:813:29
-    public static int SDL_SoftStretch(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect)
-    {
-        return _virtualTable.SDL_SoftStretch(src, srcrect, dst, dstrect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SoftStretch(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect);
 
     // Function @ SDL_surface.h:800:29
-    public static int SDL_LowerBlit(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect)
-    {
-        return _virtualTable.SDL_LowerBlit(src, srcrect, dst, dstrect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_LowerBlit(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect);
 
     // Function @ SDL_surface.h:776:29
-    public static int SDL_UpperBlit(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect)
-    {
-        return _virtualTable.SDL_UpperBlit(src, srcrect, dst, dstrect);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_UpperBlit(SDL_Surface* src, SDL_Rect* srcrect, SDL_Surface* dst, SDL_Rect* dstrect);
 
     // Function @ SDL_surface.h:705:29
-    public static int SDL_FillRects(SDL_Surface* dst, SDL_Rect* rects, int count, uint color)
-    {
-        return _virtualTable.SDL_FillRects(dst, rects, count, color);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_FillRects(SDL_Surface* dst, SDL_Rect* rects, int count, uint color);
 
     // Function @ SDL_surface.h:681:29
-    public static int SDL_FillRect(SDL_Surface* dst, SDL_Rect* rect, uint color)
-    {
-        return _virtualTable.SDL_FillRect(dst, rect, color);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_FillRect(SDL_Surface* dst, SDL_Rect* rect, uint color);
 
     // Function @ SDL_surface.h:654:29
-    public static int SDL_ConvertPixels(int width, int height, uint src_format, void* src, int src_pitch, uint dst_format, void* dst, int dst_pitch)
-    {
-        return _virtualTable.SDL_ConvertPixels(width, height, src_format, src, src_pitch, dst_format, dst, dst_pitch);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_ConvertPixels(int width, int height, uint src_format, void* src, int src_pitch, uint dst_format, void* dst, int dst_pitch);
 
     // Function @ SDL_surface.h:637:38
-    public static SDL_Surface* SDL_ConvertSurfaceFormat(SDL_Surface* src, uint pixel_format, uint flags)
-    {
-        return _virtualTable.SDL_ConvertSurfaceFormat(src, pixel_format, flags);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Surface* SDL_ConvertSurfaceFormat(SDL_Surface* src, uint pixel_format, uint flags);
 
     // Function @ SDL_surface.h:614:38
-    public static SDL_Surface* SDL_ConvertSurface(SDL_Surface* src, SDL_PixelFormat* fmt, uint flags)
-    {
-        return _virtualTable.SDL_ConvertSurface(src, fmt, flags);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Surface* SDL_ConvertSurface(SDL_Surface* src, SDL_PixelFormat* fmt, uint flags);
 
     // Function @ SDL_surface.h:592:38
-    public static SDL_Surface* SDL_DuplicateSurface(SDL_Surface* surface)
-    {
-        return _virtualTable.SDL_DuplicateSurface(surface);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Surface* SDL_DuplicateSurface(SDL_Surface* surface);
 
     // Function @ SDL_surface.h:580:30
-    public static void SDL_GetClipRect(SDL_Surface* surface, SDL_Rect* rect)
-    {
-        _virtualTable.SDL_GetClipRect(surface, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GetClipRect(SDL_Surface* surface, SDL_Rect* rect);
 
     // Function @ SDL_surface.h:563:34
-    public static CBool SDL_SetClipRect(SDL_Surface* surface, SDL_Rect* rect)
-    {
-        return _virtualTable.SDL_SetClipRect(surface, rect);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_SetClipRect(SDL_Surface* surface, SDL_Rect* rect);
 
     // Function @ SDL_surface.h:542:29
-    public static int SDL_GetSurfaceBlendMode(SDL_Surface* surface, SDL_BlendMode* blendMode)
-    {
-        return _virtualTable.SDL_GetSurfaceBlendMode(surface, blendMode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetSurfaceBlendMode(SDL_Surface* surface, SDL_BlendMode* blendMode);
 
     // Function @ SDL_surface.h:529:29
-    public static int SDL_SetSurfaceBlendMode(SDL_Surface* surface, SDL_BlendMode blendMode)
-    {
-        return _virtualTable.SDL_SetSurfaceBlendMode(surface, blendMode);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetSurfaceBlendMode(SDL_Surface* surface, SDL_BlendMode blendMode);
 
     // Function @ SDL_surface.h:512:29
-    public static int SDL_GetSurfaceAlphaMod(SDL_Surface* surface, byte* alpha)
-    {
-        return _virtualTable.SDL_GetSurfaceAlphaMod(surface, alpha);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetSurfaceAlphaMod(SDL_Surface* surface, byte* alpha);
 
     // Function @ SDL_surface.h:498:29
-    public static int SDL_SetSurfaceAlphaMod(SDL_Surface* surface, byte alpha)
-    {
-        return _virtualTable.SDL_SetSurfaceAlphaMod(surface, alpha);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetSurfaceAlphaMod(SDL_Surface* surface, byte alpha);
 
     // Function @ SDL_surface.h:478:29
-    public static int SDL_GetSurfaceColorMod(SDL_Surface* surface, byte* r, byte* g, byte* b)
-    {
-        return _virtualTable.SDL_GetSurfaceColorMod(surface, r, g, b);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetSurfaceColorMod(SDL_Surface* surface, byte* r, byte* g, byte* b);
 
     // Function @ SDL_surface.h:461:29
-    public static int SDL_SetSurfaceColorMod(SDL_Surface* surface, byte r, byte g, byte b)
-    {
-        return _virtualTable.SDL_SetSurfaceColorMod(surface, r, g, b);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetSurfaceColorMod(SDL_Surface* surface, byte r, byte g, byte b);
 
     // Function @ SDL_surface.h:439:29
-    public static int SDL_GetColorKey(SDL_Surface* surface, uint* key)
-    {
-        return _virtualTable.SDL_GetColorKey(surface, key);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetColorKey(SDL_Surface* surface, uint* key);
 
     // Function @ SDL_surface.h:421:34
-    public static CBool SDL_HasColorKey(SDL_Surface* surface)
-    {
-        return _virtualTable.SDL_HasColorKey(surface);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasColorKey(SDL_Surface* surface);
 
     // Function @ SDL_surface.h:407:29
-    public static int SDL_SetColorKey(SDL_Surface* surface, int flag, uint key)
-    {
-        return _virtualTable.SDL_SetColorKey(surface, flag, key);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetColorKey(SDL_Surface* surface, int flag, uint key);
 
     // Function @ SDL_surface.h:386:34
-    public static CBool SDL_HasSurfaceRLE(SDL_Surface* surface)
-    {
-        return _virtualTable.SDL_HasSurfaceRLE(surface);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasSurfaceRLE(SDL_Surface* surface);
 
     // Function @ SDL_surface.h:373:29
-    public static int SDL_SetSurfaceRLE(SDL_Surface* surface, int flag)
-    {
-        return _virtualTable.SDL_SetSurfaceRLE(surface, flag);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetSurfaceRLE(SDL_Surface* surface, int flag);
 
     // Function @ SDL_surface.h:347:29
-    public static int SDL_SaveBMP_RW(SDL_Surface* surface, SDL_RWops* dst, int freedst)
-    {
-        return _virtualTable.SDL_SaveBMP_RW(surface, dst, freedst);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SaveBMP_RW(SDL_Surface* surface, SDL_RWops* dst, int freedst);
 
     // Function @ SDL_surface.h:319:38
-    public static SDL_Surface* SDL_LoadBMP_RW(SDL_RWops* src, int freesrc)
-    {
-        return _virtualTable.SDL_LoadBMP_RW(src, freesrc);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Surface* SDL_LoadBMP_RW(SDL_RWops* src, int freesrc);
 
     // Function @ SDL_surface.h:303:30
-    public static void SDL_UnlockSurface(SDL_Surface* surface)
-    {
-        _virtualTable.SDL_UnlockSurface(surface);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_UnlockSurface(SDL_Surface* surface);
 
     // Function @ SDL_surface.h:294:29
-    public static int SDL_LockSurface(SDL_Surface* surface)
-    {
-        return _virtualTable.SDL_LockSurface(surface);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_LockSurface(SDL_Surface* surface);
 
     // Function @ SDL_surface.h:272:29
-    public static int SDL_SetSurfacePalette(SDL_Surface* surface, SDL_Palette* palette)
-    {
-        return _virtualTable.SDL_SetSurfacePalette(surface, palette);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetSurfacePalette(SDL_Surface* surface, SDL_Palette* palette);
 
     // Function @ SDL_surface.h:260:30
-    public static void SDL_FreeSurface(SDL_Surface* surface)
-    {
-        _virtualTable.SDL_FreeSurface(surface);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FreeSurface(SDL_Surface* surface);
 
     // Function @ SDL_surface.h:245:38
-    public static SDL_Surface* SDL_CreateRGBSurfaceWithFormatFrom(void* pixels, int width, int height, int depth, int pitch, uint format)
-    {
-        return _virtualTable.SDL_CreateRGBSurfaceWithFormatFrom(pixels, width, height, depth, pitch, format);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Surface* SDL_CreateRGBSurfaceWithFormatFrom(void* pixels, int width, int height, int depth, int pitch, uint format);
 
     // Function @ SDL_surface.h:210:38
-    public static SDL_Surface* SDL_CreateRGBSurfaceFrom(void* pixels, int width, int height, int depth, int pitch, uint Rmask, uint Gmask, uint Bmask, uint Amask)
-    {
-        return _virtualTable.SDL_CreateRGBSurfaceFrom(pixels, width, height, depth, pitch, Rmask, Gmask, Bmask, Amask);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Surface* SDL_CreateRGBSurfaceFrom(void* pixels, int width, int height, int depth, int pitch, uint Rmask, uint Gmask, uint Bmask, uint Amask);
 
     // Function @ SDL_surface.h:181:38
-    public static SDL_Surface* SDL_CreateRGBSurfaceWithFormat(uint flags, int width, int height, int depth, uint format)
-    {
-        return _virtualTable.SDL_CreateRGBSurfaceWithFormat(flags, width, height, depth, format);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Surface* SDL_CreateRGBSurfaceWithFormat(uint flags, int width, int height, int depth, uint format);
 
     // Function @ SDL_surface.h:156:38
-    public static SDL_Surface* SDL_CreateRGBSurface(uint flags, int width, int height, int depth, uint Rmask, uint Gmask, uint Bmask, uint Amask)
-    {
-        return _virtualTable.SDL_CreateRGBSurface(flags, width, height, depth, Rmask, Gmask, Bmask, Amask);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Surface* SDL_CreateRGBSurface(uint flags, int width, int height, int depth, uint Rmask, uint Gmask, uint Bmask, uint Amask);
 
     // Function @ SDL_blendmode.h:185:39
-    public static SDL_BlendMode SDL_ComposeCustomBlendMode(SDL_BlendFactor srcColorFactor, SDL_BlendFactor dstColorFactor, SDL_BlendOperation colorOperation, SDL_BlendFactor srcAlphaFactor, SDL_BlendFactor dstAlphaFactor, SDL_BlendOperation alphaOperation)
-    {
-        return _virtualTable.SDL_ComposeCustomBlendMode(srcColorFactor, dstColorFactor, colorOperation, srcAlphaFactor, dstAlphaFactor, alphaOperation);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_BlendMode SDL_ComposeCustomBlendMode(SDL_BlendFactor srcColorFactor, SDL_BlendFactor dstColorFactor, SDL_BlendOperation colorOperation, SDL_BlendFactor srcAlphaFactor, SDL_BlendFactor dstAlphaFactor, SDL_BlendOperation alphaOperation);
 
     // Function @ SDL_rect.h:205:34
-    public static CBool SDL_IntersectRectAndLine(SDL_Rect* rect, long* X1, long* Y1, long* X2, long* Y2)
-    {
-        return _virtualTable.SDL_IntersectRectAndLine(rect, X1, Y1, X2, Y2);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_IntersectRectAndLine(SDL_Rect* rect, long* X1, long* Y1, long* X2, long* Y2);
 
     // Function @ SDL_rect.h:184:34
-    public static CBool SDL_EnclosePoints(SDL_Point* points, int count, SDL_Rect* clip, SDL_Rect* result)
-    {
-        return _virtualTable.SDL_EnclosePoints(points, count, clip, result);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_EnclosePoints(SDL_Point* points, int count, SDL_Rect* clip, SDL_Rect* result);
 
     // Function @ SDL_rect.h:165:30
-    public static void SDL_UnionRect(SDL_Rect* A, SDL_Rect* B, SDL_Rect* result)
-    {
-        _virtualTable.SDL_UnionRect(A, B, result);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_UnionRect(SDL_Rect* A, SDL_Rect* B, SDL_Rect* result);
 
     // Function @ SDL_rect.h:153:34
-    public static CBool SDL_IntersectRect(SDL_Rect* A, SDL_Rect* B, SDL_Rect* result)
-    {
-        return _virtualTable.SDL_IntersectRect(A, B, result);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_IntersectRect(SDL_Rect* A, SDL_Rect* B, SDL_Rect* result);
 
     // Function @ SDL_rect.h:135:34
-    public static CBool SDL_HasIntersection(SDL_Rect* A, SDL_Rect* B)
-    {
-        return _virtualTable.SDL_HasIntersection(A, B);
-    }
-
-    // Function @ SDL_rect.h:116:27
-    public static CBool SDL_RectEquals(SDL_Rect* a, SDL_Rect* b)
-    {
-        return _virtualTable.SDL_RectEquals(a, b);
-    }
-
-    // Function @ SDL_rect.h:108:27
-    public static CBool SDL_RectEmpty(SDL_Rect* r)
-    {
-        return _virtualTable.SDL_RectEmpty(r);
-    }
-
-    // Function @ SDL_rect.h:99:27
-    public static CBool SDL_PointInRect(SDL_Point* p, SDL_Rect* r)
-    {
-        return _virtualTable.SDL_PointInRect(p, r);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasIntersection(SDL_Rect* A, SDL_Rect* B);
 
     // Function @ SDL_pixels.h:602:30
-    public static void SDL_CalculateGammaRamp(float gamma, ushort* ramp)
-    {
-        _virtualTable.SDL_CalculateGammaRamp(gamma, ramp);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_CalculateGammaRamp(float gamma, ushort* ramp);
 
     // Function @ SDL_pixels.h:589:30
-    public static void SDL_GetRGBA(uint pixel, SDL_PixelFormat* format, byte* r, byte* g, byte* b, byte* a)
-    {
-        _virtualTable.SDL_GetRGBA(pixel, format, r, g, b, a);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GetRGBA(uint pixel, SDL_PixelFormat* format, byte* r, byte* g, byte* b, byte* a);
 
     // Function @ SDL_pixels.h:562:30
-    public static void SDL_GetRGB(uint pixel, SDL_PixelFormat* format, byte* r, byte* g, byte* b)
-    {
-        _virtualTable.SDL_GetRGB(pixel, format, r, g, b);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GetRGB(uint pixel, SDL_PixelFormat* format, byte* r, byte* g, byte* b);
 
     // Function @ SDL_pixels.h:539:32
-    public static uint SDL_MapRGBA(SDL_PixelFormat* format, byte r, byte g, byte b, byte a)
-    {
-        return _virtualTable.SDL_MapRGBA(format, r, g, b, a);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_MapRGBA(SDL_PixelFormat* format, byte r, byte g, byte b, byte a);
 
     // Function @ SDL_pixels.h:506:32
-    public static uint SDL_MapRGB(SDL_PixelFormat* format, byte r, byte g, byte b)
-    {
-        return _virtualTable.SDL_MapRGB(format, r, g, b);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_MapRGB(SDL_PixelFormat* format, byte r, byte g, byte b);
 
     // Function @ SDL_pixels.h:476:30
-    public static void SDL_FreePalette(SDL_Palette* palette)
-    {
-        _virtualTable.SDL_FreePalette(palette);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FreePalette(SDL_Palette* palette);
 
     // Function @ SDL_pixels.h:465:29
-    public static int SDL_SetPaletteColors(SDL_Palette* palette, SDL_Color* colors, int firstcolor, int ncolors)
-    {
-        return _virtualTable.SDL_SetPaletteColors(palette, colors, firstcolor, ncolors);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetPaletteColors(SDL_Palette* palette, SDL_Color* colors, int firstcolor, int ncolors);
 
     // Function @ SDL_pixels.h:449:29
-    public static int SDL_SetPixelFormatPalette(SDL_PixelFormat* format, SDL_Palette* palette)
-    {
-        return _virtualTable.SDL_SetPixelFormatPalette(format, palette);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetPixelFormatPalette(SDL_PixelFormat* format, SDL_Palette* palette);
 
     // Function @ SDL_pixels.h:436:38
-    public static SDL_Palette* SDL_AllocPalette(int ncolors)
-    {
-        return _virtualTable.SDL_AllocPalette(ncolors);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_Palette* SDL_AllocPalette(int ncolors);
 
     // Function @ SDL_pixels.h:422:30
-    public static void SDL_FreeFormat(SDL_PixelFormat* format)
-    {
-        _virtualTable.SDL_FreeFormat(format);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FreeFormat(SDL_PixelFormat* format);
 
     // Function @ SDL_pixels.h:413:43
-    public static SDL_PixelFormat* SDL_AllocFormat(uint pixel_format)
-    {
-        return _virtualTable.SDL_AllocFormat(pixel_format);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_PixelFormat* SDL_AllocFormat(uint pixel_format);
 
     // Function @ SDL_pixels.h:394:32
-    public static uint SDL_MasksToPixelFormatEnum(int bpp, uint Rmask, uint Gmask, uint Bmask, uint Amask)
-    {
-        return _virtualTable.SDL_MasksToPixelFormatEnum(bpp, Rmask, Gmask, Bmask, Amask);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_MasksToPixelFormatEnum(int bpp, uint Rmask, uint Gmask, uint Bmask, uint Amask);
 
     // Function @ SDL_pixels.h:372:34
-    public static CBool SDL_PixelFormatEnumToMasks(uint format, long* bpp, uint* Rmask, uint* Gmask, uint* Bmask, uint* Amask)
-    {
-        return _virtualTable.SDL_PixelFormatEnumToMasks(format, bpp, Rmask, Gmask, Bmask, Amask);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_PixelFormatEnumToMasks(uint format, long* bpp, uint* Rmask, uint* Gmask, uint* Bmask, uint* Amask);
 
     // Function @ SDL_pixels.h:356:37
-    public static CString SDL_GetPixelFormatName(uint format)
-    {
-        return _virtualTable.SDL_GetPixelFormatName(format);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetPixelFormatName(uint format);
 
     // Function @ SDL_cpuinfo.h:512:30
-    public static void SDL_SIMDFree(void* ptr)
-    {
-        _virtualTable.SDL_SIMDFree(ptr);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SIMDFree(void* ptr);
 
     // Function @ SDL_cpuinfo.h:490:32
-    public static void* SDL_SIMDRealloc(void* mem, ulong len)
-    {
-        return _virtualTable.SDL_SIMDRealloc(mem, len);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_SIMDRealloc(void* mem, ulong len);
 
     // Function @ SDL_cpuinfo.h:468:32
-    public static void* SDL_SIMDAlloc(ulong len)
-    {
-        return _virtualTable.SDL_SIMDAlloc(len);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_SIMDAlloc(ulong len);
 
     // Function @ SDL_cpuinfo.h:431:32
-    public static ulong SDL_SIMDGetAlignment()
-    {
-        return _virtualTable.SDL_SIMDGetAlignment();
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_SIMDGetAlignment();
 
     // Function @ SDL_cpuinfo.h:415:29
-    public static int SDL_GetSystemRAM()
-    {
-        return _virtualTable.SDL_GetSystemRAM();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetSystemRAM();
 
     // Function @ SDL_cpuinfo.h:406:34
-    public static CBool SDL_HasNEON()
-    {
-        return _virtualTable.SDL_HasNEON();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasNEON();
 
     // Function @ SDL_cpuinfo.h:397:34
-    public static CBool SDL_HasARMSIMD()
-    {
-        return _virtualTable.SDL_HasARMSIMD();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasARMSIMD();
 
     // Function @ SDL_cpuinfo.h:384:34
-    public static CBool SDL_HasAVX512F()
-    {
-        return _virtualTable.SDL_HasAVX512F();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasAVX512F();
 
     // Function @ SDL_cpuinfo.h:373:34
-    public static CBool SDL_HasAVX2()
-    {
-        return _virtualTable.SDL_HasAVX2();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasAVX2();
 
     // Function @ SDL_cpuinfo.h:351:34
-    public static CBool SDL_HasAVX()
-    {
-        return _virtualTable.SDL_HasAVX();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasAVX();
 
     // Function @ SDL_cpuinfo.h:329:34
-    public static CBool SDL_HasSSE42()
-    {
-        return _virtualTable.SDL_HasSSE42();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasSSE42();
 
     // Function @ SDL_cpuinfo.h:309:34
-    public static CBool SDL_HasSSE41()
-    {
-        return _virtualTable.SDL_HasSSE41();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasSSE41();
 
     // Function @ SDL_cpuinfo.h:289:34
-    public static CBool SDL_HasSSE3()
-    {
-        return _virtualTable.SDL_HasSSE3();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasSSE3();
 
     // Function @ SDL_cpuinfo.h:269:34
-    public static CBool SDL_HasSSE2()
-    {
-        return _virtualTable.SDL_HasSSE2();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasSSE2();
 
     // Function @ SDL_cpuinfo.h:249:34
-    public static CBool SDL_HasSSE()
-    {
-        return _virtualTable.SDL_HasSSE();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasSSE();
 
     // Function @ SDL_cpuinfo.h:229:34
-    public static CBool SDL_Has3DNow()
-    {
-        return _virtualTable.SDL_Has3DNow();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_Has3DNow();
 
     // Function @ SDL_cpuinfo.h:209:34
-    public static CBool SDL_HasMMX()
-    {
-        return _virtualTable.SDL_HasMMX();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasMMX();
 
     // Function @ SDL_cpuinfo.h:189:34
-    public static CBool SDL_HasAltiVec()
-    {
-        return _virtualTable.SDL_HasAltiVec();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasAltiVec();
 
     // Function @ SDL_cpuinfo.h:169:34
-    public static CBool SDL_HasRDTSC()
-    {
-        return _virtualTable.SDL_HasRDTSC();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasRDTSC();
 
     // Function @ SDL_cpuinfo.h:149:29
-    public static int SDL_GetCPUCacheLineSize()
-    {
-        return _virtualTable.SDL_GetCPUCacheLineSize();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetCPUCacheLineSize();
 
     // Function @ SDL_cpuinfo.h:137:29
-    public static int SDL_GetCPUCount()
-    {
-        return _virtualTable.SDL_GetCPUCount();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetCPUCount();
 
     // Function @ SDL_clipboard.h:78:34
-    public static CBool SDL_HasClipboardText()
-    {
-        return _virtualTable.SDL_HasClipboardText();
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_HasClipboardText();
 
     // Function @ SDL_clipboard.h:66:32
-    public static CString SDL_GetClipboardText()
-    {
-        return _virtualTable.SDL_GetClipboardText();
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetClipboardText();
 
     // Function @ SDL_clipboard.h:51:29
-    public static int SDL_SetClipboardText(CString text)
-    {
-        return _virtualTable.SDL_SetClipboardText(text);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetClipboardText(CString text);
 
     // Function @ SDL_audio.h:1145:30
-    public static void SDL_CloseAudioDevice(SDL_AudioDeviceID dev)
-    {
-        _virtualTable.SDL_CloseAudioDevice(dev);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_CloseAudioDevice(SDL_AudioDeviceID dev);
 
     // Function @ SDL_audio.h:1144:30
-    public static void SDL_CloseAudio()
-    {
-        _virtualTable.SDL_CloseAudio();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_CloseAudio();
 
     // Function @ SDL_audio.h:1128:30
-    public static void SDL_UnlockAudioDevice(SDL_AudioDeviceID dev)
-    {
-        _virtualTable.SDL_UnlockAudioDevice(dev);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_UnlockAudioDevice(SDL_AudioDeviceID dev);
 
     // Function @ SDL_audio.h:1127:30
-    public static void SDL_UnlockAudio()
-    {
-        _virtualTable.SDL_UnlockAudio();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_UnlockAudio();
 
     // Function @ SDL_audio.h:1126:30
-    public static void SDL_LockAudioDevice(SDL_AudioDeviceID dev)
-    {
-        _virtualTable.SDL_LockAudioDevice(dev);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LockAudioDevice(SDL_AudioDeviceID dev);
 
     // Function @ SDL_audio.h:1125:30
-    public static void SDL_LockAudio()
-    {
-        _virtualTable.SDL_LockAudio();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_LockAudio();
 
     // Function @ SDL_audio.h:1113:30
-    public static void SDL_ClearQueuedAudio(SDL_AudioDeviceID dev)
-    {
-        _virtualTable.SDL_ClearQueuedAudio(dev);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_ClearQueuedAudio(SDL_AudioDeviceID dev);
 
     // Function @ SDL_audio.h:1079:32
-    public static uint SDL_GetQueuedAudioSize(SDL_AudioDeviceID dev)
-    {
-        return _virtualTable.SDL_GetQueuedAudioSize(dev);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_GetQueuedAudioSize(SDL_AudioDeviceID dev);
 
     // Function @ SDL_audio.h:1044:32
-    public static uint SDL_DequeueAudio(SDL_AudioDeviceID dev, void* data, uint len)
-    {
-        return _virtualTable.SDL_DequeueAudio(dev, data, len);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_DequeueAudio(SDL_AudioDeviceID dev, void* data, uint len);
 
     // Function @ SDL_audio.h:996:29
-    public static int SDL_QueueAudio(SDL_AudioDeviceID dev, void* data, uint len)
-    {
-        return _virtualTable.SDL_QueueAudio(dev, data, len);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_QueueAudio(SDL_AudioDeviceID dev, void* data, uint len);
 
     // Function @ SDL_audio.h:949:30
-    public static void SDL_MixAudioFormat(byte* dst, byte* src, SDL_AudioFormat format, uint len, int volume)
-    {
-        _virtualTable.SDL_MixAudioFormat(dst, src, format, len, volume);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_MixAudioFormat(byte* dst, byte* src, SDL_AudioFormat format, uint len, int volume);
 
     // Function @ SDL_audio.h:918:30
-    public static void SDL_MixAudio(byte* dst, byte* src, uint len, int volume)
-    {
-        _virtualTable.SDL_MixAudio(dst, src, len, volume);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_MixAudio(byte* dst, byte* src, uint len, int volume);
 
     // Function @ SDL_audio.h:895:30
-    public static void SDL_FreeAudioStream(SDL_AudioStream* stream)
-    {
-        _virtualTable.SDL_FreeAudioStream(stream);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FreeAudioStream(SDL_AudioStream* stream);
 
     // Function @ SDL_audio.h:883:30
-    public static void SDL_AudioStreamClear(SDL_AudioStream* stream)
-    {
-        _virtualTable.SDL_AudioStreamClear(stream);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_AudioStreamClear(SDL_AudioStream* stream);
 
     // Function @ SDL_audio.h:871:29
-    public static int SDL_AudioStreamFlush(SDL_AudioStream* stream)
-    {
-        return _virtualTable.SDL_AudioStreamFlush(stream);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_AudioStreamFlush(SDL_AudioStream* stream);
 
     // Function @ SDL_audio.h:854:29
-    public static int SDL_AudioStreamAvailable(SDL_AudioStream* stream)
-    {
-        return _virtualTable.SDL_AudioStreamAvailable(stream);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_AudioStreamAvailable(SDL_AudioStream* stream);
 
     // Function @ SDL_audio.h:839:29
-    public static int SDL_AudioStreamGet(SDL_AudioStream* stream, void* buf, int len)
-    {
-        return _virtualTable.SDL_AudioStreamGet(stream, buf, len);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_AudioStreamGet(SDL_AudioStream* stream, void* buf, int len);
 
     // Function @ SDL_audio.h:822:29
-    public static int SDL_AudioStreamPut(SDL_AudioStream* stream, void* buf, int len)
-    {
-        return _virtualTable.SDL_AudioStreamPut(stream, buf, len);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_AudioStreamPut(SDL_AudioStream* stream, void* buf, int len);
 
     // Function @ SDL_audio.h:800:43
-    public static SDL_AudioStream* SDL_NewAudioStream(SDL_AudioFormat src_format, byte src_channels, int src_rate, SDL_AudioFormat dst_format, byte dst_channels, int dst_rate)
-    {
-        return _virtualTable.SDL_NewAudioStream(src_format, src_channels, src_rate, dst_format, dst_channels, dst_rate);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_AudioStream* SDL_NewAudioStream(SDL_AudioFormat src_format, byte src_channels, int src_rate, SDL_AudioFormat dst_format, byte dst_channels, int dst_rate);
 
     // Function @ SDL_audio.h:769:29
-    public static int SDL_ConvertAudio(SDL_AudioCVT* cvt)
-    {
-        return _virtualTable.SDL_ConvertAudio(cvt);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_ConvertAudio(SDL_AudioCVT* cvt);
 
     // Function @ SDL_audio.h:725:29
-    public static int SDL_BuildAudioCVT(SDL_AudioCVT* cvt, SDL_AudioFormat src_format, byte src_channels, int src_rate, SDL_AudioFormat dst_format, byte dst_channels, int dst_rate)
-    {
-        return _virtualTable.SDL_BuildAudioCVT(cvt, src_format, src_channels, src_rate, dst_format, dst_channels, dst_rate);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_BuildAudioCVT(SDL_AudioCVT* cvt, SDL_AudioFormat src_format, byte src_channels, int src_rate, SDL_AudioFormat dst_format, byte dst_channels, int dst_rate);
 
     // Function @ SDL_audio.h:692:30
-    public static void SDL_FreeWAV(byte* audio_buf)
-    {
-        _virtualTable.SDL_FreeWAV(audio_buf);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FreeWAV(byte* audio_buf);
 
     // Function @ SDL_audio.h:666:40
-    public static SDL_AudioSpec* SDL_LoadWAV_RW(SDL_RWops* src, int freesrc, SDL_AudioSpec* spec, byte** audio_buf, uint* audio_len)
-    {
-        return _virtualTable.SDL_LoadWAV_RW(src, freesrc, spec, audio_buf, audio_len);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_AudioSpec* SDL_LoadWAV_RW(SDL_RWops* src, int freesrc, SDL_AudioSpec* spec, byte** audio_buf, uint* audio_len);
 
     // Function @ SDL_audio.h:587:30
-    public static void SDL_PauseAudioDevice(SDL_AudioDeviceID dev, int pause_on)
-    {
-        _virtualTable.SDL_PauseAudioDevice(dev, pause_on);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_PauseAudioDevice(SDL_AudioDeviceID dev, int pause_on);
 
     // Function @ SDL_audio.h:586:30
-    public static void SDL_PauseAudio(int pause_on)
-    {
-        _virtualTable.SDL_PauseAudio(pause_on);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_PauseAudio(int pause_on);
 
     // Function @ SDL_audio.h:573:41
-    public static SDL_AudioStatus SDL_GetAudioDeviceStatus(SDL_AudioDeviceID dev)
-    {
-        return _virtualTable.SDL_GetAudioDeviceStatus(dev);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_AudioStatus SDL_GetAudioDeviceStatus(SDL_AudioDeviceID dev);
 
     // Function @ SDL_audio.h:572:41
-    public static SDL_AudioStatus SDL_GetAudioStatus()
-    {
-        return _virtualTable.SDL_GetAudioStatus();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_AudioStatus SDL_GetAudioStatus();
 
     // Function @ SDL_audio.h:551:43
-    public static SDL_AudioDeviceID SDL_OpenAudioDevice(CString device, int iscapture, SDL_AudioSpec* desired, SDL_AudioSpec* obtained, int allowed_changes)
-    {
-        return _virtualTable.SDL_OpenAudioDevice(device, iscapture, desired, obtained, allowed_changes);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_AudioDeviceID SDL_OpenAudioDevice(CString device, int iscapture, SDL_AudioSpec* desired, SDL_AudioSpec* obtained, int allowed_changes);
 
     // Function @ SDL_audio.h:440:29
-    public static int SDL_GetAudioDeviceSpec(int index, int iscapture, SDL_AudioSpec* spec)
-    {
-        return _virtualTable.SDL_GetAudioDeviceSpec(index, iscapture, spec);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetAudioDeviceSpec(int index, int iscapture, SDL_AudioSpec* spec);
 
     // Function @ SDL_audio.h:415:37
-    public static CString SDL_GetAudioDeviceName(int index, int iscapture)
-    {
-        return _virtualTable.SDL_GetAudioDeviceName(index, iscapture);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetAudioDeviceName(int index, int iscapture);
 
     // Function @ SDL_audio.h:391:29
-    public static int SDL_GetNumAudioDevices(int iscapture)
-    {
-        return _virtualTable.SDL_GetNumAudioDevices(iscapture);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetNumAudioDevices(int iscapture);
 
     // Function @ SDL_audio.h:333:29
-    public static int SDL_OpenAudio(SDL_AudioSpec* desired, SDL_AudioSpec* obtained)
-    {
-        return _virtualTable.SDL_OpenAudio(desired, obtained);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_OpenAudio(SDL_AudioSpec* desired, SDL_AudioSpec* obtained);
 
     // Function @ SDL_audio.h:285:37
-    public static CString SDL_GetCurrentAudioDriver()
-    {
-        return _virtualTable.SDL_GetCurrentAudioDriver();
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetCurrentAudioDriver();
 
     // Function @ SDL_audio.h:266:30
-    public static void SDL_AudioQuit()
-    {
-        _virtualTable.SDL_AudioQuit();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_AudioQuit();
 
     // Function @ SDL_audio.h:265:29
-    public static int SDL_AudioInit(CString driver_name)
-    {
-        return _virtualTable.SDL_AudioInit(driver_name);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_AudioInit(CString driver_name);
 
     // Function @ SDL_audio.h:254:37
-    public static CString SDL_GetAudioDriver(int index)
-    {
-        return _virtualTable.SDL_GetAudioDriver(index);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetAudioDriver(int index);
 
     // Function @ SDL_audio.h:253:29
-    public static int SDL_GetNumAudioDrivers()
-    {
-        return _virtualTable.SDL_GetNumAudioDrivers();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetNumAudioDrivers();
 
     // Function @ SDL_rwops.h:401:32
-    public static ulong SDL_WriteBE64(SDL_RWops* dst, ulong value)
-    {
-        return _virtualTable.SDL_WriteBE64(dst, value);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_WriteBE64(SDL_RWops* dst, ulong value);
 
     // Function @ SDL_rwops.h:400:32
-    public static ulong SDL_WriteLE64(SDL_RWops* dst, ulong value)
-    {
-        return _virtualTable.SDL_WriteLE64(dst, value);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_WriteLE64(SDL_RWops* dst, ulong value);
 
     // Function @ SDL_rwops.h:399:32
-    public static ulong SDL_WriteBE32(SDL_RWops* dst, uint value)
-    {
-        return _virtualTable.SDL_WriteBE32(dst, value);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_WriteBE32(SDL_RWops* dst, uint value);
 
     // Function @ SDL_rwops.h:398:32
-    public static ulong SDL_WriteLE32(SDL_RWops* dst, uint value)
-    {
-        return _virtualTable.SDL_WriteLE32(dst, value);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_WriteLE32(SDL_RWops* dst, uint value);
 
     // Function @ SDL_rwops.h:397:32
-    public static ulong SDL_WriteBE16(SDL_RWops* dst, ushort value)
-    {
-        return _virtualTable.SDL_WriteBE16(dst, value);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_WriteBE16(SDL_RWops* dst, ushort value);
 
     // Function @ SDL_rwops.h:396:32
-    public static ulong SDL_WriteLE16(SDL_RWops* dst, ushort value)
-    {
-        return _virtualTable.SDL_WriteLE16(dst, value);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_WriteLE16(SDL_RWops* dst, ushort value);
 
     // Function @ SDL_rwops.h:395:32
-    public static ulong SDL_WriteU8(SDL_RWops* dst, byte value)
-    {
-        return _virtualTable.SDL_WriteU8(dst, value);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_WriteU8(SDL_RWops* dst, byte value);
 
     // Function @ SDL_rwops.h:386:32
-    public static ulong SDL_ReadBE64(SDL_RWops* src)
-    {
-        return _virtualTable.SDL_ReadBE64(src);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_ReadBE64(SDL_RWops* src);
 
     // Function @ SDL_rwops.h:385:32
-    public static ulong SDL_ReadLE64(SDL_RWops* src)
-    {
-        return _virtualTable.SDL_ReadLE64(src);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_ReadLE64(SDL_RWops* src);
 
     // Function @ SDL_rwops.h:384:32
-    public static uint SDL_ReadBE32(SDL_RWops* src)
-    {
-        return _virtualTable.SDL_ReadBE32(src);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_ReadBE32(SDL_RWops* src);
 
     // Function @ SDL_rwops.h:383:32
-    public static uint SDL_ReadLE32(SDL_RWops* src)
-    {
-        return _virtualTable.SDL_ReadLE32(src);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_ReadLE32(SDL_RWops* src);
 
     // Function @ SDL_rwops.h:382:32
-    public static ushort SDL_ReadBE16(SDL_RWops* src)
-    {
-        return _virtualTable.SDL_ReadBE16(src);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_ReadBE16(SDL_RWops* src);
 
     // Function @ SDL_rwops.h:381:32
-    public static ushort SDL_ReadLE16(SDL_RWops* src)
-    {
-        return _virtualTable.SDL_ReadLE16(src);
-    }
+    [DllImport("SDL2")]
+    public static extern ushort SDL_ReadLE16(SDL_RWops* src);
 
     // Function @ SDL_rwops.h:380:31
-    public static byte SDL_ReadU8(SDL_RWops* src)
-    {
-        return _virtualTable.SDL_ReadU8(src);
-    }
+    [DllImport("SDL2")]
+    public static extern byte SDL_ReadU8(SDL_RWops* src);
 
     // Function @ SDL_rwops.h:372:31
-    public static void* SDL_LoadFile(CString file, ulong* datasize)
-    {
-        return _virtualTable.SDL_LoadFile(file, datasize);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_LoadFile(CString file, ulong* datasize);
 
     // Function @ SDL_rwops.h:355:31
-    public static void* SDL_LoadFile_RW(SDL_RWops* src, ulong* datasize, int freesrc)
-    {
-        return _virtualTable.SDL_LoadFile_RW(src, datasize, freesrc);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_LoadFile_RW(SDL_RWops* src, ulong* datasize, int freesrc);
 
     // Function @ SDL_rwops.h:339:29
-    public static int SDL_RWclose(SDL_RWops* context)
-    {
-        return _virtualTable.SDL_RWclose(context);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_RWclose(SDL_RWops* context);
 
     // Function @ SDL_rwops.h:309:32
-    public static ulong SDL_RWwrite(SDL_RWops* context, void* ptr, ulong size, ulong num)
-    {
-        return _virtualTable.SDL_RWwrite(context, ptr, size, num);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_RWwrite(SDL_RWops* context, void* ptr, ulong size, ulong num);
 
     // Function @ SDL_rwops.h:279:32
-    public static ulong SDL_RWread(SDL_RWops* context, void* ptr, ulong size, ulong maxnum)
-    {
-        return _virtualTable.SDL_RWread(context, ptr, size, maxnum);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_RWread(SDL_RWops* context, void* ptr, ulong size, ulong maxnum);
 
     // Function @ SDL_rwops.h:251:32
-    public static long SDL_RWtell(SDL_RWops* context)
-    {
-        return _virtualTable.SDL_RWtell(context);
-    }
+    [DllImport("SDL2")]
+    public static extern long SDL_RWtell(SDL_RWops* context);
 
     // Function @ SDL_rwops.h:227:32
-    public static long SDL_RWseek(SDL_RWops* context, long offset, int whence)
-    {
-        return _virtualTable.SDL_RWseek(context, offset, whence);
-    }
+    [DllImport("SDL2")]
+    public static extern long SDL_RWseek(SDL_RWops* context, long offset, int whence);
 
     // Function @ SDL_rwops.h:194:32
-    public static long SDL_RWsize(SDL_RWops* context)
-    {
-        return _virtualTable.SDL_RWsize(context);
-    }
+    [DllImport("SDL2")]
+    public static extern long SDL_RWsize(SDL_RWops* context);
 
     // Function @ SDL_rwops.h:178:30
-    public static void SDL_FreeRW(SDL_RWops* area)
-    {
-        _virtualTable.SDL_FreeRW(area);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_FreeRW(SDL_RWops* area);
 
     // Function @ SDL_rwops.h:177:36
-    public static SDL_RWops* SDL_AllocRW()
-    {
-        return _virtualTable.SDL_AllocRW();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_RWops* SDL_AllocRW();
 
     // Function @ SDL_rwops.h:171:36
-    public static SDL_RWops* SDL_RWFromConstMem(void* mem, int size)
-    {
-        return _virtualTable.SDL_RWFromConstMem(mem, size);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_RWops* SDL_RWFromConstMem(void* mem, int size);
 
     // Function @ SDL_rwops.h:170:36
-    public static SDL_RWops* SDL_RWFromMem(void* mem, int size)
-    {
-        return _virtualTable.SDL_RWFromMem(mem, size);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_RWops* SDL_RWFromMem(void* mem, int size);
 
-    // Function @ SDL_rwops.h:166:36
-    public static SDL_RWops* SDL_RWFromFP(void* fp, CBool autoclose)
-    {
-        return _virtualTable.SDL_RWFromFP(fp, autoclose);
-    }
+    // Function @ SDL_rwops.h:163:36
+    [DllImport("SDL2")]
+    public static extern SDL_RWops* SDL_RWFromFP(FILE* fp, CBool autoclose);
 
     // Function @ SDL_rwops.h:159:36
-    public static SDL_RWops* SDL_RWFromFile(CString file, CString mode)
-    {
-        return _virtualTable.SDL_RWFromFile(file, mode);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_RWops* SDL_RWFromFile(CString file, CString mode);
 
     // Function @ SDL_thread.h:445:30
-    public static void SDL_TLSCleanup()
-    {
-        _virtualTable.SDL_TLSCleanup();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_TLSCleanup();
 
     // Function @ SDL_thread.h:440:29
-    public static int SDL_TLSSet(SDL_TLSID id, void* value, FnPtr_SDL_VoidPtr_Void destructor)
-    {
-        return _virtualTable.SDL_TLSSet(id, value, destructor);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_TLSSet(SDL_TLSID id, void* value, FnPtr_SDL_VoidPtr_Void destructor);
 
     // Function @ SDL_thread.h:415:32
-    public static void* SDL_TLSGet(SDL_TLSID id)
-    {
-        return _virtualTable.SDL_TLSGet(id);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_TLSGet(SDL_TLSID id);
 
     // Function @ SDL_thread.h:401:35
-    public static SDL_TLSID SDL_TLSCreate()
-    {
-        return _virtualTable.SDL_TLSCreate();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_TLSID SDL_TLSCreate();
 
     // Function @ SDL_thread.h:386:30
-    public static void SDL_DetachThread(SDL_Thread* thread)
-    {
-        _virtualTable.SDL_DetachThread(thread);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DetachThread(SDL_Thread* thread);
 
     // Function @ SDL_thread.h:350:30
-    public static void SDL_WaitThread(SDL_Thread* thread, long* status)
-    {
-        _virtualTable.SDL_WaitThread(thread, status);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_WaitThread(SDL_Thread* thread, long* status);
 
     // Function @ SDL_thread.h:317:29
-    public static int SDL_SetThreadPriority(SDL_ThreadPriority priority)
-    {
-        return _virtualTable.SDL_SetThreadPriority(priority);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetThreadPriority(SDL_ThreadPriority priority);
 
     // Function @ SDL_thread.h:304:38
-    public static SDL_threadID SDL_GetThreadID(SDL_Thread* thread)
-    {
-        return _virtualTable.SDL_GetThreadID(thread);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_threadID SDL_GetThreadID(SDL_Thread* thread);
 
     // Function @ SDL_thread.h:289:38
-    public static SDL_threadID SDL_ThreadID()
-    {
-        return _virtualTable.SDL_ThreadID();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_threadID SDL_ThreadID();
 
     // Function @ SDL_thread.h:273:37
-    public static CString SDL_GetThreadName(SDL_Thread* thread)
-    {
-        return _virtualTable.SDL_GetThreadName(thread);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetThreadName(SDL_Thread* thread);
 
-    // Function @ SDL_thread.h:135:1
-    public static SDL_Thread* SDL_CreateThreadWithStackSize(FnPtr_SDL_VoidPtr_Int fn, CString name, ulong stacksize, void* data, pfnSDL_CurrentBeginThread pfnBeginThread, pfnSDL_CurrentEndThread pfnEndThread)
-    {
-        return _virtualTable.SDL_CreateThreadWithStackSize(fn, name, stacksize, data, pfnBeginThread, pfnEndThread);
-    }
+    // Function @ SDL_thread.h:257:1
+    [DllImport("SDL2")]
+    public static extern SDL_Thread* SDL_CreateThreadWithStackSize(SDL_ThreadFunction fn, CString name, ulong stacksize, void* data);
 
-    // Function @ SDL_thread.h:130:1
-    public static SDL_Thread* SDL_CreateThread(SDL_ThreadFunction fn, CString name, void* data, pfnSDL_CurrentBeginThread pfnBeginThread, pfnSDL_CurrentEndThread pfnEndThread)
-    {
-        return _virtualTable.SDL_CreateThread(fn, name, data, pfnBeginThread, pfnEndThread);
-    }
+    // Function @ SDL_thread.h:212:1
+    [DllImport("SDL2")]
+    public static extern SDL_Thread* SDL_CreateThread(SDL_ThreadFunction fn, CString name, void* data);
 
     // Function @ SDL_mutex.h:422:29
-    public static int SDL_CondWaitTimeout(SDL_cond* cond, SDL_mutex* mutex, uint ms)
-    {
-        return _virtualTable.SDL_CondWaitTimeout(cond, mutex, ms);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_CondWaitTimeout(SDL_cond* cond, SDL_mutex* mutex, uint ms);
 
     // Function @ SDL_mutex.h:395:29
-    public static int SDL_CondWait(SDL_cond* cond, SDL_mutex* mutex)
-    {
-        return _virtualTable.SDL_CondWait(cond, mutex);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_CondWait(SDL_cond* cond, SDL_mutex* mutex);
 
     // Function @ SDL_mutex.h:369:29
-    public static int SDL_CondBroadcast(SDL_cond* cond)
-    {
-        return _virtualTable.SDL_CondBroadcast(cond);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_CondBroadcast(SDL_cond* cond);
 
     // Function @ SDL_mutex.h:354:29
-    public static int SDL_CondSignal(SDL_cond* cond)
-    {
-        return _virtualTable.SDL_CondSignal(cond);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_CondSignal(SDL_cond* cond);
 
     // Function @ SDL_mutex.h:339:30
-    public static void SDL_DestroyCond(SDL_cond* cond)
-    {
-        _virtualTable.SDL_DestroyCond(cond);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DestroyCond(SDL_cond* cond);
 
     // Function @ SDL_mutex.h:326:35
-    public static SDL_cond* SDL_CreateCond()
-    {
-        return _virtualTable.SDL_CreateCond();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_cond* SDL_CreateCond();
 
     // Function @ SDL_mutex.h:300:32
-    public static uint SDL_SemValue(SDL_sem* sem)
-    {
-        return _virtualTable.SDL_SemValue(sem);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_SemValue(SDL_sem* sem);
 
     // Function @ SDL_mutex.h:290:29
-    public static int SDL_SemPost(SDL_sem* sem)
-    {
-        return _virtualTable.SDL_SemPost(sem);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SemPost(SDL_sem* sem);
 
     // Function @ SDL_mutex.h:274:29
-    public static int SDL_SemWaitTimeout(SDL_sem* sem, uint ms)
-    {
-        return _virtualTable.SDL_SemWaitTimeout(sem, ms);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SemWaitTimeout(SDL_sem* sem, uint ms);
 
     // Function @ SDL_mutex.h:250:29
-    public static int SDL_SemTryWait(SDL_sem* sem)
-    {
-        return _virtualTable.SDL_SemTryWait(sem);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SemTryWait(SDL_sem* sem);
 
     // Function @ SDL_mutex.h:228:29
-    public static int SDL_SemWait(SDL_sem* sem)
-    {
-        return _virtualTable.SDL_SemWait(sem);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SemWait(SDL_sem* sem);
 
     // Function @ SDL_mutex.h:203:30
-    public static void SDL_DestroySemaphore(SDL_sem* sem)
-    {
-        _virtualTable.SDL_DestroySemaphore(sem);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DestroySemaphore(SDL_sem* sem);
 
     // Function @ SDL_mutex.h:186:34
-    public static SDL_sem* SDL_CreateSemaphore(uint initial_value)
-    {
-        return _virtualTable.SDL_CreateSemaphore(initial_value);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_sem* SDL_CreateSemaphore(uint initial_value);
 
     // Function @ SDL_mutex.h:152:30
-    public static void SDL_DestroyMutex(SDL_mutex* mutex)
-    {
-        _virtualTable.SDL_DestroyMutex(mutex);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_DestroyMutex(SDL_mutex* mutex);
 
     // Function @ SDL_mutex.h:133:29
-    public static int SDL_UnlockMutex(SDL_mutex* mutex)
-    {
-        return _virtualTable.SDL_UnlockMutex(mutex);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_UnlockMutex(SDL_mutex* mutex);
 
     // Function @ SDL_mutex.h:116:29
-    public static int SDL_TryLockMutex(SDL_mutex* mutex)
-    {
-        return _virtualTable.SDL_TryLockMutex(mutex);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_TryLockMutex(SDL_mutex* mutex);
 
     // Function @ SDL_mutex.h:95:29
-    public static int SDL_LockMutex(SDL_mutex* mutex)
-    {
-        return _virtualTable.SDL_LockMutex(mutex);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_LockMutex(SDL_mutex* mutex);
 
     // Function @ SDL_mutex.h:79:36
-    public static SDL_mutex* SDL_CreateMutex()
-    {
-        return _virtualTable.SDL_CreateMutex();
-    }
-
-    // Function @ SDL_endian.h:270:1
-    public static float SDL_SwapFloat(float x)
-    {
-        return _virtualTable.SDL_SwapFloat(x);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_mutex* SDL_CreateMutex();
 
     // Function @ SDL_error.h:143:29
-    public static int SDL_Error(SDL_errorcode code)
-    {
-        return _virtualTable.SDL_Error(code);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_Error(SDL_errorcode code);
 
     // Function @ SDL_error.h:121:30
-    public static void SDL_ClearError()
-    {
-        _virtualTable.SDL_ClearError();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_ClearError();
 
     // Function @ SDL_error.h:113:32
-    public static CString SDL_GetErrorMsg(CString errstr, int maxlen)
-    {
-        return _virtualTable.SDL_GetErrorMsg(errstr, maxlen);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetErrorMsg(CString errstr, int maxlen);
 
     // Function @ SDL_error.h:98:37
-    public static CString SDL_GetError()
-    {
-        return _virtualTable.SDL_GetError();
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetError();
 
     // Function @ SDL_error.h:64:29
-    public static int SDL_SetError(CString fmt)
-    {
-        return _virtualTable.SDL_SetError(fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetError(CString fmt);
 
     // Function @ SDL_atomic.h:370:31
-    public static void* SDL_AtomicGetPtr(void** a)
-    {
-        return _virtualTable.SDL_AtomicGetPtr(a);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_AtomicGetPtr(void** a);
 
     // Function @ SDL_atomic.h:356:31
-    public static void* SDL_AtomicSetPtr(void** a, void* v)
-    {
-        return _virtualTable.SDL_AtomicSetPtr(a, v);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_AtomicSetPtr(void** a, void* v);
 
     // Function @ SDL_atomic.h:341:34
-    public static CBool SDL_AtomicCASPtr(void** a, void* oldval, void* newval)
-    {
-        return _virtualTable.SDL_AtomicCASPtr(a, oldval, newval);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_AtomicCASPtr(void** a, void* oldval, void* newval);
 
     // Function @ SDL_atomic.h:304:29
-    public static int SDL_AtomicAdd(SDL_atomic_t* a, int v)
-    {
-        return _virtualTable.SDL_AtomicAdd(a, v);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_AtomicAdd(SDL_atomic_t* a, int v);
 
     // Function @ SDL_atomic.h:287:29
-    public static int SDL_AtomicGet(SDL_atomic_t* a)
-    {
-        return _virtualTable.SDL_AtomicGet(a);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_AtomicGet(SDL_atomic_t* a);
 
     // Function @ SDL_atomic.h:274:29
-    public static int SDL_AtomicSet(SDL_atomic_t* a, int v)
-    {
-        return _virtualTable.SDL_AtomicSet(a, v);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_AtomicSet(SDL_atomic_t* a, int v);
 
     // Function @ SDL_atomic.h:258:34
-    public static CBool SDL_AtomicCAS(SDL_atomic_t* a, int oldval, int newval)
-    {
-        return _virtualTable.SDL_AtomicCAS(a, oldval, newval);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_AtomicCAS(SDL_atomic_t* a, int oldval, int newval);
 
     // Function @ SDL_atomic.h:178:30
-    public static void SDL_MemoryBarrierAcquireFunction()
-    {
-        _virtualTable.SDL_MemoryBarrierAcquireFunction();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_MemoryBarrierAcquireFunction();
 
     // Function @ SDL_atomic.h:177:30
-    public static void SDL_MemoryBarrierReleaseFunction()
-    {
-        _virtualTable.SDL_MemoryBarrierReleaseFunction();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_MemoryBarrierReleaseFunction();
 
     // Function @ SDL_atomic.h:134:30
-    public static void SDL_AtomicUnlock(SDL_SpinLock* @lock)
-    {
-        _virtualTable.SDL_AtomicUnlock(@lock);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_AtomicUnlock(SDL_SpinLock* @lock);
 
     // Function @ SDL_atomic.h:117:30
-    public static void SDL_AtomicLock(SDL_SpinLock* @lock)
-    {
-        _virtualTable.SDL_AtomicLock(@lock);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_AtomicLock(SDL_SpinLock* @lock);
 
     // Function @ SDL_atomic.h:104:34
-    public static CBool SDL_AtomicTryLock(SDL_SpinLock* @lock)
-    {
-        return _virtualTable.SDL_AtomicTryLock(@lock);
-    }
+    [DllImport("SDL2")]
+    public static extern CBool SDL_AtomicTryLock(SDL_SpinLock* @lock);
 
     // Function @ SDL_assert.h:302:30
-    public static void SDL_ResetAssertionReport()
-    {
-        _virtualTable.SDL_ResetAssertionReport();
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_ResetAssertionReport();
 
     // Function @ SDL_assert.h:290:48
-    public static SDL_AssertData* SDL_GetAssertionReport()
-    {
-        return _virtualTable.SDL_GetAssertionReport();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_AssertData* SDL_GetAssertionReport();
 
     // Function @ SDL_assert.h:264:46
-    public static SDL_AssertionHandler SDL_GetAssertionHandler(void** puserdata)
-    {
-        return _virtualTable.SDL_GetAssertionHandler(puserdata);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_AssertionHandler SDL_GetAssertionHandler(void** puserdata);
 
     // Function @ SDL_assert.h:241:46
-    public static SDL_AssertionHandler SDL_GetDefaultAssertionHandler()
-    {
-        return _virtualTable.SDL_GetDefaultAssertionHandler();
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_AssertionHandler SDL_GetDefaultAssertionHandler();
 
     // Function @ SDL_assert.h:222:30
-    public static void SDL_SetAssertionHandler(SDL_AssertionHandler handler, void* userdata)
-    {
-        _virtualTable.SDL_SetAssertionHandler(handler, userdata);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_SetAssertionHandler(SDL_AssertionHandler handler, void* userdata);
 
     // Function @ SDL_assert.h:129:41
-    public static SDL_AssertState SDL_ReportAssertion(SDL_AssertData* param, CString param2, CString param3, int param4)
-    {
-        return _virtualTable.SDL_ReportAssertion(param, param2, param3, param4);
-    }
-
-    // Function @ SDL_assert.h:52:25
-    public static void __debugbreak()
-    {
-        _virtualTable.__debugbreak();
-    }
-
-    // Function @ SDL_stdinc.h:674:24
-    public static void* SDL_memcpy4(void* dst, void* src, ulong dwords)
-    {
-        return _virtualTable.SDL_memcpy4(dst, src, dwords);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_AssertState SDL_ReportAssertion(SDL_AssertData* param, CString param2, CString param3, int param4);
 
     // Function @ SDL_stdinc.h:619:31
-    public static CString SDL_iconv_string(CString tocode, CString fromcode, CString inbuf, ulong inbytesleft)
-    {
-        return _virtualTable.SDL_iconv_string(tocode, fromcode, inbuf, inbytesleft);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_iconv_string(CString tocode, CString fromcode, CString inbuf, ulong inbytesleft);
 
     // Function @ SDL_stdinc.h:612:32
-    public static ulong SDL_iconv(SDL_iconv_t cd, CString* inbuf, ulong* inbytesleft, CString* outbuf, ulong* outbytesleft)
-    {
-        return _virtualTable.SDL_iconv(cd, inbuf, inbytesleft, outbuf, outbytesleft);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_iconv(SDL_iconv_t cd, CString* inbuf, ulong* inbytesleft, CString* outbuf, ulong* outbytesleft);
 
     // Function @ SDL_stdinc.h:611:29
-    public static int SDL_iconv_close(SDL_iconv_t cd)
-    {
-        return _virtualTable.SDL_iconv_close(cd);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_iconv_close(SDL_iconv_t cd);
 
     // Function @ SDL_stdinc.h:609:37
-    public static SDL_iconv_t SDL_iconv_open(CString tocode, CString fromcode)
-    {
-        return _virtualTable.SDL_iconv_open(tocode, fromcode);
-    }
+    [DllImport("SDL2")]
+    public static extern SDL_iconv_t SDL_iconv_open(CString tocode, CString fromcode);
 
     // Function @ SDL_stdinc.h:599:31
-    public static float SDL_tanf(float x)
-    {
-        return _virtualTable.SDL_tanf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_tanf(float x);
 
     // Function @ SDL_stdinc.h:598:32
-    public static double SDL_tan(double x)
-    {
-        return _virtualTable.SDL_tan(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_tan(double x);
 
     // Function @ SDL_stdinc.h:597:31
-    public static float SDL_sqrtf(float x)
-    {
-        return _virtualTable.SDL_sqrtf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_sqrtf(float x);
 
     // Function @ SDL_stdinc.h:596:32
-    public static double SDL_sqrt(double x)
-    {
-        return _virtualTable.SDL_sqrt(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_sqrt(double x);
 
     // Function @ SDL_stdinc.h:595:31
-    public static float SDL_sinf(float x)
-    {
-        return _virtualTable.SDL_sinf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_sinf(float x);
 
     // Function @ SDL_stdinc.h:594:32
-    public static double SDL_sin(double x)
-    {
-        return _virtualTable.SDL_sin(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_sin(double x);
 
     // Function @ SDL_stdinc.h:593:31
-    public static float SDL_scalbnf(float x, int n)
-    {
-        return _virtualTable.SDL_scalbnf(x, n);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_scalbnf(float x, int n);
 
     // Function @ SDL_stdinc.h:592:32
-    public static double SDL_scalbn(double x, int n)
-    {
-        return _virtualTable.SDL_scalbn(x, n);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_scalbn(double x, int n);
 
     // Function @ SDL_stdinc.h:591:30
-    public static int SDL_lroundf(float x)
-    {
-        return _virtualTable.SDL_lroundf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern long SDL_lroundf(float x);
 
     // Function @ SDL_stdinc.h:590:30
-    public static int SDL_lround(double x)
-    {
-        return _virtualTable.SDL_lround(x);
-    }
+    [DllImport("SDL2")]
+    public static extern long SDL_lround(double x);
 
     // Function @ SDL_stdinc.h:589:31
-    public static float SDL_roundf(float x)
-    {
-        return _virtualTable.SDL_roundf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_roundf(float x);
 
     // Function @ SDL_stdinc.h:588:32
-    public static double SDL_round(double x)
-    {
-        return _virtualTable.SDL_round(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_round(double x);
 
     // Function @ SDL_stdinc.h:587:31
-    public static float SDL_powf(float x, float y)
-    {
-        return _virtualTable.SDL_powf(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_powf(float x, float y);
 
     // Function @ SDL_stdinc.h:586:32
-    public static double SDL_pow(double x, double y)
-    {
-        return _virtualTable.SDL_pow(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_pow(double x, double y);
 
     // Function @ SDL_stdinc.h:585:31
-    public static float SDL_log10f(float x)
-    {
-        return _virtualTable.SDL_log10f(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_log10f(float x);
 
     // Function @ SDL_stdinc.h:584:32
-    public static double SDL_log10(double x)
-    {
-        return _virtualTable.SDL_log10(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_log10(double x);
 
     // Function @ SDL_stdinc.h:583:31
-    public static float SDL_logf(float x)
-    {
-        return _virtualTable.SDL_logf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_logf(float x);
 
     // Function @ SDL_stdinc.h:582:32
-    public static double SDL_log(double x)
-    {
-        return _virtualTable.SDL_log(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_log(double x);
 
     // Function @ SDL_stdinc.h:581:31
-    public static float SDL_fmodf(float x, float y)
-    {
-        return _virtualTable.SDL_fmodf(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_fmodf(float x, float y);
 
     // Function @ SDL_stdinc.h:580:32
-    public static double SDL_fmod(double x, double y)
-    {
-        return _virtualTable.SDL_fmod(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_fmod(double x, double y);
 
     // Function @ SDL_stdinc.h:579:31
-    public static float SDL_truncf(float x)
-    {
-        return _virtualTable.SDL_truncf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_truncf(float x);
 
     // Function @ SDL_stdinc.h:578:32
-    public static double SDL_trunc(double x)
-    {
-        return _virtualTable.SDL_trunc(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_trunc(double x);
 
     // Function @ SDL_stdinc.h:577:31
-    public static float SDL_floorf(float x)
-    {
-        return _virtualTable.SDL_floorf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_floorf(float x);
 
     // Function @ SDL_stdinc.h:576:32
-    public static double SDL_floor(double x)
-    {
-        return _virtualTable.SDL_floor(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_floor(double x);
 
     // Function @ SDL_stdinc.h:575:31
-    public static float SDL_fabsf(float x)
-    {
-        return _virtualTable.SDL_fabsf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_fabsf(float x);
 
     // Function @ SDL_stdinc.h:574:32
-    public static double SDL_fabs(double x)
-    {
-        return _virtualTable.SDL_fabs(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_fabs(double x);
 
     // Function @ SDL_stdinc.h:573:31
-    public static float SDL_expf(float x)
-    {
-        return _virtualTable.SDL_expf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_expf(float x);
 
     // Function @ SDL_stdinc.h:572:32
-    public static double SDL_exp(double x)
-    {
-        return _virtualTable.SDL_exp(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_exp(double x);
 
     // Function @ SDL_stdinc.h:571:31
-    public static float SDL_cosf(float x)
-    {
-        return _virtualTable.SDL_cosf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_cosf(float x);
 
     // Function @ SDL_stdinc.h:570:32
-    public static double SDL_cos(double x)
-    {
-        return _virtualTable.SDL_cos(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_cos(double x);
 
     // Function @ SDL_stdinc.h:569:31
-    public static float SDL_copysignf(float x, float y)
-    {
-        return _virtualTable.SDL_copysignf(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_copysignf(float x, float y);
 
     // Function @ SDL_stdinc.h:568:32
-    public static double SDL_copysign(double x, double y)
-    {
-        return _virtualTable.SDL_copysign(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_copysign(double x, double y);
 
     // Function @ SDL_stdinc.h:567:31
-    public static float SDL_ceilf(float x)
-    {
-        return _virtualTable.SDL_ceilf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_ceilf(float x);
 
     // Function @ SDL_stdinc.h:566:32
-    public static double SDL_ceil(double x)
-    {
-        return _virtualTable.SDL_ceil(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_ceil(double x);
 
     // Function @ SDL_stdinc.h:565:31
-    public static float SDL_atan2f(float x, float y)
-    {
-        return _virtualTable.SDL_atan2f(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_atan2f(float x, float y);
 
     // Function @ SDL_stdinc.h:564:32
-    public static double SDL_atan2(double x, double y)
-    {
-        return _virtualTable.SDL_atan2(x, y);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_atan2(double x, double y);
 
     // Function @ SDL_stdinc.h:563:31
-    public static float SDL_atanf(float x)
-    {
-        return _virtualTable.SDL_atanf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_atanf(float x);
 
     // Function @ SDL_stdinc.h:562:32
-    public static double SDL_atan(double x)
-    {
-        return _virtualTable.SDL_atan(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_atan(double x);
 
     // Function @ SDL_stdinc.h:561:31
-    public static float SDL_asinf(float x)
-    {
-        return _virtualTable.SDL_asinf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_asinf(float x);
 
     // Function @ SDL_stdinc.h:560:32
-    public static double SDL_asin(double x)
-    {
-        return _virtualTable.SDL_asin(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_asin(double x);
 
     // Function @ SDL_stdinc.h:559:31
-    public static float SDL_acosf(float x)
-    {
-        return _virtualTable.SDL_acosf(x);
-    }
+    [DllImport("SDL2")]
+    public static extern float SDL_acosf(float x);
 
     // Function @ SDL_stdinc.h:558:32
-    public static double SDL_acos(double x)
-    {
-        return _virtualTable.SDL_acos(x);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_acos(double x);
 
     // Function @ SDL_stdinc.h:550:29
-    public static int SDL_vsnprintf(CString text, ulong maxlen, CString fmt, IntPtr ap)
-    {
-        return _virtualTable.SDL_vsnprintf(text, maxlen, fmt, ap);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_vsnprintf(CString text, ulong maxlen, CString fmt, IntPtr ap);
 
     // Function @ SDL_stdinc.h:549:29
-    public static int SDL_snprintf(CString text, ulong maxlen, CString fmt)
-    {
-        return _virtualTable.SDL_snprintf(text, maxlen, fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_snprintf(CString text, ulong maxlen, CString fmt);
 
     // Function @ SDL_stdinc.h:548:29
-    public static int SDL_vsscanf(CString text, CString fmt, IntPtr ap)
-    {
-        return _virtualTable.SDL_vsscanf(text, fmt, ap);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_vsscanf(CString text, CString fmt, IntPtr ap);
 
     // Function @ SDL_stdinc.h:547:29
-    public static int SDL_sscanf(CString text, CString fmt)
-    {
-        return _virtualTable.SDL_sscanf(text, fmt);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_sscanf(CString text, CString fmt);
 
     // Function @ SDL_stdinc.h:545:29
-    public static int SDL_strncasecmp(CString str1, CString str2, ulong len)
-    {
-        return _virtualTable.SDL_strncasecmp(str1, str2, len);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_strncasecmp(CString str1, CString str2, ulong len);
 
     // Function @ SDL_stdinc.h:544:29
-    public static int SDL_strcasecmp(CString str1, CString str2)
-    {
-        return _virtualTable.SDL_strcasecmp(str1, str2);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_strcasecmp(CString str1, CString str2);
 
     // Function @ SDL_stdinc.h:543:29
-    public static int SDL_strncmp(CString str1, CString str2, ulong maxlen)
-    {
-        return _virtualTable.SDL_strncmp(str1, str2, maxlen);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_strncmp(CString str1, CString str2, ulong maxlen);
 
     // Function @ SDL_stdinc.h:542:29
-    public static int SDL_strcmp(CString str1, CString str2)
-    {
-        return _virtualTable.SDL_strcmp(str1, str2);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_strcmp(CString str1, CString str2);
 
     // Function @ SDL_stdinc.h:540:32
-    public static double SDL_strtod(CString str, CString* endp)
-    {
-        return _virtualTable.SDL_strtod(str, endp);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_strtod(CString str, CString* endp);
 
     // Function @ SDL_stdinc.h:539:32
-    public static ulong SDL_strtoull(CString str, CString* endp, int @base)
-    {
-        return _virtualTable.SDL_strtoull(str, endp, @base);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_strtoull(CString str, CString* endp, int @base);
 
     // Function @ SDL_stdinc.h:538:32
-    public static long SDL_strtoll(CString str, CString* endp, int @base)
-    {
-        return _virtualTable.SDL_strtoll(str, endp, @base);
-    }
+    [DllImport("SDL2")]
+    public static extern long SDL_strtoll(CString str, CString* endp, int @base);
 
     // Function @ SDL_stdinc.h:537:39
-    public static uint SDL_strtoul(CString str, CString* endp, int @base)
-    {
-        return _virtualTable.SDL_strtoul(str, endp, @base);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_strtoul(CString str, CString* endp, int @base);
 
     // Function @ SDL_stdinc.h:536:30
-    public static int SDL_strtol(CString str, CString* endp, int @base)
-    {
-        return _virtualTable.SDL_strtol(str, endp, @base);
-    }
+    [DllImport("SDL2")]
+    public static extern long SDL_strtol(CString str, CString* endp, int @base);
 
     // Function @ SDL_stdinc.h:535:32
-    public static double SDL_atof(CString str)
-    {
-        return _virtualTable.SDL_atof(str);
-    }
+    [DllImport("SDL2")]
+    public static extern double SDL_atof(CString str);
 
     // Function @ SDL_stdinc.h:534:29
-    public static int SDL_atoi(CString str)
-    {
-        return _virtualTable.SDL_atoi(str);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_atoi(CString str);
 
     // Function @ SDL_stdinc.h:532:31
-    public static CString SDL_ulltoa(ulong value, CString str, int radix)
-    {
-        return _virtualTable.SDL_ulltoa(value, str, radix);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_ulltoa(ulong value, CString str, int radix);
 
     // Function @ SDL_stdinc.h:531:31
-    public static CString SDL_lltoa(long value, CString str, int radix)
-    {
-        return _virtualTable.SDL_lltoa(value, str, radix);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_lltoa(long value, CString str, int radix);
 
     // Function @ SDL_stdinc.h:530:31
-    public static CString SDL_ultoa(uint value, CString str, int radix)
-    {
-        return _virtualTable.SDL_ultoa(value, str, radix);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_ultoa(ulong value, CString str, int radix);
 
     // Function @ SDL_stdinc.h:529:31
-    public static CString SDL_ltoa(int value, CString str, int radix)
-    {
-        return _virtualTable.SDL_ltoa(value, str, radix);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_ltoa(long value, CString str, int radix);
 
     // Function @ SDL_stdinc.h:528:31
-    public static CString SDL_uitoa(uint value, CString str, int radix)
-    {
-        return _virtualTable.SDL_uitoa(value, str, radix);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_uitoa(uint value, CString str, int radix);
 
     // Function @ SDL_stdinc.h:527:31
-    public static CString SDL_itoa(int value, CString str, int radix)
-    {
-        return _virtualTable.SDL_itoa(value, str, radix);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_itoa(int value, CString str, int radix);
 
     // Function @ SDL_stdinc.h:525:32
-    public static ulong SDL_utf8strlen(CString str)
-    {
-        return _virtualTable.SDL_utf8strlen(str);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_utf8strlen(CString str);
 
     // Function @ SDL_stdinc.h:524:31
-    public static CString SDL_strtokr(CString s1, CString s2, CString* saveptr)
-    {
-        return _virtualTable.SDL_strtokr(s1, s2, saveptr);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_strtokr(CString s1, CString s2, CString* saveptr);
 
     // Function @ SDL_stdinc.h:523:31
-    public static CString SDL_strstr(CString haystack, CString needle)
-    {
-        return _virtualTable.SDL_strstr(haystack, needle);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_strstr(CString haystack, CString needle);
 
     // Function @ SDL_stdinc.h:522:31
-    public static CString SDL_strrchr(CString str, int c)
-    {
-        return _virtualTable.SDL_strrchr(str, c);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_strrchr(CString str, int c);
 
     // Function @ SDL_stdinc.h:521:31
-    public static CString SDL_strchr(CString str, int c)
-    {
-        return _virtualTable.SDL_strchr(str, c);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_strchr(CString str, int c);
 
     // Function @ SDL_stdinc.h:520:31
-    public static CString SDL_strlwr(CString str)
-    {
-        return _virtualTable.SDL_strlwr(str);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_strlwr(CString str);
 
     // Function @ SDL_stdinc.h:519:31
-    public static CString SDL_strupr(CString str)
-    {
-        return _virtualTable.SDL_strupr(str);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_strupr(CString str);
 
     // Function @ SDL_stdinc.h:518:31
-    public static CString SDL_strrev(CString str)
-    {
-        return _virtualTable.SDL_strrev(str);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_strrev(CString str);
 
     // Function @ SDL_stdinc.h:517:31
-    public static CString SDL_strdup(CString str)
-    {
-        return _virtualTable.SDL_strdup(str);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_strdup(CString str);
 
     // Function @ SDL_stdinc.h:516:32
-    public static ulong SDL_strlcat(CString dst, CString src, ulong maxlen)
-    {
-        return _virtualTable.SDL_strlcat(dst, src, maxlen);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_strlcat(CString dst, CString src, ulong maxlen);
 
     // Function @ SDL_stdinc.h:515:32
-    public static ulong SDL_utf8strlcpy(CString dst, CString src, ulong dst_bytes)
-    {
-        return _virtualTable.SDL_utf8strlcpy(dst, src, dst_bytes);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_utf8strlcpy(CString dst, CString src, ulong dst_bytes);
 
     // Function @ SDL_stdinc.h:514:32
-    public static ulong SDL_strlcpy(CString dst, CString src, ulong maxlen)
-    {
-        return _virtualTable.SDL_strlcpy(dst, src, maxlen);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_strlcpy(CString dst, CString src, ulong maxlen);
 
     // Function @ SDL_stdinc.h:513:32
-    public static ulong SDL_strlen(CString str)
-    {
-        return _virtualTable.SDL_strlen(str);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_strlen(CString str);
 
     // Function @ SDL_stdinc.h:511:29
-    public static int SDL_wcsncasecmp(wchar_t* str1, wchar_t* str2, ulong len)
-    {
-        return _virtualTable.SDL_wcsncasecmp(str1, str2, len);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_wcsncasecmp(wchar_t* str1, wchar_t* str2, ulong len);
 
     // Function @ SDL_stdinc.h:510:29
-    public static int SDL_wcscasecmp(wchar_t* str1, wchar_t* str2)
-    {
-        return _virtualTable.SDL_wcscasecmp(str1, str2);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_wcscasecmp(wchar_t* str1, wchar_t* str2);
 
     // Function @ SDL_stdinc.h:509:29
-    public static int SDL_wcsncmp(wchar_t* str1, wchar_t* str2, ulong maxlen)
-    {
-        return _virtualTable.SDL_wcsncmp(str1, str2, maxlen);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_wcsncmp(wchar_t* str1, wchar_t* str2, ulong maxlen);
 
     // Function @ SDL_stdinc.h:508:29
-    public static int SDL_wcscmp(wchar_t* str1, wchar_t* str2)
-    {
-        return _virtualTable.SDL_wcscmp(str1, str2);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_wcscmp(wchar_t* str1, wchar_t* str2);
 
     // Function @ SDL_stdinc.h:506:34
-    public static wchar_t* SDL_wcsstr(wchar_t* haystack, wchar_t* needle)
-    {
-        return _virtualTable.SDL_wcsstr(haystack, needle);
-    }
+    [DllImport("SDL2")]
+    public static extern wchar_t* SDL_wcsstr(wchar_t* haystack, wchar_t* needle);
 
     // Function @ SDL_stdinc.h:505:34
-    public static wchar_t* SDL_wcsdup(wchar_t* wstr)
-    {
-        return _virtualTable.SDL_wcsdup(wstr);
-    }
+    [DllImport("SDL2")]
+    public static extern wchar_t* SDL_wcsdup(wchar_t* wstr);
 
     // Function @ SDL_stdinc.h:504:32
-    public static ulong SDL_wcslcat(wchar_t* dst, wchar_t* src, ulong maxlen)
-    {
-        return _virtualTable.SDL_wcslcat(dst, src, maxlen);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_wcslcat(wchar_t* dst, wchar_t* src, ulong maxlen);
 
     // Function @ SDL_stdinc.h:503:32
-    public static ulong SDL_wcslcpy(wchar_t* dst, wchar_t* src, ulong maxlen)
-    {
-        return _virtualTable.SDL_wcslcpy(dst, src, maxlen);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_wcslcpy(wchar_t* dst, wchar_t* src, ulong maxlen);
 
     // Function @ SDL_stdinc.h:502:32
-    public static ulong SDL_wcslen(wchar_t* wstr)
-    {
-        return _virtualTable.SDL_wcslen(wstr);
-    }
+    [DllImport("SDL2")]
+    public static extern ulong SDL_wcslen(wchar_t* wstr);
 
     // Function @ SDL_stdinc.h:500:29
-    public static int SDL_memcmp(void* s1, void* s2, ulong len)
-    {
-        return _virtualTable.SDL_memcmp(s1, s2, len);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_memcmp(void* s1, void* s2, ulong len);
 
     // Function @ SDL_stdinc.h:499:31
-    public static void* SDL_memmove(void* dst, void* src, ulong len)
-    {
-        return _virtualTable.SDL_memmove(dst, src, len);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_memmove(void* dst, void* src, ulong len);
 
     // Function @ SDL_stdinc.h:497:31
-    public static void* SDL_memcpy(void* dst, void* src, ulong len)
-    {
-        return _virtualTable.SDL_memcpy(dst, src, len);
-    }
-
-    // Function @ SDL_stdinc.h:467:23
-    public static void SDL_memset4(void* dst, uint val, ulong dwords)
-    {
-        _virtualTable.SDL_memset4(dst, val, dwords);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_memcpy(void* dst, void* src, ulong len);
 
     // Function @ SDL_stdinc.h:460:31
-    public static void* SDL_memset(void* dst, int c, ulong len)
-    {
-        return _virtualTable.SDL_memset(dst, c, len);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_memset(void* dst, int c, ulong len);
 
     // Function @ SDL_stdinc.h:458:32
-    public static uint SDL_crc32(uint crc, void* data, ulong len)
-    {
-        return _virtualTable.SDL_crc32(crc, data, len);
-    }
+    [DllImport("SDL2")]
+    public static extern uint SDL_crc32(uint crc, void* data, ulong len);
 
     // Function @ SDL_stdinc.h:456:29
-    public static int SDL_tolower(int x)
-    {
-        return _virtualTable.SDL_tolower(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_tolower(int x);
 
     // Function @ SDL_stdinc.h:455:29
-    public static int SDL_toupper(int x)
-    {
-        return _virtualTable.SDL_toupper(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_toupper(int x);
 
     // Function @ SDL_stdinc.h:454:29
-    public static int SDL_isgraph(int x)
-    {
-        return _virtualTable.SDL_isgraph(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_isgraph(int x);
 
     // Function @ SDL_stdinc.h:453:29
-    public static int SDL_isprint(int x)
-    {
-        return _virtualTable.SDL_isprint(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_isprint(int x);
 
     // Function @ SDL_stdinc.h:452:29
-    public static int SDL_islower(int x)
-    {
-        return _virtualTable.SDL_islower(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_islower(int x);
 
     // Function @ SDL_stdinc.h:451:29
-    public static int SDL_isupper(int x)
-    {
-        return _virtualTable.SDL_isupper(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_isupper(int x);
 
     // Function @ SDL_stdinc.h:450:29
-    public static int SDL_isspace(int x)
-    {
-        return _virtualTable.SDL_isspace(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_isspace(int x);
 
     // Function @ SDL_stdinc.h:449:29
-    public static int SDL_ispunct(int x)
-    {
-        return _virtualTable.SDL_ispunct(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_ispunct(int x);
 
     // Function @ SDL_stdinc.h:448:29
-    public static int SDL_isxdigit(int x)
-    {
-        return _virtualTable.SDL_isxdigit(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_isxdigit(int x);
 
     // Function @ SDL_stdinc.h:447:29
-    public static int SDL_isdigit(int x)
-    {
-        return _virtualTable.SDL_isdigit(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_isdigit(int x);
 
     // Function @ SDL_stdinc.h:446:29
-    public static int SDL_iscntrl(int x)
-    {
-        return _virtualTable.SDL_iscntrl(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_iscntrl(int x);
 
     // Function @ SDL_stdinc.h:445:29
-    public static int SDL_isblank(int x)
-    {
-        return _virtualTable.SDL_isblank(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_isblank(int x);
 
     // Function @ SDL_stdinc.h:444:29
-    public static int SDL_isalnum(int x)
-    {
-        return _virtualTable.SDL_isalnum(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_isalnum(int x);
 
     // Function @ SDL_stdinc.h:443:29
-    public static int SDL_isalpha(int x)
-    {
-        return _virtualTable.SDL_isalpha(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_isalpha(int x);
 
     // Function @ SDL_stdinc.h:436:29
-    public static int SDL_abs(int x)
-    {
-        return _virtualTable.SDL_abs(x);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_abs(int x);
 
     // Function @ SDL_stdinc.h:434:30
-    public static void SDL_qsort(void* @base, ulong nmemb, ulong size, FnPtr_SDL_VoidPtr_VoidPtr_Int compare)
-    {
-        _virtualTable.SDL_qsort(@base, nmemb, size, compare);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_qsort(void* @base, ulong nmemb, ulong size, FnPtr_SDL_VoidPtr_VoidPtr_Int compare);
 
     // Function @ SDL_stdinc.h:432:29
-    public static int SDL_setenv(CString name, CString value, int overwrite)
-    {
-        return _virtualTable.SDL_setenv(name, value, overwrite);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_setenv(CString name, CString value, int overwrite);
 
     // Function @ SDL_stdinc.h:431:31
-    public static CString SDL_getenv(CString name)
-    {
-        return _virtualTable.SDL_getenv(name);
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_getenv(CString name);
 
     // Function @ SDL_stdinc.h:429:29
-    public static int SDL_GetNumAllocations()
-    {
-        return _virtualTable.SDL_GetNumAllocations();
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_GetNumAllocations();
 
     // Function @ SDL_stdinc.h:421:29
-    public static int SDL_SetMemoryFunctions(SDL_malloc_func malloc_func, SDL_calloc_func calloc_func, SDL_realloc_func realloc_func, SDL_free_func free_func)
-    {
-        return _virtualTable.SDL_SetMemoryFunctions(malloc_func, calloc_func, realloc_func, free_func);
-    }
+    [DllImport("SDL2")]
+    public static extern int SDL_SetMemoryFunctions(SDL_malloc_func malloc_func, SDL_calloc_func calloc_func, SDL_realloc_func realloc_func, SDL_free_func free_func);
 
     // Function @ SDL_stdinc.h:408:30
-    public static void SDL_GetMemoryFunctions(SDL_malloc_func* malloc_func, SDL_calloc_func* calloc_func, SDL_realloc_func* realloc_func, SDL_free_func* free_func)
-    {
-        _virtualTable.SDL_GetMemoryFunctions(malloc_func, calloc_func, realloc_func, free_func);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_GetMemoryFunctions(SDL_malloc_func* malloc_func, SDL_calloc_func* calloc_func, SDL_realloc_func* realloc_func, SDL_free_func* free_func);
 
     // Function @ SDL_stdinc.h:398:30
-    public static void SDL_free(void* mem)
-    {
-        _virtualTable.SDL_free(mem);
-    }
+    [DllImport("SDL2")]
+    public static extern void SDL_free(void* mem);
 
     // Function @ SDL_stdinc.h:397:31
-    public static void* SDL_realloc(void* mem, ulong size)
-    {
-        return _virtualTable.SDL_realloc(mem, size);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_realloc(void* mem, ulong size);
 
     // Function @ SDL_stdinc.h:396:31
-    public static void* SDL_calloc(ulong nmemb, ulong size)
-    {
-        return _virtualTable.SDL_calloc(nmemb, size);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_calloc(ulong nmemb, ulong size);
 
     // Function @ SDL_stdinc.h:395:31
-    public static void* SDL_malloc(ulong size)
-    {
-        return _virtualTable.SDL_malloc(size);
-    }
+    [DllImport("SDL2")]
+    public static extern void* SDL_malloc(ulong size);
 
     // Function @ SDL_platform.h:202:38
-    public static CString SDL_GetPlatform()
-    {
-        return _virtualTable.SDL_GetPlatform();
-    }
+    [DllImport("SDL2")]
+    public static extern CString SDL_GetPlatform();
 
     // FunctionPointer @ SDL_timer.h:111:27
     [StructLayout(LayoutKind.Sequential)]
@@ -4561,34 +3023,6 @@ public static unsafe partial class SDL
     public struct FnPtr_SDL_VoidPtr_Void
     {
         public delegate* unmanaged<void*, void> Pointer;
-    }
-
-    // FunctionPointer @ SDL_thread.h:117:25
-    [StructLayout(LayoutKind.Sequential)]
-    public struct pfnSDL_CurrentEndThread
-    {
-        public delegate* unmanaged<uint, void> Pointer;
-    }
-
-    // FunctionPointer @ SDL_thread.h:114:30
-    [StructLayout(LayoutKind.Sequential)]
-    public struct pfnSDL_CurrentBeginThread
-    {
-        public delegate* unmanaged<void*, uint, FnPtr_SDL_VoidPtr_Uint, void*, uint, ulong*, UIntPtr> Pointer;
-    }
-
-    // FunctionPointer @ SDL_thread.h:115:60
-    [StructLayout(LayoutKind.Sequential)]
-    public struct FnPtr_SDL_VoidPtr_Uint
-    {
-        public delegate* unmanaged<void*, uint> Pointer;
-    }
-
-    // FunctionPointer @ SDL_thread.h:135:46
-    [StructLayout(LayoutKind.Sequential)]
-    public struct FnPtr_SDL_VoidPtr_Int
-    {
-        public delegate* unmanaged<void*, int> Pointer;
     }
 
     // FunctionPointer @ SDL_thread.h:88:24
@@ -6324,7 +4758,7 @@ public static unsafe partial class SDL
     }
 
     // Struct @ SDL_audio.h:241:23
-    [StructLayout(LayoutKind.Explicit, Size = 136, Pack = 8)]
+    [StructLayout(LayoutKind.Explicit, Size = 128, Pack = 1)]
     public struct SDL_AudioCVT
     {
         [FieldOffset(0)] // size = 4, padding = 0
@@ -6348,13 +4782,13 @@ public static unsafe partial class SDL
         [FieldOffset(28)] // size = 4, padding = 0
         public int len_cvt;
 
-        [FieldOffset(32)] // size = 4, padding = 4
+        [FieldOffset(32)] // size = 4, padding = 0
         public int len_mult;
 
-        [FieldOffset(40)] // size = 8, padding = 0
+        [FieldOffset(36)] // size = 8, padding = 0
         public double len_ratio;
 
-        [FieldOffset(48)] // size = 80, padding = 0
+        [FieldOffset(44)] // size = 80, padding = 0
         public fixed ulong _filters[80 / 8]; // SDL_AudioFilter[10]
 
         public Span<SDL_AudioFilter> filters
@@ -6370,7 +4804,7 @@ public static unsafe partial class SDL
             }
         }
 
-        [FieldOffset(128)] // size = 4, padding = 4
+        [FieldOffset(124)] // size = 4, padding = 0
         public int filter_index;
     }
 
@@ -6675,14 +5109,14 @@ public static unsafe partial class SDL
     }
 
     // Typedef @ SDL_thread.h:60:23
-    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
+    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 8)]
     public struct SDL_threadID
     {
-        [FieldOffset(0)] // size = 4, padding = 0
-        public uint Data;
+        [FieldOffset(0)] // size = 8, padding = 0
+        public ulong Data;
 
-        public static implicit operator uint(SDL_threadID data) => data.Data;
-        public static implicit operator SDL_threadID(uint data) => new() { Data = data };
+        public static implicit operator ulong(SDL_threadID data) => data.Data;
+        public static implicit operator SDL_threadID(ulong data) => new() { Data = data };
     }
 
     // Typedef @ SDL_atomic.h:89:13
@@ -6708,344 +5142,355 @@ public static unsafe partial class SDL
     }
 
     // Typedef @ System
-    [StructLayout(LayoutKind.Explicit, Size = 2, Pack = 2)]
+    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
     public struct wchar_t
     {
-        [FieldOffset(0)] // size = 2, padding = 0
-        public ushort Data;
+        [FieldOffset(0)] // size = 4, padding = 0
+        public __darwin_wchar_t Data;
 
-        public static implicit operator ushort(wchar_t data) => data.Data;
-        public static implicit operator wchar_t(ushort data) => new() { Data = data };
+        public static implicit operator __darwin_wchar_t(wchar_t data) => data.Data;
+        public static implicit operator wchar_t(__darwin_wchar_t data) => new() { Data = data };
+    }
+
+    // Typedef @ System
+    [StructLayout(LayoutKind.Explicit, Size = 4, Pack = 4)]
+    public struct __darwin_wchar_t
+    {
+        [FieldOffset(0)] // size = 4, padding = 0
+        public int Data;
+
+        public static implicit operator int(__darwin_wchar_t data) => data.Data;
+        public static implicit operator __darwin_wchar_t(int data) => new() { Data = data };
     }
 
     // Enum @ SDL_stdinc.h:171:3
-    public enum SDL_bool : int
+    public enum SDL_bool : uint
     {
-        SDL_FALSE = 0,
-        SDL_TRUE = 1
+        SDL_FALSE = 0U,
+        SDL_TRUE = 1U
     }
 
     // Enum @ SDL_shape.h:89:3
-    public enum WindowShapeMode : int
+    public enum WindowShapeMode : uint
     {
-        ShapeModeDefault = 0,
-        ShapeModeBinarizeAlpha = 1,
-        ShapeModeReverseBinarizeAlpha = 2,
-        ShapeModeColorKey = 3
+        ShapeModeDefault = 0U,
+        ShapeModeBinarizeAlpha = 1U,
+        ShapeModeReverseBinarizeAlpha = 2U,
+        ShapeModeColorKey = 3U
     }
 
     // Enum @ SDL_render.h:126:3
-    public enum SDL_RendererFlip : int
+    public enum SDL_RendererFlip : uint
     {
-        SDL_FLIP_NONE = 0,
-        SDL_FLIP_HORIZONTAL = 1,
-        SDL_FLIP_VERTICAL = 2
+        SDL_FLIP_NONE = 0U,
+        SDL_FLIP_HORIZONTAL = 1U,
+        SDL_FLIP_VERTICAL = 2U
     }
 
     // Enum @ SDL_blendmode.h:60:3
-    public enum SDL_BlendMode : int
+    public enum SDL_BlendMode : uint
     {
-        SDL_BLENDMODE_NONE = 0,
-        SDL_BLENDMODE_BLEND = 1,
-        SDL_BLENDMODE_ADD = 2,
-        SDL_BLENDMODE_MOD = 4,
-        SDL_BLENDMODE_MUL = 8,
-        SDL_BLENDMODE_INVALID = 2147483647
+        SDL_BLENDMODE_NONE = 0U,
+        SDL_BLENDMODE_BLEND = 1U,
+        SDL_BLENDMODE_ADD = 2U,
+        SDL_BLENDMODE_MOD = 4U,
+        SDL_BLENDMODE_MUL = 8U,
+        SDL_BLENDMODE_INVALID = 2147483647U
     }
 
     // Enum @ SDL_render.h:96:3
-    public enum SDL_ScaleMode : int
+    public enum SDL_ScaleMode : uint
     {
-        SDL_ScaleModeNearest = 0,
-        SDL_ScaleModeLinear = 1,
-        SDL_ScaleModeBest = 2
+        SDL_ScaleModeNearest = 0U,
+        SDL_ScaleModeLinear = 1U,
+        SDL_ScaleModeBest = 2U
     }
 
     // Enum @ SDL_power.h:49:3
-    public enum SDL_PowerState : int
+    public enum SDL_PowerState : uint
     {
-        SDL_POWERSTATE_UNKNOWN = 0,
-        SDL_POWERSTATE_ON_BATTERY = 1,
-        SDL_POWERSTATE_NO_BATTERY = 2,
-        SDL_POWERSTATE_CHARGING = 3,
-        SDL_POWERSTATE_CHARGED = 4
+        SDL_POWERSTATE_UNKNOWN = 0U,
+        SDL_POWERSTATE_ON_BATTERY = 1U,
+        SDL_POWERSTATE_NO_BATTERY = 2U,
+        SDL_POWERSTATE_CHARGING = 3U,
+        SDL_POWERSTATE_CHARGED = 4U
     }
 
     // Enum @ SDL_log.h:111:3
-    public enum SDL_LogPriority : int
+    public enum SDL_LogPriority : uint
     {
-        SDL_LOG_PRIORITY_VERBOSE = 1,
-        SDL_LOG_PRIORITY_DEBUG = 2,
-        SDL_LOG_PRIORITY_INFO = 3,
-        SDL_LOG_PRIORITY_WARN = 4,
-        SDL_LOG_PRIORITY_ERROR = 5,
-        SDL_LOG_PRIORITY_CRITICAL = 6,
-        SDL_NUM_LOG_PRIORITIES = 7
+        SDL_LOG_PRIORITY_VERBOSE = 1U,
+        SDL_LOG_PRIORITY_DEBUG = 2U,
+        SDL_LOG_PRIORITY_INFO = 3U,
+        SDL_LOG_PRIORITY_WARN = 4U,
+        SDL_LOG_PRIORITY_ERROR = 5U,
+        SDL_LOG_PRIORITY_CRITICAL = 6U,
+        SDL_NUM_LOG_PRIORITIES = 7U
     }
 
     // Enum @ SDL_hints.h:1671:3
-    public enum SDL_HintPriority : int
+    public enum SDL_HintPriority : uint
     {
-        SDL_HINT_DEFAULT = 0,
-        SDL_HINT_NORMAL = 1,
-        SDL_HINT_OVERRIDE = 2
+        SDL_HINT_DEFAULT = 0U,
+        SDL_HINT_NORMAL = 1U,
+        SDL_HINT_OVERRIDE = 2U
     }
 
     // Enum @ SDL_scancode.h:409:3
-    public enum SDL_Scancode : int
+    public enum SDL_Scancode : uint
     {
-        SDL_SCANCODE_UNKNOWN = 0,
-        SDL_SCANCODE_A = 4,
-        SDL_SCANCODE_B = 5,
-        SDL_SCANCODE_C = 6,
-        SDL_SCANCODE_D = 7,
-        SDL_SCANCODE_E = 8,
-        SDL_SCANCODE_F = 9,
-        SDL_SCANCODE_G = 10,
-        SDL_SCANCODE_H = 11,
-        SDL_SCANCODE_I = 12,
-        SDL_SCANCODE_J = 13,
-        SDL_SCANCODE_K = 14,
-        SDL_SCANCODE_L = 15,
-        SDL_SCANCODE_M = 16,
-        SDL_SCANCODE_N = 17,
-        SDL_SCANCODE_O = 18,
-        SDL_SCANCODE_P = 19,
-        SDL_SCANCODE_Q = 20,
-        SDL_SCANCODE_R = 21,
-        SDL_SCANCODE_S = 22,
-        SDL_SCANCODE_T = 23,
-        SDL_SCANCODE_U = 24,
-        SDL_SCANCODE_V = 25,
-        SDL_SCANCODE_W = 26,
-        SDL_SCANCODE_X = 27,
-        SDL_SCANCODE_Y = 28,
-        SDL_SCANCODE_Z = 29,
-        SDL_SCANCODE_1 = 30,
-        SDL_SCANCODE_2 = 31,
-        SDL_SCANCODE_3 = 32,
-        SDL_SCANCODE_4 = 33,
-        SDL_SCANCODE_5 = 34,
-        SDL_SCANCODE_6 = 35,
-        SDL_SCANCODE_7 = 36,
-        SDL_SCANCODE_8 = 37,
-        SDL_SCANCODE_9 = 38,
-        SDL_SCANCODE_0 = 39,
-        SDL_SCANCODE_RETURN = 40,
-        SDL_SCANCODE_ESCAPE = 41,
-        SDL_SCANCODE_BACKSPACE = 42,
-        SDL_SCANCODE_TAB = 43,
-        SDL_SCANCODE_SPACE = 44,
-        SDL_SCANCODE_MINUS = 45,
-        SDL_SCANCODE_EQUALS = 46,
-        SDL_SCANCODE_LEFTBRACKET = 47,
-        SDL_SCANCODE_RIGHTBRACKET = 48,
-        SDL_SCANCODE_BACKSLASH = 49,
-        SDL_SCANCODE_NONUSHASH = 50,
-        SDL_SCANCODE_SEMICOLON = 51,
-        SDL_SCANCODE_APOSTROPHE = 52,
-        SDL_SCANCODE_GRAVE = 53,
-        SDL_SCANCODE_COMMA = 54,
-        SDL_SCANCODE_PERIOD = 55,
-        SDL_SCANCODE_SLASH = 56,
-        SDL_SCANCODE_CAPSLOCK = 57,
-        SDL_SCANCODE_F1 = 58,
-        SDL_SCANCODE_F2 = 59,
-        SDL_SCANCODE_F3 = 60,
-        SDL_SCANCODE_F4 = 61,
-        SDL_SCANCODE_F5 = 62,
-        SDL_SCANCODE_F6 = 63,
-        SDL_SCANCODE_F7 = 64,
-        SDL_SCANCODE_F8 = 65,
-        SDL_SCANCODE_F9 = 66,
-        SDL_SCANCODE_F10 = 67,
-        SDL_SCANCODE_F11 = 68,
-        SDL_SCANCODE_F12 = 69,
-        SDL_SCANCODE_PRINTSCREEN = 70,
-        SDL_SCANCODE_SCROLLLOCK = 71,
-        SDL_SCANCODE_PAUSE = 72,
-        SDL_SCANCODE_INSERT = 73,
-        SDL_SCANCODE_HOME = 74,
-        SDL_SCANCODE_PAGEUP = 75,
-        SDL_SCANCODE_DELETE = 76,
-        SDL_SCANCODE_END = 77,
-        SDL_SCANCODE_PAGEDOWN = 78,
-        SDL_SCANCODE_RIGHT = 79,
-        SDL_SCANCODE_LEFT = 80,
-        SDL_SCANCODE_DOWN = 81,
-        SDL_SCANCODE_UP = 82,
-        SDL_SCANCODE_NUMLOCKCLEAR = 83,
-        SDL_SCANCODE_KP_DIVIDE = 84,
-        SDL_SCANCODE_KP_MULTIPLY = 85,
-        SDL_SCANCODE_KP_MINUS = 86,
-        SDL_SCANCODE_KP_PLUS = 87,
-        SDL_SCANCODE_KP_ENTER = 88,
-        SDL_SCANCODE_KP_1 = 89,
-        SDL_SCANCODE_KP_2 = 90,
-        SDL_SCANCODE_KP_3 = 91,
-        SDL_SCANCODE_KP_4 = 92,
-        SDL_SCANCODE_KP_5 = 93,
-        SDL_SCANCODE_KP_6 = 94,
-        SDL_SCANCODE_KP_7 = 95,
-        SDL_SCANCODE_KP_8 = 96,
-        SDL_SCANCODE_KP_9 = 97,
-        SDL_SCANCODE_KP_0 = 98,
-        SDL_SCANCODE_KP_PERIOD = 99,
-        SDL_SCANCODE_NONUSBACKSLASH = 100,
-        SDL_SCANCODE_APPLICATION = 101,
-        SDL_SCANCODE_POWER = 102,
-        SDL_SCANCODE_KP_EQUALS = 103,
-        SDL_SCANCODE_F13 = 104,
-        SDL_SCANCODE_F14 = 105,
-        SDL_SCANCODE_F15 = 106,
-        SDL_SCANCODE_F16 = 107,
-        SDL_SCANCODE_F17 = 108,
-        SDL_SCANCODE_F18 = 109,
-        SDL_SCANCODE_F19 = 110,
-        SDL_SCANCODE_F20 = 111,
-        SDL_SCANCODE_F21 = 112,
-        SDL_SCANCODE_F22 = 113,
-        SDL_SCANCODE_F23 = 114,
-        SDL_SCANCODE_F24 = 115,
-        SDL_SCANCODE_EXECUTE = 116,
-        SDL_SCANCODE_HELP = 117,
-        SDL_SCANCODE_MENU = 118,
-        SDL_SCANCODE_SELECT = 119,
-        SDL_SCANCODE_STOP = 120,
-        SDL_SCANCODE_AGAIN = 121,
-        SDL_SCANCODE_UNDO = 122,
-        SDL_SCANCODE_CUT = 123,
-        SDL_SCANCODE_COPY = 124,
-        SDL_SCANCODE_PASTE = 125,
-        SDL_SCANCODE_FIND = 126,
-        SDL_SCANCODE_MUTE = 127,
-        SDL_SCANCODE_VOLUMEUP = 128,
-        SDL_SCANCODE_VOLUMEDOWN = 129,
-        SDL_SCANCODE_KP_COMMA = 133,
-        SDL_SCANCODE_KP_EQUALSAS400 = 134,
-        SDL_SCANCODE_INTERNATIONAL1 = 135,
-        SDL_SCANCODE_INTERNATIONAL2 = 136,
-        SDL_SCANCODE_INTERNATIONAL3 = 137,
-        SDL_SCANCODE_INTERNATIONAL4 = 138,
-        SDL_SCANCODE_INTERNATIONAL5 = 139,
-        SDL_SCANCODE_INTERNATIONAL6 = 140,
-        SDL_SCANCODE_INTERNATIONAL7 = 141,
-        SDL_SCANCODE_INTERNATIONAL8 = 142,
-        SDL_SCANCODE_INTERNATIONAL9 = 143,
-        SDL_SCANCODE_LANG1 = 144,
-        SDL_SCANCODE_LANG2 = 145,
-        SDL_SCANCODE_LANG3 = 146,
-        SDL_SCANCODE_LANG4 = 147,
-        SDL_SCANCODE_LANG5 = 148,
-        SDL_SCANCODE_LANG6 = 149,
-        SDL_SCANCODE_LANG7 = 150,
-        SDL_SCANCODE_LANG8 = 151,
-        SDL_SCANCODE_LANG9 = 152,
-        SDL_SCANCODE_ALTERASE = 153,
-        SDL_SCANCODE_SYSREQ = 154,
-        SDL_SCANCODE_CANCEL = 155,
-        SDL_SCANCODE_CLEAR = 156,
-        SDL_SCANCODE_PRIOR = 157,
-        SDL_SCANCODE_RETURN2 = 158,
-        SDL_SCANCODE_SEPARATOR = 159,
-        SDL_SCANCODE_OUT = 160,
-        SDL_SCANCODE_OPER = 161,
-        SDL_SCANCODE_CLEARAGAIN = 162,
-        SDL_SCANCODE_CRSEL = 163,
-        SDL_SCANCODE_EXSEL = 164,
-        SDL_SCANCODE_KP_00 = 176,
-        SDL_SCANCODE_KP_000 = 177,
-        SDL_SCANCODE_THOUSANDSSEPARATOR = 178,
-        SDL_SCANCODE_DECIMALSEPARATOR = 179,
-        SDL_SCANCODE_CURRENCYUNIT = 180,
-        SDL_SCANCODE_CURRENCYSUBUNIT = 181,
-        SDL_SCANCODE_KP_LEFTPAREN = 182,
-        SDL_SCANCODE_KP_RIGHTPAREN = 183,
-        SDL_SCANCODE_KP_LEFTBRACE = 184,
-        SDL_SCANCODE_KP_RIGHTBRACE = 185,
-        SDL_SCANCODE_KP_TAB = 186,
-        SDL_SCANCODE_KP_BACKSPACE = 187,
-        SDL_SCANCODE_KP_A = 188,
-        SDL_SCANCODE_KP_B = 189,
-        SDL_SCANCODE_KP_C = 190,
-        SDL_SCANCODE_KP_D = 191,
-        SDL_SCANCODE_KP_E = 192,
-        SDL_SCANCODE_KP_F = 193,
-        SDL_SCANCODE_KP_XOR = 194,
-        SDL_SCANCODE_KP_POWER = 195,
-        SDL_SCANCODE_KP_PERCENT = 196,
-        SDL_SCANCODE_KP_LESS = 197,
-        SDL_SCANCODE_KP_GREATER = 198,
-        SDL_SCANCODE_KP_AMPERSAND = 199,
-        SDL_SCANCODE_KP_DBLAMPERSAND = 200,
-        SDL_SCANCODE_KP_VERTICALBAR = 201,
-        SDL_SCANCODE_KP_DBLVERTICALBAR = 202,
-        SDL_SCANCODE_KP_COLON = 203,
-        SDL_SCANCODE_KP_HASH = 204,
-        SDL_SCANCODE_KP_SPACE = 205,
-        SDL_SCANCODE_KP_AT = 206,
-        SDL_SCANCODE_KP_EXCLAM = 207,
-        SDL_SCANCODE_KP_MEMSTORE = 208,
-        SDL_SCANCODE_KP_MEMRECALL = 209,
-        SDL_SCANCODE_KP_MEMCLEAR = 210,
-        SDL_SCANCODE_KP_MEMADD = 211,
-        SDL_SCANCODE_KP_MEMSUBTRACT = 212,
-        SDL_SCANCODE_KP_MEMMULTIPLY = 213,
-        SDL_SCANCODE_KP_MEMDIVIDE = 214,
-        SDL_SCANCODE_KP_PLUSMINUS = 215,
-        SDL_SCANCODE_KP_CLEAR = 216,
-        SDL_SCANCODE_KP_CLEARENTRY = 217,
-        SDL_SCANCODE_KP_BINARY = 218,
-        SDL_SCANCODE_KP_OCTAL = 219,
-        SDL_SCANCODE_KP_DECIMAL = 220,
-        SDL_SCANCODE_KP_HEXADECIMAL = 221,
-        SDL_SCANCODE_LCTRL = 224,
-        SDL_SCANCODE_LSHIFT = 225,
-        SDL_SCANCODE_LALT = 226,
-        SDL_SCANCODE_LGUI = 227,
-        SDL_SCANCODE_RCTRL = 228,
-        SDL_SCANCODE_RSHIFT = 229,
-        SDL_SCANCODE_RALT = 230,
-        SDL_SCANCODE_RGUI = 231,
-        SDL_SCANCODE_MODE = 257,
-        SDL_SCANCODE_AUDIONEXT = 258,
-        SDL_SCANCODE_AUDIOPREV = 259,
-        SDL_SCANCODE_AUDIOSTOP = 260,
-        SDL_SCANCODE_AUDIOPLAY = 261,
-        SDL_SCANCODE_AUDIOMUTE = 262,
-        SDL_SCANCODE_MEDIASELECT = 263,
-        SDL_SCANCODE_WWW = 264,
-        SDL_SCANCODE_MAIL = 265,
-        SDL_SCANCODE_CALCULATOR = 266,
-        SDL_SCANCODE_COMPUTER = 267,
-        SDL_SCANCODE_AC_SEARCH = 268,
-        SDL_SCANCODE_AC_HOME = 269,
-        SDL_SCANCODE_AC_BACK = 270,
-        SDL_SCANCODE_AC_FORWARD = 271,
-        SDL_SCANCODE_AC_STOP = 272,
-        SDL_SCANCODE_AC_REFRESH = 273,
-        SDL_SCANCODE_AC_BOOKMARKS = 274,
-        SDL_SCANCODE_BRIGHTNESSDOWN = 275,
-        SDL_SCANCODE_BRIGHTNESSUP = 276,
-        SDL_SCANCODE_DISPLAYSWITCH = 277,
-        SDL_SCANCODE_KBDILLUMTOGGLE = 278,
-        SDL_SCANCODE_KBDILLUMDOWN = 279,
-        SDL_SCANCODE_KBDILLUMUP = 280,
-        SDL_SCANCODE_EJECT = 281,
-        SDL_SCANCODE_SLEEP = 282,
-        SDL_SCANCODE_APP1 = 283,
-        SDL_SCANCODE_APP2 = 284,
-        SDL_SCANCODE_AUDIOREWIND = 285,
-        SDL_SCANCODE_AUDIOFASTFORWARD = 286,
-        SDL_NUM_SCANCODES = 512
+        SDL_SCANCODE_UNKNOWN = 0U,
+        SDL_SCANCODE_A = 4U,
+        SDL_SCANCODE_B = 5U,
+        SDL_SCANCODE_C = 6U,
+        SDL_SCANCODE_D = 7U,
+        SDL_SCANCODE_E = 8U,
+        SDL_SCANCODE_F = 9U,
+        SDL_SCANCODE_G = 10U,
+        SDL_SCANCODE_H = 11U,
+        SDL_SCANCODE_I = 12U,
+        SDL_SCANCODE_J = 13U,
+        SDL_SCANCODE_K = 14U,
+        SDL_SCANCODE_L = 15U,
+        SDL_SCANCODE_M = 16U,
+        SDL_SCANCODE_N = 17U,
+        SDL_SCANCODE_O = 18U,
+        SDL_SCANCODE_P = 19U,
+        SDL_SCANCODE_Q = 20U,
+        SDL_SCANCODE_R = 21U,
+        SDL_SCANCODE_S = 22U,
+        SDL_SCANCODE_T = 23U,
+        SDL_SCANCODE_U = 24U,
+        SDL_SCANCODE_V = 25U,
+        SDL_SCANCODE_W = 26U,
+        SDL_SCANCODE_X = 27U,
+        SDL_SCANCODE_Y = 28U,
+        SDL_SCANCODE_Z = 29U,
+        SDL_SCANCODE_1 = 30U,
+        SDL_SCANCODE_2 = 31U,
+        SDL_SCANCODE_3 = 32U,
+        SDL_SCANCODE_4 = 33U,
+        SDL_SCANCODE_5 = 34U,
+        SDL_SCANCODE_6 = 35U,
+        SDL_SCANCODE_7 = 36U,
+        SDL_SCANCODE_8 = 37U,
+        SDL_SCANCODE_9 = 38U,
+        SDL_SCANCODE_0 = 39U,
+        SDL_SCANCODE_RETURN = 40U,
+        SDL_SCANCODE_ESCAPE = 41U,
+        SDL_SCANCODE_BACKSPACE = 42U,
+        SDL_SCANCODE_TAB = 43U,
+        SDL_SCANCODE_SPACE = 44U,
+        SDL_SCANCODE_MINUS = 45U,
+        SDL_SCANCODE_EQUALS = 46U,
+        SDL_SCANCODE_LEFTBRACKET = 47U,
+        SDL_SCANCODE_RIGHTBRACKET = 48U,
+        SDL_SCANCODE_BACKSLASH = 49U,
+        SDL_SCANCODE_NONUSHASH = 50U,
+        SDL_SCANCODE_SEMICOLON = 51U,
+        SDL_SCANCODE_APOSTROPHE = 52U,
+        SDL_SCANCODE_GRAVE = 53U,
+        SDL_SCANCODE_COMMA = 54U,
+        SDL_SCANCODE_PERIOD = 55U,
+        SDL_SCANCODE_SLASH = 56U,
+        SDL_SCANCODE_CAPSLOCK = 57U,
+        SDL_SCANCODE_F1 = 58U,
+        SDL_SCANCODE_F2 = 59U,
+        SDL_SCANCODE_F3 = 60U,
+        SDL_SCANCODE_F4 = 61U,
+        SDL_SCANCODE_F5 = 62U,
+        SDL_SCANCODE_F6 = 63U,
+        SDL_SCANCODE_F7 = 64U,
+        SDL_SCANCODE_F8 = 65U,
+        SDL_SCANCODE_F9 = 66U,
+        SDL_SCANCODE_F10 = 67U,
+        SDL_SCANCODE_F11 = 68U,
+        SDL_SCANCODE_F12 = 69U,
+        SDL_SCANCODE_PRINTSCREEN = 70U,
+        SDL_SCANCODE_SCROLLLOCK = 71U,
+        SDL_SCANCODE_PAUSE = 72U,
+        SDL_SCANCODE_INSERT = 73U,
+        SDL_SCANCODE_HOME = 74U,
+        SDL_SCANCODE_PAGEUP = 75U,
+        SDL_SCANCODE_DELETE = 76U,
+        SDL_SCANCODE_END = 77U,
+        SDL_SCANCODE_PAGEDOWN = 78U,
+        SDL_SCANCODE_RIGHT = 79U,
+        SDL_SCANCODE_LEFT = 80U,
+        SDL_SCANCODE_DOWN = 81U,
+        SDL_SCANCODE_UP = 82U,
+        SDL_SCANCODE_NUMLOCKCLEAR = 83U,
+        SDL_SCANCODE_KP_DIVIDE = 84U,
+        SDL_SCANCODE_KP_MULTIPLY = 85U,
+        SDL_SCANCODE_KP_MINUS = 86U,
+        SDL_SCANCODE_KP_PLUS = 87U,
+        SDL_SCANCODE_KP_ENTER = 88U,
+        SDL_SCANCODE_KP_1 = 89U,
+        SDL_SCANCODE_KP_2 = 90U,
+        SDL_SCANCODE_KP_3 = 91U,
+        SDL_SCANCODE_KP_4 = 92U,
+        SDL_SCANCODE_KP_5 = 93U,
+        SDL_SCANCODE_KP_6 = 94U,
+        SDL_SCANCODE_KP_7 = 95U,
+        SDL_SCANCODE_KP_8 = 96U,
+        SDL_SCANCODE_KP_9 = 97U,
+        SDL_SCANCODE_KP_0 = 98U,
+        SDL_SCANCODE_KP_PERIOD = 99U,
+        SDL_SCANCODE_NONUSBACKSLASH = 100U,
+        SDL_SCANCODE_APPLICATION = 101U,
+        SDL_SCANCODE_POWER = 102U,
+        SDL_SCANCODE_KP_EQUALS = 103U,
+        SDL_SCANCODE_F13 = 104U,
+        SDL_SCANCODE_F14 = 105U,
+        SDL_SCANCODE_F15 = 106U,
+        SDL_SCANCODE_F16 = 107U,
+        SDL_SCANCODE_F17 = 108U,
+        SDL_SCANCODE_F18 = 109U,
+        SDL_SCANCODE_F19 = 110U,
+        SDL_SCANCODE_F20 = 111U,
+        SDL_SCANCODE_F21 = 112U,
+        SDL_SCANCODE_F22 = 113U,
+        SDL_SCANCODE_F23 = 114U,
+        SDL_SCANCODE_F24 = 115U,
+        SDL_SCANCODE_EXECUTE = 116U,
+        SDL_SCANCODE_HELP = 117U,
+        SDL_SCANCODE_MENU = 118U,
+        SDL_SCANCODE_SELECT = 119U,
+        SDL_SCANCODE_STOP = 120U,
+        SDL_SCANCODE_AGAIN = 121U,
+        SDL_SCANCODE_UNDO = 122U,
+        SDL_SCANCODE_CUT = 123U,
+        SDL_SCANCODE_COPY = 124U,
+        SDL_SCANCODE_PASTE = 125U,
+        SDL_SCANCODE_FIND = 126U,
+        SDL_SCANCODE_MUTE = 127U,
+        SDL_SCANCODE_VOLUMEUP = 128U,
+        SDL_SCANCODE_VOLUMEDOWN = 129U,
+        SDL_SCANCODE_KP_COMMA = 133U,
+        SDL_SCANCODE_KP_EQUALSAS400 = 134U,
+        SDL_SCANCODE_INTERNATIONAL1 = 135U,
+        SDL_SCANCODE_INTERNATIONAL2 = 136U,
+        SDL_SCANCODE_INTERNATIONAL3 = 137U,
+        SDL_SCANCODE_INTERNATIONAL4 = 138U,
+        SDL_SCANCODE_INTERNATIONAL5 = 139U,
+        SDL_SCANCODE_INTERNATIONAL6 = 140U,
+        SDL_SCANCODE_INTERNATIONAL7 = 141U,
+        SDL_SCANCODE_INTERNATIONAL8 = 142U,
+        SDL_SCANCODE_INTERNATIONAL9 = 143U,
+        SDL_SCANCODE_LANG1 = 144U,
+        SDL_SCANCODE_LANG2 = 145U,
+        SDL_SCANCODE_LANG3 = 146U,
+        SDL_SCANCODE_LANG4 = 147U,
+        SDL_SCANCODE_LANG5 = 148U,
+        SDL_SCANCODE_LANG6 = 149U,
+        SDL_SCANCODE_LANG7 = 150U,
+        SDL_SCANCODE_LANG8 = 151U,
+        SDL_SCANCODE_LANG9 = 152U,
+        SDL_SCANCODE_ALTERASE = 153U,
+        SDL_SCANCODE_SYSREQ = 154U,
+        SDL_SCANCODE_CANCEL = 155U,
+        SDL_SCANCODE_CLEAR = 156U,
+        SDL_SCANCODE_PRIOR = 157U,
+        SDL_SCANCODE_RETURN2 = 158U,
+        SDL_SCANCODE_SEPARATOR = 159U,
+        SDL_SCANCODE_OUT = 160U,
+        SDL_SCANCODE_OPER = 161U,
+        SDL_SCANCODE_CLEARAGAIN = 162U,
+        SDL_SCANCODE_CRSEL = 163U,
+        SDL_SCANCODE_EXSEL = 164U,
+        SDL_SCANCODE_KP_00 = 176U,
+        SDL_SCANCODE_KP_000 = 177U,
+        SDL_SCANCODE_THOUSANDSSEPARATOR = 178U,
+        SDL_SCANCODE_DECIMALSEPARATOR = 179U,
+        SDL_SCANCODE_CURRENCYUNIT = 180U,
+        SDL_SCANCODE_CURRENCYSUBUNIT = 181U,
+        SDL_SCANCODE_KP_LEFTPAREN = 182U,
+        SDL_SCANCODE_KP_RIGHTPAREN = 183U,
+        SDL_SCANCODE_KP_LEFTBRACE = 184U,
+        SDL_SCANCODE_KP_RIGHTBRACE = 185U,
+        SDL_SCANCODE_KP_TAB = 186U,
+        SDL_SCANCODE_KP_BACKSPACE = 187U,
+        SDL_SCANCODE_KP_A = 188U,
+        SDL_SCANCODE_KP_B = 189U,
+        SDL_SCANCODE_KP_C = 190U,
+        SDL_SCANCODE_KP_D = 191U,
+        SDL_SCANCODE_KP_E = 192U,
+        SDL_SCANCODE_KP_F = 193U,
+        SDL_SCANCODE_KP_XOR = 194U,
+        SDL_SCANCODE_KP_POWER = 195U,
+        SDL_SCANCODE_KP_PERCENT = 196U,
+        SDL_SCANCODE_KP_LESS = 197U,
+        SDL_SCANCODE_KP_GREATER = 198U,
+        SDL_SCANCODE_KP_AMPERSAND = 199U,
+        SDL_SCANCODE_KP_DBLAMPERSAND = 200U,
+        SDL_SCANCODE_KP_VERTICALBAR = 201U,
+        SDL_SCANCODE_KP_DBLVERTICALBAR = 202U,
+        SDL_SCANCODE_KP_COLON = 203U,
+        SDL_SCANCODE_KP_HASH = 204U,
+        SDL_SCANCODE_KP_SPACE = 205U,
+        SDL_SCANCODE_KP_AT = 206U,
+        SDL_SCANCODE_KP_EXCLAM = 207U,
+        SDL_SCANCODE_KP_MEMSTORE = 208U,
+        SDL_SCANCODE_KP_MEMRECALL = 209U,
+        SDL_SCANCODE_KP_MEMCLEAR = 210U,
+        SDL_SCANCODE_KP_MEMADD = 211U,
+        SDL_SCANCODE_KP_MEMSUBTRACT = 212U,
+        SDL_SCANCODE_KP_MEMMULTIPLY = 213U,
+        SDL_SCANCODE_KP_MEMDIVIDE = 214U,
+        SDL_SCANCODE_KP_PLUSMINUS = 215U,
+        SDL_SCANCODE_KP_CLEAR = 216U,
+        SDL_SCANCODE_KP_CLEARENTRY = 217U,
+        SDL_SCANCODE_KP_BINARY = 218U,
+        SDL_SCANCODE_KP_OCTAL = 219U,
+        SDL_SCANCODE_KP_DECIMAL = 220U,
+        SDL_SCANCODE_KP_HEXADECIMAL = 221U,
+        SDL_SCANCODE_LCTRL = 224U,
+        SDL_SCANCODE_LSHIFT = 225U,
+        SDL_SCANCODE_LALT = 226U,
+        SDL_SCANCODE_LGUI = 227U,
+        SDL_SCANCODE_RCTRL = 228U,
+        SDL_SCANCODE_RSHIFT = 229U,
+        SDL_SCANCODE_RALT = 230U,
+        SDL_SCANCODE_RGUI = 231U,
+        SDL_SCANCODE_MODE = 257U,
+        SDL_SCANCODE_AUDIONEXT = 258U,
+        SDL_SCANCODE_AUDIOPREV = 259U,
+        SDL_SCANCODE_AUDIOSTOP = 260U,
+        SDL_SCANCODE_AUDIOPLAY = 261U,
+        SDL_SCANCODE_AUDIOMUTE = 262U,
+        SDL_SCANCODE_MEDIASELECT = 263U,
+        SDL_SCANCODE_WWW = 264U,
+        SDL_SCANCODE_MAIL = 265U,
+        SDL_SCANCODE_CALCULATOR = 266U,
+        SDL_SCANCODE_COMPUTER = 267U,
+        SDL_SCANCODE_AC_SEARCH = 268U,
+        SDL_SCANCODE_AC_HOME = 269U,
+        SDL_SCANCODE_AC_BACK = 270U,
+        SDL_SCANCODE_AC_FORWARD = 271U,
+        SDL_SCANCODE_AC_STOP = 272U,
+        SDL_SCANCODE_AC_REFRESH = 273U,
+        SDL_SCANCODE_AC_BOOKMARKS = 274U,
+        SDL_SCANCODE_BRIGHTNESSDOWN = 275U,
+        SDL_SCANCODE_BRIGHTNESSUP = 276U,
+        SDL_SCANCODE_DISPLAYSWITCH = 277U,
+        SDL_SCANCODE_KBDILLUMTOGGLE = 278U,
+        SDL_SCANCODE_KBDILLUMDOWN = 279U,
+        SDL_SCANCODE_KBDILLUMUP = 280U,
+        SDL_SCANCODE_EJECT = 281U,
+        SDL_SCANCODE_SLEEP = 282U,
+        SDL_SCANCODE_APP1 = 283U,
+        SDL_SCANCODE_APP2 = 284U,
+        SDL_SCANCODE_AUDIOREWIND = 285U,
+        SDL_SCANCODE_AUDIOFASTFORWARD = 286U,
+        SDL_NUM_SCANCODES = 512U
     }
 
     // Enum @ SDL_events.h:667:3
-    public enum SDL_eventaction : int
+    public enum SDL_eventaction : uint
     {
-        SDL_ADDEVENT = 0,
-        SDL_PEEKEVENT = 1,
-        SDL_GETEVENT = 2
+        SDL_ADDEVENT = 0U,
+        SDL_PEEKEVENT = 1U,
+        SDL_GETEVENT = 2U
     }
 
     // Enum @ SDL_touch.h:50:3
@@ -7095,12 +5540,12 @@ public static unsafe partial class SDL
     }
 
     // Enum @ SDL_gamecontroller.h:79:3
-    public enum SDL_GameControllerBindType : int
+    public enum SDL_GameControllerBindType : uint
     {
-        SDL_CONTROLLER_BINDTYPE_NONE = 0,
-        SDL_CONTROLLER_BINDTYPE_BUTTON = 1,
-        SDL_CONTROLLER_BINDTYPE_AXIS = 2,
-        SDL_CONTROLLER_BINDTYPE_HAT = 3
+        SDL_CONTROLLER_BINDTYPE_NONE = 0U,
+        SDL_CONTROLLER_BINDTYPE_BUTTON = 1U,
+        SDL_CONTROLLER_BINDTYPE_AXIS = 2U,
+        SDL_CONTROLLER_BINDTYPE_HAT = 3U
     }
 
     // Enum @ SDL_gamecontroller.h:519:3
@@ -7117,16 +5562,16 @@ public static unsafe partial class SDL
     }
 
     // Enum @ SDL_gamecontroller.h:71:3
-    public enum SDL_GameControllerType : int
+    public enum SDL_GameControllerType : uint
     {
-        SDL_CONTROLLER_TYPE_UNKNOWN = 0,
-        SDL_CONTROLLER_TYPE_XBOX360 = 1,
-        SDL_CONTROLLER_TYPE_XBOXONE = 2,
-        SDL_CONTROLLER_TYPE_PS3 = 3,
-        SDL_CONTROLLER_TYPE_PS4 = 4,
-        SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO = 5,
-        SDL_CONTROLLER_TYPE_VIRTUAL = 6,
-        SDL_CONTROLLER_TYPE_PS5 = 7
+        SDL_CONTROLLER_TYPE_UNKNOWN = 0U,
+        SDL_CONTROLLER_TYPE_XBOX360 = 1U,
+        SDL_CONTROLLER_TYPE_XBOXONE = 2U,
+        SDL_CONTROLLER_TYPE_PS3 = 3U,
+        SDL_CONTROLLER_TYPE_PS4 = 4U,
+        SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO = 5U,
+        SDL_CONTROLLER_TYPE_VIRTUAL = 6U,
+        SDL_CONTROLLER_TYPE_PS5 = 7U
     }
 
     // Enum @ SDL_joystick.h:108:3
@@ -7142,2465 +5587,186 @@ public static unsafe partial class SDL
     }
 
     // Enum @ SDL_joystick.h:97:3
-    public enum SDL_JoystickType : int
+    public enum SDL_JoystickType : uint
     {
-        SDL_JOYSTICK_TYPE_UNKNOWN = 0,
-        SDL_JOYSTICK_TYPE_GAMECONTROLLER = 1,
-        SDL_JOYSTICK_TYPE_WHEEL = 2,
-        SDL_JOYSTICK_TYPE_ARCADE_STICK = 3,
-        SDL_JOYSTICK_TYPE_FLIGHT_STICK = 4,
-        SDL_JOYSTICK_TYPE_DANCE_PAD = 5,
-        SDL_JOYSTICK_TYPE_GUITAR = 6,
-        SDL_JOYSTICK_TYPE_DRUM_KIT = 7,
-        SDL_JOYSTICK_TYPE_ARCADE_PAD = 8,
-        SDL_JOYSTICK_TYPE_THROTTLE = 9
+        SDL_JOYSTICK_TYPE_UNKNOWN = 0U,
+        SDL_JOYSTICK_TYPE_GAMECONTROLLER = 1U,
+        SDL_JOYSTICK_TYPE_WHEEL = 2U,
+        SDL_JOYSTICK_TYPE_ARCADE_STICK = 3U,
+        SDL_JOYSTICK_TYPE_FLIGHT_STICK = 4U,
+        SDL_JOYSTICK_TYPE_DANCE_PAD = 5U,
+        SDL_JOYSTICK_TYPE_GUITAR = 6U,
+        SDL_JOYSTICK_TYPE_DRUM_KIT = 7U,
+        SDL_JOYSTICK_TYPE_ARCADE_PAD = 8U,
+        SDL_JOYSTICK_TYPE_THROTTLE = 9U
     }
 
     // Enum @ SDL_mouse.h:61:3
-    public enum SDL_SystemCursor : int
+    public enum SDL_SystemCursor : uint
     {
-        SDL_SYSTEM_CURSOR_ARROW = 0,
-        SDL_SYSTEM_CURSOR_IBEAM = 1,
-        SDL_SYSTEM_CURSOR_WAIT = 2,
-        SDL_SYSTEM_CURSOR_CROSSHAIR = 3,
-        SDL_SYSTEM_CURSOR_WAITARROW = 4,
-        SDL_SYSTEM_CURSOR_SIZENWSE = 5,
-        SDL_SYSTEM_CURSOR_SIZENESW = 6,
-        SDL_SYSTEM_CURSOR_SIZEWE = 7,
-        SDL_SYSTEM_CURSOR_SIZENS = 8,
-        SDL_SYSTEM_CURSOR_SIZEALL = 9,
-        SDL_SYSTEM_CURSOR_NO = 10,
-        SDL_SYSTEM_CURSOR_HAND = 11,
-        SDL_NUM_SYSTEM_CURSORS = 12
+        SDL_SYSTEM_CURSOR_ARROW = 0U,
+        SDL_SYSTEM_CURSOR_IBEAM = 1U,
+        SDL_SYSTEM_CURSOR_WAIT = 2U,
+        SDL_SYSTEM_CURSOR_CROSSHAIR = 3U,
+        SDL_SYSTEM_CURSOR_WAITARROW = 4U,
+        SDL_SYSTEM_CURSOR_SIZENWSE = 5U,
+        SDL_SYSTEM_CURSOR_SIZENESW = 6U,
+        SDL_SYSTEM_CURSOR_SIZEWE = 7U,
+        SDL_SYSTEM_CURSOR_SIZENS = 8U,
+        SDL_SYSTEM_CURSOR_SIZEALL = 9U,
+        SDL_SYSTEM_CURSOR_NO = 10U,
+        SDL_SYSTEM_CURSOR_HAND = 11U,
+        SDL_NUM_SYSTEM_CURSORS = 12U
     }
 
     // Enum @ SDL_keycode.h:347:3
-    public enum SDL_Keymod : int
+    public enum SDL_Keymod : uint
     {
-        KMOD_NONE = 0,
-        KMOD_LSHIFT = 1,
-        KMOD_RSHIFT = 2,
-        KMOD_LCTRL = 64,
-        KMOD_RCTRL = 128,
-        KMOD_LALT = 256,
-        KMOD_RALT = 512,
-        KMOD_LGUI = 1024,
-        KMOD_RGUI = 2048,
-        KMOD_NUM = 4096,
-        KMOD_CAPS = 8192,
-        KMOD_MODE = 16384,
-        KMOD_RESERVED = 32768,
-        KMOD_CTRL = 192,
-        KMOD_SHIFT = 3,
-        KMOD_ALT = 768,
-        KMOD_GUI = 3072
+        KMOD_NONE = 0U,
+        KMOD_LSHIFT = 1U,
+        KMOD_RSHIFT = 2U,
+        KMOD_LCTRL = 64U,
+        KMOD_RCTRL = 128U,
+        KMOD_LALT = 256U,
+        KMOD_RALT = 512U,
+        KMOD_LGUI = 1024U,
+        KMOD_RGUI = 2048U,
+        KMOD_NUM = 4096U,
+        KMOD_CAPS = 8192U,
+        KMOD_MODE = 16384U,
+        KMOD_RESERVED = 32768U,
+        KMOD_CTRL = 192U,
+        KMOD_SHIFT = 3U,
+        KMOD_ALT = 768U,
+        KMOD_GUI = 3072U
     }
 
     // Enum @ SDL_video.h:236:3
-    public enum SDL_GLattr : int
+    public enum SDL_GLattr : uint
     {
-        SDL_GL_RED_SIZE = 0,
-        SDL_GL_GREEN_SIZE = 1,
-        SDL_GL_BLUE_SIZE = 2,
-        SDL_GL_ALPHA_SIZE = 3,
-        SDL_GL_BUFFER_SIZE = 4,
-        SDL_GL_DOUBLEBUFFER = 5,
-        SDL_GL_DEPTH_SIZE = 6,
-        SDL_GL_STENCIL_SIZE = 7,
-        SDL_GL_ACCUM_RED_SIZE = 8,
-        SDL_GL_ACCUM_GREEN_SIZE = 9,
-        SDL_GL_ACCUM_BLUE_SIZE = 10,
-        SDL_GL_ACCUM_ALPHA_SIZE = 11,
-        SDL_GL_STEREO = 12,
-        SDL_GL_MULTISAMPLEBUFFERS = 13,
-        SDL_GL_MULTISAMPLESAMPLES = 14,
-        SDL_GL_ACCELERATED_VISUAL = 15,
-        SDL_GL_RETAINED_BACKING = 16,
-        SDL_GL_CONTEXT_MAJOR_VERSION = 17,
-        SDL_GL_CONTEXT_MINOR_VERSION = 18,
-        SDL_GL_CONTEXT_EGL = 19,
-        SDL_GL_CONTEXT_FLAGS = 20,
-        SDL_GL_CONTEXT_PROFILE_MASK = 21,
-        SDL_GL_SHARE_WITH_CURRENT_CONTEXT = 22,
-        SDL_GL_FRAMEBUFFER_SRGB_CAPABLE = 23,
-        SDL_GL_CONTEXT_RELEASE_BEHAVIOR = 24,
-        SDL_GL_CONTEXT_RESET_NOTIFICATION = 25,
-        SDL_GL_CONTEXT_NO_ERROR = 26
+        SDL_GL_RED_SIZE = 0U,
+        SDL_GL_GREEN_SIZE = 1U,
+        SDL_GL_BLUE_SIZE = 2U,
+        SDL_GL_ALPHA_SIZE = 3U,
+        SDL_GL_BUFFER_SIZE = 4U,
+        SDL_GL_DOUBLEBUFFER = 5U,
+        SDL_GL_DEPTH_SIZE = 6U,
+        SDL_GL_STENCIL_SIZE = 7U,
+        SDL_GL_ACCUM_RED_SIZE = 8U,
+        SDL_GL_ACCUM_GREEN_SIZE = 9U,
+        SDL_GL_ACCUM_BLUE_SIZE = 10U,
+        SDL_GL_ACCUM_ALPHA_SIZE = 11U,
+        SDL_GL_STEREO = 12U,
+        SDL_GL_MULTISAMPLEBUFFERS = 13U,
+        SDL_GL_MULTISAMPLESAMPLES = 14U,
+        SDL_GL_ACCELERATED_VISUAL = 15U,
+        SDL_GL_RETAINED_BACKING = 16U,
+        SDL_GL_CONTEXT_MAJOR_VERSION = 17U,
+        SDL_GL_CONTEXT_MINOR_VERSION = 18U,
+        SDL_GL_CONTEXT_EGL = 19U,
+        SDL_GL_CONTEXT_FLAGS = 20U,
+        SDL_GL_CONTEXT_PROFILE_MASK = 21U,
+        SDL_GL_SHARE_WITH_CURRENT_CONTEXT = 22U,
+        SDL_GL_FRAMEBUFFER_SRGB_CAPABLE = 23U,
+        SDL_GL_CONTEXT_RELEASE_BEHAVIOR = 24U,
+        SDL_GL_CONTEXT_RESET_NOTIFICATION = 25U,
+        SDL_GL_CONTEXT_NO_ERROR = 26U
     }
 
     // Enum @ SDL_video.h:1452:3
-    public enum SDL_HitTestResult : int
+    public enum SDL_HitTestResult : uint
     {
-        SDL_HITTEST_NORMAL = 0,
-        SDL_HITTEST_DRAGGABLE = 1,
-        SDL_HITTEST_RESIZE_TOPLEFT = 2,
-        SDL_HITTEST_RESIZE_TOP = 3,
-        SDL_HITTEST_RESIZE_TOPRIGHT = 4,
-        SDL_HITTEST_RESIZE_RIGHT = 5,
-        SDL_HITTEST_RESIZE_BOTTOMRIGHT = 6,
-        SDL_HITTEST_RESIZE_BOTTOM = 7,
-        SDL_HITTEST_RESIZE_BOTTOMLEFT = 8,
-        SDL_HITTEST_RESIZE_LEFT = 9
+        SDL_HITTEST_NORMAL = 0U,
+        SDL_HITTEST_DRAGGABLE = 1U,
+        SDL_HITTEST_RESIZE_TOPLEFT = 2U,
+        SDL_HITTEST_RESIZE_TOP = 3U,
+        SDL_HITTEST_RESIZE_TOPRIGHT = 4U,
+        SDL_HITTEST_RESIZE_RIGHT = 5U,
+        SDL_HITTEST_RESIZE_BOTTOMRIGHT = 6U,
+        SDL_HITTEST_RESIZE_BOTTOM = 7U,
+        SDL_HITTEST_RESIZE_BOTTOMLEFT = 8U,
+        SDL_HITTEST_RESIZE_LEFT = 9U
     }
 
     // Enum @ SDL_video.h:197:3
-    public enum SDL_DisplayOrientation : int
+    public enum SDL_DisplayOrientation : uint
     {
-        SDL_ORIENTATION_UNKNOWN = 0,
-        SDL_ORIENTATION_LANDSCAPE = 1,
-        SDL_ORIENTATION_LANDSCAPE_FLIPPED = 2,
-        SDL_ORIENTATION_PORTRAIT = 3,
-        SDL_ORIENTATION_PORTRAIT_FLIPPED = 4
+        SDL_ORIENTATION_UNKNOWN = 0U,
+        SDL_ORIENTATION_LANDSCAPE = 1U,
+        SDL_ORIENTATION_LANDSCAPE_FLIPPED = 2U,
+        SDL_ORIENTATION_PORTRAIT = 3U,
+        SDL_ORIENTATION_PORTRAIT_FLIPPED = 4U
     }
 
     // Enum @ SDL_surface.h:112:3
-    public enum SDL_YUV_CONVERSION_MODE : int
+    public enum SDL_YUV_CONVERSION_MODE : uint
     {
-        SDL_YUV_CONVERSION_JPEG = 0,
-        SDL_YUV_CONVERSION_BT601 = 1,
-        SDL_YUV_CONVERSION_BT709 = 2,
-        SDL_YUV_CONVERSION_AUTOMATIC = 3
+        SDL_YUV_CONVERSION_JPEG = 0U,
+        SDL_YUV_CONVERSION_BT601 = 1U,
+        SDL_YUV_CONVERSION_BT709 = 2U,
+        SDL_YUV_CONVERSION_AUTOMATIC = 3U
     }
 
     // Enum @ SDL_blendmode.h:73:3
-    public enum SDL_BlendOperation : int
+    public enum SDL_BlendOperation : uint
     {
-        SDL_BLENDOPERATION_ADD = 1,
-        SDL_BLENDOPERATION_SUBTRACT = 2,
-        SDL_BLENDOPERATION_REV_SUBTRACT = 3,
-        SDL_BLENDOPERATION_MINIMUM = 4,
-        SDL_BLENDOPERATION_MAXIMUM = 5
+        SDL_BLENDOPERATION_ADD = 1U,
+        SDL_BLENDOPERATION_SUBTRACT = 2U,
+        SDL_BLENDOPERATION_REV_SUBTRACT = 3U,
+        SDL_BLENDOPERATION_MINIMUM = 4U,
+        SDL_BLENDOPERATION_MAXIMUM = 5U
     }
 
     // Enum @ SDL_blendmode.h:91:3
-    public enum SDL_BlendFactor : int
+    public enum SDL_BlendFactor : uint
     {
-        SDL_BLENDFACTOR_ZERO = 1,
-        SDL_BLENDFACTOR_ONE = 2,
-        SDL_BLENDFACTOR_SRC_COLOR = 3,
-        SDL_BLENDFACTOR_ONE_MINUS_SRC_COLOR = 4,
-        SDL_BLENDFACTOR_SRC_ALPHA = 5,
-        SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA = 6,
-        SDL_BLENDFACTOR_DST_COLOR = 7,
-        SDL_BLENDFACTOR_ONE_MINUS_DST_COLOR = 8,
-        SDL_BLENDFACTOR_DST_ALPHA = 9,
-        SDL_BLENDFACTOR_ONE_MINUS_DST_ALPHA = 10
+        SDL_BLENDFACTOR_ZERO = 1U,
+        SDL_BLENDFACTOR_ONE = 2U,
+        SDL_BLENDFACTOR_SRC_COLOR = 3U,
+        SDL_BLENDFACTOR_ONE_MINUS_SRC_COLOR = 4U,
+        SDL_BLENDFACTOR_SRC_ALPHA = 5U,
+        SDL_BLENDFACTOR_ONE_MINUS_SRC_ALPHA = 6U,
+        SDL_BLENDFACTOR_DST_COLOR = 7U,
+        SDL_BLENDFACTOR_ONE_MINUS_DST_COLOR = 8U,
+        SDL_BLENDFACTOR_DST_ALPHA = 9U,
+        SDL_BLENDFACTOR_ONE_MINUS_DST_ALPHA = 10U
     }
 
     // Enum @ SDL_audio.h:571:3
-    public enum SDL_AudioStatus : int
+    public enum SDL_AudioStatus : uint
     {
-        SDL_AUDIO_STOPPED = 0,
-        SDL_AUDIO_PLAYING = 1,
-        SDL_AUDIO_PAUSED = 2
+        SDL_AUDIO_STOPPED = 0U,
+        SDL_AUDIO_PLAYING = 1U,
+        SDL_AUDIO_PAUSED = 2U
     }
 
     // Enum @ SDL_thread.h:80:3
-    public enum SDL_ThreadPriority : int
+    public enum SDL_ThreadPriority : uint
     {
-        SDL_THREAD_PRIORITY_LOW = 0,
-        SDL_THREAD_PRIORITY_NORMAL = 1,
-        SDL_THREAD_PRIORITY_HIGH = 2,
-        SDL_THREAD_PRIORITY_TIME_CRITICAL = 3
+        SDL_THREAD_PRIORITY_LOW = 0U,
+        SDL_THREAD_PRIORITY_NORMAL = 1U,
+        SDL_THREAD_PRIORITY_HIGH = 2U,
+        SDL_THREAD_PRIORITY_TIME_CRITICAL = 3U
     }
 
     // Enum @ SDL_error.h:141:3
-    public enum SDL_errorcode : int
+    public enum SDL_errorcode : uint
     {
-        SDL_ENOMEM = 0,
-        SDL_EFREAD = 1,
-        SDL_EFWRITE = 2,
-        SDL_EFSEEK = 3,
-        SDL_UNSUPPORTED = 4,
-        SDL_LASTERROR = 5
+        SDL_ENOMEM = 0U,
+        SDL_EFREAD = 1U,
+        SDL_EFWRITE = 2U,
+        SDL_EFSEEK = 3U,
+        SDL_UNSUPPORTED = 4U,
+        SDL_LASTERROR = 5U
     }
 
     // Enum @ SDL_assert.h:113:3
-    public enum SDL_AssertState : int
+    public enum SDL_AssertState : uint
     {
-        SDL_ASSERTION_RETRY = 0,
-        SDL_ASSERTION_BREAK = 1,
-        SDL_ASSERTION_ABORT = 2,
-        SDL_ASSERTION_IGNORE = 3,
-        SDL_ASSERTION_ALWAYS_IGNORE = 4
+        SDL_ASSERTION_RETRY = 0U,
+        SDL_ASSERTION_BREAK = 1U,
+        SDL_ASSERTION_ABORT = 2U,
+        SDL_ASSERTION_IGNORE = 3U,
+        SDL_ASSERTION_ALWAYS_IGNORE = 4U
     }
-
-    private static void _LoadVirtualTable()
-    {
-        #region "Functions"
-        _virtualTable.SDL_Quit = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Quit");
-        _virtualTable.SDL_WasInit = (delegate* unmanaged[Cdecl]<uint, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WasInit");
-        _virtualTable.SDL_QuitSubSystem = (delegate* unmanaged[Cdecl]<uint, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_QuitSubSystem");
-        _virtualTable.SDL_InitSubSystem = (delegate* unmanaged[Cdecl]<uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_InitSubSystem");
-        _virtualTable.SDL_Init = (delegate* unmanaged[Cdecl]<uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Init");
-        _virtualTable.SDL_OpenURL = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_OpenURL");
-        _virtualTable.SDL_GetPreferredLocales = (delegate* unmanaged[Cdecl]<SDL_Locale*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetPreferredLocales");
-        _virtualTable.SDL_GetRevisionNumber = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRevisionNumber");
-        _virtualTable.SDL_GetRevision = (delegate* unmanaged[Cdecl]<CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRevision");
-        _virtualTable.SDL_GetVersion = (delegate* unmanaged[Cdecl]<SDL_version*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetVersion");
-        _virtualTable.SDL_RemoveTimer = (delegate* unmanaged[Cdecl]<SDL_TimerID, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RemoveTimer");
-        _virtualTable.SDL_AddTimer = (delegate* unmanaged[Cdecl]<uint, SDL_TimerCallback, void*, SDL_TimerID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AddTimer");
-        _virtualTable.SDL_Delay = (delegate* unmanaged[Cdecl]<uint, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Delay");
-        _virtualTable.SDL_GetPerformanceFrequency = (delegate* unmanaged[Cdecl]<ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetPerformanceFrequency");
-        _virtualTable.SDL_GetPerformanceCounter = (delegate* unmanaged[Cdecl]<ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetPerformanceCounter");
-        _virtualTable.SDL_GetTicks = (delegate* unmanaged[Cdecl]<uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetTicks");
-        _virtualTable.SDL_GetShapedWindowMode = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_WindowShapeMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetShapedWindowMode");
-        _virtualTable.SDL_SetWindowShape = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Surface*, SDL_WindowShapeMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowShape");
-        _virtualTable.SDL_IsShapedWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_IsShapedWindow");
-        _virtualTable.SDL_CreateShapedWindow = (delegate* unmanaged[Cdecl]<CString, uint, uint, uint, uint, uint, SDL_Window*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateShapedWindow");
-        _virtualTable.SDL_RenderGetMetalCommandEncoder = (delegate* unmanaged[Cdecl]<SDL_Renderer*, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderGetMetalCommandEncoder");
-        _virtualTable.SDL_RenderGetMetalLayer = (delegate* unmanaged[Cdecl]<SDL_Renderer*, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderGetMetalLayer");
-        _virtualTable.SDL_GL_UnbindTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_UnbindTexture");
-        _virtualTable.SDL_GL_BindTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, float*, float*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_BindTexture");
-        _virtualTable.SDL_RenderFlush = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderFlush");
-        _virtualTable.SDL_DestroyRenderer = (delegate* unmanaged[Cdecl]<SDL_Renderer*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DestroyRenderer");
-        _virtualTable.SDL_DestroyTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DestroyTexture");
-        _virtualTable.SDL_RenderPresent = (delegate* unmanaged[Cdecl]<SDL_Renderer*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderPresent");
-        _virtualTable.SDL_RenderReadPixels = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, uint, void*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderReadPixels");
-        _virtualTable.SDL_RenderCopyExF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_FRect*, double, SDL_FPoint*, SDL_RendererFlip, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderCopyExF");
-        _virtualTable.SDL_RenderCopyF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_FRect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderCopyF");
-        _virtualTable.SDL_RenderFillRectsF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderFillRectsF");
-        _virtualTable.SDL_RenderFillRectF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderFillRectF");
-        _virtualTable.SDL_RenderDrawRectsF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawRectsF");
-        _virtualTable.SDL_RenderDrawRectF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawRectF");
-        _virtualTable.SDL_RenderDrawLinesF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FPoint*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawLinesF");
-        _virtualTable.SDL_RenderDrawLineF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, float, float, float, float, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawLineF");
-        _virtualTable.SDL_RenderDrawPointsF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FPoint*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawPointsF");
-        _virtualTable.SDL_RenderDrawPointF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, float, float, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawPointF");
-        _virtualTable.SDL_RenderCopyEx = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_Rect*, double, SDL_Point*, SDL_RendererFlip, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderCopyEx");
-        _virtualTable.SDL_RenderCopy = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderCopy");
-        _virtualTable.SDL_RenderFillRects = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderFillRects");
-        _virtualTable.SDL_RenderFillRect = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderFillRect");
-        _virtualTable.SDL_RenderDrawRects = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawRects");
-        _virtualTable.SDL_RenderDrawRect = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawRect");
-        _virtualTable.SDL_RenderDrawLines = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Point*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawLines");
-        _virtualTable.SDL_RenderDrawLine = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int, int, int, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawLine");
-        _virtualTable.SDL_RenderDrawPoints = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Point*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawPoints");
-        _virtualTable.SDL_RenderDrawPoint = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderDrawPoint");
-        _virtualTable.SDL_RenderClear = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderClear");
-        _virtualTable.SDL_GetRenderDrawBlendMode = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_BlendMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRenderDrawBlendMode");
-        _virtualTable.SDL_SetRenderDrawBlendMode = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_BlendMode, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetRenderDrawBlendMode");
-        _virtualTable.SDL_GetRenderDrawColor = (delegate* unmanaged[Cdecl]<SDL_Renderer*, byte*, byte*, byte*, byte*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRenderDrawColor");
-        _virtualTable.SDL_SetRenderDrawColor = (delegate* unmanaged[Cdecl]<SDL_Renderer*, byte, byte, byte, byte, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetRenderDrawColor");
-        _virtualTable.SDL_RenderGetScale = (delegate* unmanaged[Cdecl]<SDL_Renderer*, float*, float*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderGetScale");
-        _virtualTable.SDL_RenderSetScale = (delegate* unmanaged[Cdecl]<SDL_Renderer*, float, float, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderSetScale");
-        _virtualTable.SDL_RenderIsClipEnabled = (delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderIsClipEnabled");
-        _virtualTable.SDL_RenderGetClipRect = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderGetClipRect");
-        _virtualTable.SDL_RenderSetClipRect = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderSetClipRect");
-        _virtualTable.SDL_RenderGetViewport = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderGetViewport");
-        _virtualTable.SDL_RenderSetViewport = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderSetViewport");
-        _virtualTable.SDL_RenderGetIntegerScale = (delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderGetIntegerScale");
-        _virtualTable.SDL_RenderSetIntegerScale = (delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderSetIntegerScale");
-        _virtualTable.SDL_RenderGetLogicalSize = (delegate* unmanaged[Cdecl]<SDL_Renderer*, long*, long*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderGetLogicalSize");
-        _virtualTable.SDL_RenderSetLogicalSize = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderSetLogicalSize");
-        _virtualTable.SDL_GetRenderTarget = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRenderTarget");
-        _virtualTable.SDL_SetRenderTarget = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetRenderTarget");
-        _virtualTable.SDL_RenderTargetSupported = (delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RenderTargetSupported");
-        _virtualTable.SDL_UnlockTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UnlockTexture");
-        _virtualTable.SDL_LockTextureToSurface = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, SDL_Surface**, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LockTextureToSurface");
-        _virtualTable.SDL_LockTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, void**, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LockTexture");
-        _virtualTable.SDL_UpdateNVTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, byte*, int, byte*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UpdateNVTexture");
-        _virtualTable.SDL_UpdateYUVTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, byte*, int, byte*, int, byte*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UpdateYUVTexture");
-        _virtualTable.SDL_UpdateTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, void*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UpdateTexture");
-        _virtualTable.SDL_GetTextureScaleMode = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_ScaleMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetTextureScaleMode");
-        _virtualTable.SDL_SetTextureScaleMode = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_ScaleMode, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetTextureScaleMode");
-        _virtualTable.SDL_GetTextureBlendMode = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_BlendMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetTextureBlendMode");
-        _virtualTable.SDL_SetTextureBlendMode = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_BlendMode, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetTextureBlendMode");
-        _virtualTable.SDL_GetTextureAlphaMod = (delegate* unmanaged[Cdecl]<SDL_Texture*, byte*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetTextureAlphaMod");
-        _virtualTable.SDL_SetTextureAlphaMod = (delegate* unmanaged[Cdecl]<SDL_Texture*, byte, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetTextureAlphaMod");
-        _virtualTable.SDL_GetTextureColorMod = (delegate* unmanaged[Cdecl]<SDL_Texture*, byte*, byte*, byte*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetTextureColorMod");
-        _virtualTable.SDL_SetTextureColorMod = (delegate* unmanaged[Cdecl]<SDL_Texture*, byte, byte, byte, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetTextureColorMod");
-        _virtualTable.SDL_QueryTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, uint*, long*, long*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_QueryTexture");
-        _virtualTable.SDL_CreateTextureFromSurface = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Surface*, SDL_Texture*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateTextureFromSurface");
-        _virtualTable.SDL_CreateTexture = (delegate* unmanaged[Cdecl]<SDL_Renderer*, uint, int, int, int, SDL_Texture*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateTexture");
-        _virtualTable.SDL_GetRendererOutputSize = (delegate* unmanaged[Cdecl]<SDL_Renderer*, long*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRendererOutputSize");
-        _virtualTable.SDL_GetRendererInfo = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_RendererInfo*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRendererInfo");
-        _virtualTable.SDL_GetRenderer = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Renderer*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRenderer");
-        _virtualTable.SDL_CreateSoftwareRenderer = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Renderer*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateSoftwareRenderer");
-        _virtualTable.SDL_CreateRenderer = (delegate* unmanaged[Cdecl]<SDL_Window*, int, uint, SDL_Renderer*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateRenderer");
-        _virtualTable.SDL_CreateWindowAndRenderer = (delegate* unmanaged[Cdecl]<int, int, uint, SDL_Window**, SDL_Renderer**, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateWindowAndRenderer");
-        _virtualTable.SDL_GetRenderDriverInfo = (delegate* unmanaged[Cdecl]<int, SDL_RendererInfo*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRenderDriverInfo");
-        _virtualTable.SDL_GetNumRenderDrivers = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetNumRenderDrivers");
-        _virtualTable.SDL_GetPowerInfo = (delegate* unmanaged[Cdecl]<long*, long*, SDL_PowerState>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetPowerInfo");
-        _virtualTable.SDL_Metal_GetDrawableSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Metal_GetDrawableSize");
-        _virtualTable.SDL_Metal_GetLayer = (delegate* unmanaged[Cdecl]<SDL_MetalView, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Metal_GetLayer");
-        _virtualTable.SDL_Metal_DestroyView = (delegate* unmanaged[Cdecl]<SDL_MetalView, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Metal_DestroyView");
-        _virtualTable.SDL_Metal_CreateView = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_MetalView>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Metal_CreateView");
-        _virtualTable.SDL_ShowSimpleMessageBox = (delegate* unmanaged[Cdecl]<uint, CString, CString, SDL_Window*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ShowSimpleMessageBox");
-        _virtualTable.SDL_ShowMessageBox = (delegate* unmanaged[Cdecl]<SDL_MessageBoxData*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ShowMessageBox");
-        _virtualTable.SDL_LogSetOutputFunction = (delegate* unmanaged[Cdecl]<SDL_LogOutputFunction, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogSetOutputFunction");
-        _virtualTable.SDL_LogGetOutputFunction = (delegate* unmanaged[Cdecl]<SDL_LogOutputFunction*, void**, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogGetOutputFunction");
-        _virtualTable.SDL_LogMessageV = (delegate* unmanaged[Cdecl]<int, SDL_LogPriority, CString, IntPtr, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogMessageV");
-        _virtualTable.SDL_LogMessage = (delegate* unmanaged[Cdecl]<int, SDL_LogPriority, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogMessage");
-        _virtualTable.SDL_LogCritical = (delegate* unmanaged[Cdecl]<int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogCritical");
-        _virtualTable.SDL_LogError = (delegate* unmanaged[Cdecl]<int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogError");
-        _virtualTable.SDL_LogWarn = (delegate* unmanaged[Cdecl]<int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogWarn");
-        _virtualTable.SDL_LogInfo = (delegate* unmanaged[Cdecl]<int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogInfo");
-        _virtualTable.SDL_LogDebug = (delegate* unmanaged[Cdecl]<int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogDebug");
-        _virtualTable.SDL_LogVerbose = (delegate* unmanaged[Cdecl]<int, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogVerbose");
-        _virtualTable.SDL_Log = (delegate* unmanaged[Cdecl]<CString, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Log");
-        _virtualTable.SDL_LogResetPriorities = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogResetPriorities");
-        _virtualTable.SDL_LogGetPriority = (delegate* unmanaged[Cdecl]<int, SDL_LogPriority>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogGetPriority");
-        _virtualTable.SDL_LogSetPriority = (delegate* unmanaged[Cdecl]<int, SDL_LogPriority, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogSetPriority");
-        _virtualTable.SDL_LogSetAllPriority = (delegate* unmanaged[Cdecl]<SDL_LogPriority, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LogSetAllPriority");
-        _virtualTable.SDL_UnloadObject = (delegate* unmanaged[Cdecl]<void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UnloadObject");
-        _virtualTable.SDL_LoadFunction = (delegate* unmanaged[Cdecl]<void*, CString, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LoadFunction");
-        _virtualTable.SDL_LoadObject = (delegate* unmanaged[Cdecl]<CString, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LoadObject");
-        _virtualTable.SDL_ClearHints = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ClearHints");
-        _virtualTable.SDL_DelHintCallback = (delegate* unmanaged[Cdecl]<CString, SDL_HintCallback, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DelHintCallback");
-        _virtualTable.SDL_AddHintCallback = (delegate* unmanaged[Cdecl]<CString, SDL_HintCallback, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AddHintCallback");
-        _virtualTable.SDL_GetHintBoolean = (delegate* unmanaged[Cdecl]<CString, CBool, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetHintBoolean");
-        _virtualTable.SDL_GetHint = (delegate* unmanaged[Cdecl]<CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetHint");
-        _virtualTable.SDL_SetHint = (delegate* unmanaged[Cdecl]<CString, CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetHint");
-        _virtualTable.SDL_SetHintWithPriority = (delegate* unmanaged[Cdecl]<CString, CString, SDL_HintPriority, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetHintWithPriority");
-        _virtualTable.SDL_HapticRumbleStop = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticRumbleStop");
-        _virtualTable.SDL_HapticRumblePlay = (delegate* unmanaged[Cdecl]<SDL_Haptic*, float, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticRumblePlay");
-        _virtualTable.SDL_HapticRumbleInit = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticRumbleInit");
-        _virtualTable.SDL_HapticRumbleSupported = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticRumbleSupported");
-        _virtualTable.SDL_HapticStopAll = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticStopAll");
-        _virtualTable.SDL_HapticUnpause = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticUnpause");
-        _virtualTable.SDL_HapticPause = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticPause");
-        _virtualTable.SDL_HapticSetAutocenter = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticSetAutocenter");
-        _virtualTable.SDL_HapticSetGain = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticSetGain");
-        _virtualTable.SDL_HapticGetEffectStatus = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticGetEffectStatus");
-        _virtualTable.SDL_HapticDestroyEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticDestroyEffect");
-        _virtualTable.SDL_HapticStopEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticStopEffect");
-        _virtualTable.SDL_HapticRunEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticRunEffect");
-        _virtualTable.SDL_HapticUpdateEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, SDL_HapticEffect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticUpdateEffect");
-        _virtualTable.SDL_HapticNewEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, SDL_HapticEffect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticNewEffect");
-        _virtualTable.SDL_HapticEffectSupported = (delegate* unmanaged[Cdecl]<SDL_Haptic*, SDL_HapticEffect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticEffectSupported");
-        _virtualTable.SDL_HapticNumAxes = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticNumAxes");
-        _virtualTable.SDL_HapticQuery = (delegate* unmanaged[Cdecl]<SDL_Haptic*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticQuery");
-        _virtualTable.SDL_HapticNumEffectsPlaying = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticNumEffectsPlaying");
-        _virtualTable.SDL_HapticNumEffects = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticNumEffects");
-        _virtualTable.SDL_HapticClose = (delegate* unmanaged[Cdecl]<SDL_Haptic*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticClose");
-        _virtualTable.SDL_HapticOpenFromJoystick = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_Haptic*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticOpenFromJoystick");
-        _virtualTable.SDL_JoystickIsHaptic = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickIsHaptic");
-        _virtualTable.SDL_HapticOpenFromMouse = (delegate* unmanaged[Cdecl]<SDL_Haptic*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticOpenFromMouse");
-        _virtualTable.SDL_MouseIsHaptic = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MouseIsHaptic");
-        _virtualTable.SDL_HapticIndex = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticIndex");
-        _virtualTable.SDL_HapticOpened = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticOpened");
-        _virtualTable.SDL_HapticOpen = (delegate* unmanaged[Cdecl]<int, SDL_Haptic*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticOpen");
-        _virtualTable.SDL_HapticName = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HapticName");
-        _virtualTable.SDL_NumHaptics = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_NumHaptics");
-        _virtualTable.SDL_GetPrefPath = (delegate* unmanaged[Cdecl]<CString, CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetPrefPath");
-        _virtualTable.SDL_GetBasePath = (delegate* unmanaged[Cdecl]<CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetBasePath");
-        _virtualTable.SDL_RegisterEvents = (delegate* unmanaged[Cdecl]<int, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RegisterEvents");
-        _virtualTable.SDL_EventState = (delegate* unmanaged[Cdecl]<uint, int, byte>)Runtime.LibraryGetExport(_libraryHandle, "SDL_EventState");
-        _virtualTable.SDL_FilterEvents = (delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FilterEvents");
-        _virtualTable.SDL_DelEventWatch = (delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DelEventWatch");
-        _virtualTable.SDL_AddEventWatch = (delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AddEventWatch");
-        _virtualTable.SDL_GetEventFilter = (delegate* unmanaged[Cdecl]<SDL_EventFilter*, void**, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetEventFilter");
-        _virtualTable.SDL_SetEventFilter = (delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetEventFilter");
-        _virtualTable.SDL_PushEvent = (delegate* unmanaged[Cdecl]<SDL_Event*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_PushEvent");
-        _virtualTable.SDL_WaitEventTimeout = (delegate* unmanaged[Cdecl]<SDL_Event*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WaitEventTimeout");
-        _virtualTable.SDL_WaitEvent = (delegate* unmanaged[Cdecl]<SDL_Event*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WaitEvent");
-        _virtualTable.SDL_PollEvent = (delegate* unmanaged[Cdecl]<SDL_Event*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_PollEvent");
-        _virtualTable.SDL_FlushEvents = (delegate* unmanaged[Cdecl]<uint, uint, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FlushEvents");
-        _virtualTable.SDL_FlushEvent = (delegate* unmanaged[Cdecl]<uint, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FlushEvent");
-        _virtualTable.SDL_HasEvents = (delegate* unmanaged[Cdecl]<uint, uint, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasEvents");
-        _virtualTable.SDL_HasEvent = (delegate* unmanaged[Cdecl]<uint, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasEvent");
-        _virtualTable.SDL_PeepEvents = (delegate* unmanaged[Cdecl]<SDL_Event*, int, SDL_eventaction, uint, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_PeepEvents");
-        _virtualTable.SDL_PumpEvents = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_PumpEvents");
-        _virtualTable.SDL_LoadDollarTemplates = (delegate* unmanaged[Cdecl]<SDL_TouchID, SDL_RWops*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LoadDollarTemplates");
-        _virtualTable.SDL_SaveDollarTemplate = (delegate* unmanaged[Cdecl]<SDL_GestureID, SDL_RWops*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SaveDollarTemplate");
-        _virtualTable.SDL_SaveAllDollarTemplates = (delegate* unmanaged[Cdecl]<SDL_RWops*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SaveAllDollarTemplates");
-        _virtualTable.SDL_RecordGesture = (delegate* unmanaged[Cdecl]<SDL_TouchID, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RecordGesture");
-        _virtualTable.SDL_GetTouchFinger = (delegate* unmanaged[Cdecl]<SDL_TouchID, int, SDL_Finger*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetTouchFinger");
-        _virtualTable.SDL_GetNumTouchFingers = (delegate* unmanaged[Cdecl]<SDL_TouchID, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetNumTouchFingers");
-        _virtualTable.SDL_GetTouchDeviceType = (delegate* unmanaged[Cdecl]<SDL_TouchID, SDL_TouchDeviceType>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetTouchDeviceType");
-        _virtualTable.SDL_GetTouchDevice = (delegate* unmanaged[Cdecl]<int, SDL_TouchID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetTouchDevice");
-        _virtualTable.SDL_GetNumTouchDevices = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetNumTouchDevices");
-        _virtualTable.SDL_GameControllerClose = (delegate* unmanaged[Cdecl]<SDL_GameController*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerClose");
-        _virtualTable.SDL_GameControllerSetLED = (delegate* unmanaged[Cdecl]<SDL_GameController*, byte, byte, byte, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerSetLED");
-        _virtualTable.SDL_GameControllerHasLED = (delegate* unmanaged[Cdecl]<SDL_GameController*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerHasLED");
-        _virtualTable.SDL_GameControllerRumbleTriggers = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort, ushort, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerRumbleTriggers");
-        _virtualTable.SDL_GameControllerRumble = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort, ushort, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerRumble");
-        _virtualTable.SDL_GameControllerGetSensorData = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, float*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetSensorData");
-        _virtualTable.SDL_GameControllerIsSensorEnabled = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerIsSensorEnabled");
-        _virtualTable.SDL_GameControllerSetSensorEnabled = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, CBool, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerSetSensorEnabled");
-        _virtualTable.SDL_GameControllerHasSensor = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerHasSensor");
-        _virtualTable.SDL_GameControllerGetTouchpadFinger = (delegate* unmanaged[Cdecl]<SDL_GameController*, int, int, byte*, float*, float*, float*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetTouchpadFinger");
-        _virtualTable.SDL_GameControllerGetNumTouchpadFingers = (delegate* unmanaged[Cdecl]<SDL_GameController*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetNumTouchpadFingers");
-        _virtualTable.SDL_GameControllerGetNumTouchpads = (delegate* unmanaged[Cdecl]<SDL_GameController*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetNumTouchpads");
-        _virtualTable.SDL_GameControllerGetButton = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerButton, byte>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetButton");
-        _virtualTable.SDL_GameControllerHasButton = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerButton, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerHasButton");
-        _virtualTable.SDL_GameControllerGetBindForButton = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerButton, SDL_GameControllerButtonBind>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetBindForButton");
-        _virtualTable.SDL_GameControllerGetStringForButton = (delegate* unmanaged[Cdecl]<SDL_GameControllerButton, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetStringForButton");
-        _virtualTable.SDL_GameControllerGetButtonFromString = (delegate* unmanaged[Cdecl]<CString, SDL_GameControllerButton>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetButtonFromString");
-        _virtualTable.SDL_GameControllerGetAxis = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerAxis, short>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetAxis");
-        _virtualTable.SDL_GameControllerHasAxis = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerAxis, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerHasAxis");
-        _virtualTable.SDL_GameControllerGetBindForAxis = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerAxis, SDL_GameControllerButtonBind>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetBindForAxis");
-        _virtualTable.SDL_GameControllerGetStringForAxis = (delegate* unmanaged[Cdecl]<SDL_GameControllerAxis, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetStringForAxis");
-        _virtualTable.SDL_GameControllerGetAxisFromString = (delegate* unmanaged[Cdecl]<CString, SDL_GameControllerAxis>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetAxisFromString");
-        _virtualTable.SDL_GameControllerUpdate = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerUpdate");
-        _virtualTable.SDL_GameControllerEventState = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerEventState");
-        _virtualTable.SDL_GameControllerGetJoystick = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_Joystick*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetJoystick");
-        _virtualTable.SDL_GameControllerGetAttached = (delegate* unmanaged[Cdecl]<SDL_GameController*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetAttached");
-        _virtualTable.SDL_GameControllerGetSerial = (delegate* unmanaged[Cdecl]<SDL_GameController*, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetSerial");
-        _virtualTable.SDL_GameControllerGetProductVersion = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetProductVersion");
-        _virtualTable.SDL_GameControllerGetProduct = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetProduct");
-        _virtualTable.SDL_GameControllerGetVendor = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetVendor");
-        _virtualTable.SDL_GameControllerSetPlayerIndex = (delegate* unmanaged[Cdecl]<SDL_GameController*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerSetPlayerIndex");
-        _virtualTable.SDL_GameControllerGetPlayerIndex = (delegate* unmanaged[Cdecl]<SDL_GameController*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetPlayerIndex");
-        _virtualTable.SDL_GameControllerGetType = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerType>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerGetType");
-        _virtualTable.SDL_GameControllerName = (delegate* unmanaged[Cdecl]<SDL_GameController*, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerName");
-        _virtualTable.SDL_GameControllerFromPlayerIndex = (delegate* unmanaged[Cdecl]<int, SDL_GameController*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerFromPlayerIndex");
-        _virtualTable.SDL_GameControllerFromInstanceID = (delegate* unmanaged[Cdecl]<SDL_JoystickID, SDL_GameController*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerFromInstanceID");
-        _virtualTable.SDL_GameControllerOpen = (delegate* unmanaged[Cdecl]<int, SDL_GameController*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerOpen");
-        _virtualTable.SDL_GameControllerMappingForDeviceIndex = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerMappingForDeviceIndex");
-        _virtualTable.SDL_GameControllerTypeForIndex = (delegate* unmanaged[Cdecl]<int, SDL_GameControllerType>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerTypeForIndex");
-        _virtualTable.SDL_GameControllerNameForIndex = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerNameForIndex");
-        _virtualTable.SDL_IsGameController = (delegate* unmanaged[Cdecl]<int, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_IsGameController");
-        _virtualTable.SDL_GameControllerMapping = (delegate* unmanaged[Cdecl]<SDL_GameController*, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerMapping");
-        _virtualTable.SDL_GameControllerMappingForGUID = (delegate* unmanaged[Cdecl]<SDL_JoystickGUID, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerMappingForGUID");
-        _virtualTable.SDL_GameControllerMappingForIndex = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerMappingForIndex");
-        _virtualTable.SDL_GameControllerNumMappings = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerNumMappings");
-        _virtualTable.SDL_GameControllerAddMapping = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerAddMapping");
-        _virtualTable.SDL_GameControllerAddMappingsFromRW = (delegate* unmanaged[Cdecl]<SDL_RWops*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GameControllerAddMappingsFromRW");
-        _virtualTable.SDL_SensorUpdate = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorUpdate");
-        _virtualTable.SDL_SensorClose = (delegate* unmanaged[Cdecl]<SDL_Sensor*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorClose");
-        _virtualTable.SDL_SensorGetData = (delegate* unmanaged[Cdecl]<SDL_Sensor*, float*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorGetData");
-        _virtualTable.SDL_SensorGetInstanceID = (delegate* unmanaged[Cdecl]<SDL_Sensor*, SDL_SensorID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorGetInstanceID");
-        _virtualTable.SDL_SensorGetNonPortableType = (delegate* unmanaged[Cdecl]<SDL_Sensor*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorGetNonPortableType");
-        _virtualTable.SDL_SensorGetType = (delegate* unmanaged[Cdecl]<SDL_Sensor*, SDL_SensorType>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorGetType");
-        _virtualTable.SDL_SensorGetName = (delegate* unmanaged[Cdecl]<SDL_Sensor*, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorGetName");
-        _virtualTable.SDL_SensorFromInstanceID = (delegate* unmanaged[Cdecl]<SDL_SensorID, SDL_Sensor*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorFromInstanceID");
-        _virtualTable.SDL_SensorOpen = (delegate* unmanaged[Cdecl]<int, SDL_Sensor*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorOpen");
-        _virtualTable.SDL_SensorGetDeviceInstanceID = (delegate* unmanaged[Cdecl]<int, SDL_SensorID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorGetDeviceInstanceID");
-        _virtualTable.SDL_SensorGetDeviceNonPortableType = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorGetDeviceNonPortableType");
-        _virtualTable.SDL_SensorGetDeviceType = (delegate* unmanaged[Cdecl]<int, SDL_SensorType>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorGetDeviceType");
-        _virtualTable.SDL_SensorGetDeviceName = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SensorGetDeviceName");
-        _virtualTable.SDL_NumSensors = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_NumSensors");
-        _virtualTable.SDL_UnlockSensors = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UnlockSensors");
-        _virtualTable.SDL_LockSensors = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LockSensors");
-        _virtualTable.SDL_JoystickCurrentPowerLevel = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickPowerLevel>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickCurrentPowerLevel");
-        _virtualTable.SDL_JoystickClose = (delegate* unmanaged[Cdecl]<SDL_Joystick*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickClose");
-        _virtualTable.SDL_JoystickSetLED = (delegate* unmanaged[Cdecl]<SDL_Joystick*, byte, byte, byte, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickSetLED");
-        _virtualTable.SDL_JoystickHasLED = (delegate* unmanaged[Cdecl]<SDL_Joystick*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickHasLED");
-        _virtualTable.SDL_JoystickRumbleTriggers = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort, ushort, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickRumbleTriggers");
-        _virtualTable.SDL_JoystickRumble = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort, ushort, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickRumble");
-        _virtualTable.SDL_JoystickGetButton = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetButton");
-        _virtualTable.SDL_JoystickGetBall = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, long*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetBall");
-        _virtualTable.SDL_JoystickGetHat = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetHat");
-        _virtualTable.SDL_JoystickGetAxisInitialState = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, short*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetAxisInitialState");
-        _virtualTable.SDL_JoystickGetAxis = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, short>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetAxis");
-        _virtualTable.SDL_JoystickEventState = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickEventState");
-        _virtualTable.SDL_JoystickUpdate = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickUpdate");
-        _virtualTable.SDL_JoystickNumButtons = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickNumButtons");
-        _virtualTable.SDL_JoystickNumHats = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickNumHats");
-        _virtualTable.SDL_JoystickNumBalls = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickNumBalls");
-        _virtualTable.SDL_JoystickNumAxes = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickNumAxes");
-        _virtualTable.SDL_JoystickInstanceID = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickInstanceID");
-        _virtualTable.SDL_JoystickGetAttached = (delegate* unmanaged[Cdecl]<SDL_Joystick*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetAttached");
-        _virtualTable.SDL_JoystickGetGUIDFromString = (delegate* unmanaged[Cdecl]<CString, SDL_JoystickGUID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetGUIDFromString");
-        _virtualTable.SDL_JoystickGetGUIDString = (delegate* unmanaged[Cdecl]<SDL_JoystickGUID, CString, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetGUIDString");
-        _virtualTable.SDL_JoystickGetType = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickType>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetType");
-        _virtualTable.SDL_JoystickGetSerial = (delegate* unmanaged[Cdecl]<SDL_Joystick*, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetSerial");
-        _virtualTable.SDL_JoystickGetProductVersion = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetProductVersion");
-        _virtualTable.SDL_JoystickGetProduct = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetProduct");
-        _virtualTable.SDL_JoystickGetVendor = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetVendor");
-        _virtualTable.SDL_JoystickGetGUID = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickGUID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetGUID");
-        _virtualTable.SDL_JoystickSetPlayerIndex = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickSetPlayerIndex");
-        _virtualTable.SDL_JoystickGetPlayerIndex = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetPlayerIndex");
-        _virtualTable.SDL_JoystickName = (delegate* unmanaged[Cdecl]<SDL_Joystick*, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickName");
-        _virtualTable.SDL_JoystickSetVirtualHat = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickSetVirtualHat");
-        _virtualTable.SDL_JoystickSetVirtualButton = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickSetVirtualButton");
-        _virtualTable.SDL_JoystickSetVirtualAxis = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, short, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickSetVirtualAxis");
-        _virtualTable.SDL_JoystickIsVirtual = (delegate* unmanaged[Cdecl]<int, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickIsVirtual");
-        _virtualTable.SDL_JoystickDetachVirtual = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickDetachVirtual");
-        _virtualTable.SDL_JoystickAttachVirtual = (delegate* unmanaged[Cdecl]<SDL_JoystickType, int, int, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickAttachVirtual");
-        _virtualTable.SDL_JoystickFromPlayerIndex = (delegate* unmanaged[Cdecl]<int, SDL_Joystick*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickFromPlayerIndex");
-        _virtualTable.SDL_JoystickFromInstanceID = (delegate* unmanaged[Cdecl]<SDL_JoystickID, SDL_Joystick*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickFromInstanceID");
-        _virtualTable.SDL_JoystickOpen = (delegate* unmanaged[Cdecl]<int, SDL_Joystick*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickOpen");
-        _virtualTable.SDL_JoystickGetDeviceInstanceID = (delegate* unmanaged[Cdecl]<int, SDL_JoystickID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetDeviceInstanceID");
-        _virtualTable.SDL_JoystickGetDeviceType = (delegate* unmanaged[Cdecl]<int, SDL_JoystickType>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetDeviceType");
-        _virtualTable.SDL_JoystickGetDeviceProductVersion = (delegate* unmanaged[Cdecl]<int, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetDeviceProductVersion");
-        _virtualTable.SDL_JoystickGetDeviceProduct = (delegate* unmanaged[Cdecl]<int, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetDeviceProduct");
-        _virtualTable.SDL_JoystickGetDeviceVendor = (delegate* unmanaged[Cdecl]<int, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetDeviceVendor");
-        _virtualTable.SDL_JoystickGetDeviceGUID = (delegate* unmanaged[Cdecl]<int, SDL_JoystickGUID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetDeviceGUID");
-        _virtualTable.SDL_JoystickGetDevicePlayerIndex = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickGetDevicePlayerIndex");
-        _virtualTable.SDL_JoystickNameForIndex = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_JoystickNameForIndex");
-        _virtualTable.SDL_NumJoysticks = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_NumJoysticks");
-        _virtualTable.SDL_UnlockJoysticks = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UnlockJoysticks");
-        _virtualTable.SDL_LockJoysticks = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LockJoysticks");
-        _virtualTable.SDL_ShowCursor = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ShowCursor");
-        _virtualTable.SDL_FreeCursor = (delegate* unmanaged[Cdecl]<SDL_Cursor*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FreeCursor");
-        _virtualTable.SDL_GetDefaultCursor = (delegate* unmanaged[Cdecl]<SDL_Cursor*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetDefaultCursor");
-        _virtualTable.SDL_GetCursor = (delegate* unmanaged[Cdecl]<SDL_Cursor*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetCursor");
-        _virtualTable.SDL_SetCursor = (delegate* unmanaged[Cdecl]<SDL_Cursor*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetCursor");
-        _virtualTable.SDL_CreateSystemCursor = (delegate* unmanaged[Cdecl]<SDL_SystemCursor, SDL_Cursor*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateSystemCursor");
-        _virtualTable.SDL_CreateColorCursor = (delegate* unmanaged[Cdecl]<SDL_Surface*, int, int, SDL_Cursor*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateColorCursor");
-        _virtualTable.SDL_CreateCursor = (delegate* unmanaged[Cdecl]<byte*, byte*, int, int, int, int, SDL_Cursor*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateCursor");
-        _virtualTable.SDL_GetRelativeMouseMode = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRelativeMouseMode");
-        _virtualTable.SDL_CaptureMouse = (delegate* unmanaged[Cdecl]<CBool, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CaptureMouse");
-        _virtualTable.SDL_SetRelativeMouseMode = (delegate* unmanaged[Cdecl]<CBool, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetRelativeMouseMode");
-        _virtualTable.SDL_WarpMouseGlobal = (delegate* unmanaged[Cdecl]<int, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WarpMouseGlobal");
-        _virtualTable.SDL_WarpMouseInWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WarpMouseInWindow");
-        _virtualTable.SDL_GetRelativeMouseState = (delegate* unmanaged[Cdecl]<long*, long*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRelativeMouseState");
-        _virtualTable.SDL_GetGlobalMouseState = (delegate* unmanaged[Cdecl]<long*, long*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetGlobalMouseState");
-        _virtualTable.SDL_GetMouseState = (delegate* unmanaged[Cdecl]<long*, long*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetMouseState");
-        _virtualTable.SDL_GetMouseFocus = (delegate* unmanaged[Cdecl]<SDL_Window*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetMouseFocus");
-        _virtualTable.SDL_IsScreenKeyboardShown = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_IsScreenKeyboardShown");
-        _virtualTable.SDL_HasScreenKeyboardSupport = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasScreenKeyboardSupport");
-        _virtualTable.SDL_SetTextInputRect = (delegate* unmanaged[Cdecl]<SDL_Rect*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetTextInputRect");
-        _virtualTable.SDL_StopTextInput = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_StopTextInput");
-        _virtualTable.SDL_IsTextInputActive = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_IsTextInputActive");
-        _virtualTable.SDL_StartTextInput = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_StartTextInput");
-        _virtualTable.SDL_GetKeyFromName = (delegate* unmanaged[Cdecl]<CString, SDL_Keycode>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetKeyFromName");
-        _virtualTable.SDL_GetKeyName = (delegate* unmanaged[Cdecl]<SDL_Keycode, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetKeyName");
-        _virtualTable.SDL_GetScancodeFromName = (delegate* unmanaged[Cdecl]<CString, SDL_Scancode>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetScancodeFromName");
-        _virtualTable.SDL_GetScancodeName = (delegate* unmanaged[Cdecl]<SDL_Scancode, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetScancodeName");
-        _virtualTable.SDL_GetScancodeFromKey = (delegate* unmanaged[Cdecl]<SDL_Keycode, SDL_Scancode>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetScancodeFromKey");
-        _virtualTable.SDL_GetKeyFromScancode = (delegate* unmanaged[Cdecl]<SDL_Scancode, SDL_Keycode>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetKeyFromScancode");
-        _virtualTable.SDL_SetModState = (delegate* unmanaged[Cdecl]<SDL_Keymod, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetModState");
-        _virtualTable.SDL_GetModState = (delegate* unmanaged[Cdecl]<SDL_Keymod>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetModState");
-        _virtualTable.SDL_GetKeyboardState = (delegate* unmanaged[Cdecl]<long*, byte*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetKeyboardState");
-        _virtualTable.SDL_GetKeyboardFocus = (delegate* unmanaged[Cdecl]<SDL_Window*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetKeyboardFocus");
-        _virtualTable.SDL_GL_DeleteContext = (delegate* unmanaged[Cdecl]<SDL_GLContext, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_DeleteContext");
-        _virtualTable.SDL_GL_SwapWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_SwapWindow");
-        _virtualTable.SDL_GL_GetSwapInterval = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_GetSwapInterval");
-        _virtualTable.SDL_GL_SetSwapInterval = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_SetSwapInterval");
-        _virtualTable.SDL_GL_GetDrawableSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_GetDrawableSize");
-        _virtualTable.SDL_GL_GetCurrentContext = (delegate* unmanaged[Cdecl]<SDL_GLContext>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_GetCurrentContext");
-        _virtualTable.SDL_GL_GetCurrentWindow = (delegate* unmanaged[Cdecl]<SDL_Window*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_GetCurrentWindow");
-        _virtualTable.SDL_GL_MakeCurrent = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_GLContext, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_MakeCurrent");
-        _virtualTable.SDL_GL_CreateContext = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_GLContext>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_CreateContext");
-        _virtualTable.SDL_GL_GetAttribute = (delegate* unmanaged[Cdecl]<SDL_GLattr, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_GetAttribute");
-        _virtualTable.SDL_GL_SetAttribute = (delegate* unmanaged[Cdecl]<SDL_GLattr, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_SetAttribute");
-        _virtualTable.SDL_GL_ResetAttributes = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_ResetAttributes");
-        _virtualTable.SDL_GL_ExtensionSupported = (delegate* unmanaged[Cdecl]<CString, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_ExtensionSupported");
-        _virtualTable.SDL_GL_UnloadLibrary = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_UnloadLibrary");
-        _virtualTable.SDL_GL_GetProcAddress = (delegate* unmanaged[Cdecl]<CString, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_GetProcAddress");
-        _virtualTable.SDL_GL_LoadLibrary = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GL_LoadLibrary");
-        _virtualTable.SDL_DisableScreenSaver = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DisableScreenSaver");
-        _virtualTable.SDL_EnableScreenSaver = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_EnableScreenSaver");
-        _virtualTable.SDL_IsScreenSaverEnabled = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_IsScreenSaverEnabled");
-        _virtualTable.SDL_DestroyWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DestroyWindow");
-        _virtualTable.SDL_SetWindowHitTest = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_HitTest, void*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowHitTest");
-        _virtualTable.SDL_GetWindowGammaRamp = (delegate* unmanaged[Cdecl]<SDL_Window*, ushort*, ushort*, ushort*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowGammaRamp");
-        _virtualTable.SDL_SetWindowGammaRamp = (delegate* unmanaged[Cdecl]<SDL_Window*, ushort*, ushort*, ushort*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowGammaRamp");
-        _virtualTable.SDL_SetWindowInputFocus = (delegate* unmanaged[Cdecl]<SDL_Window*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowInputFocus");
-        _virtualTable.SDL_SetWindowModalFor = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Window*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowModalFor");
-        _virtualTable.SDL_GetWindowOpacity = (delegate* unmanaged[Cdecl]<SDL_Window*, float*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowOpacity");
-        _virtualTable.SDL_SetWindowOpacity = (delegate* unmanaged[Cdecl]<SDL_Window*, float, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowOpacity");
-        _virtualTable.SDL_GetWindowBrightness = (delegate* unmanaged[Cdecl]<SDL_Window*, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowBrightness");
-        _virtualTable.SDL_SetWindowBrightness = (delegate* unmanaged[Cdecl]<SDL_Window*, float, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowBrightness");
-        _virtualTable.SDL_GetGrabbedWindow = (delegate* unmanaged[Cdecl]<SDL_Window*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetGrabbedWindow");
-        _virtualTable.SDL_GetWindowMouseGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowMouseGrab");
-        _virtualTable.SDL_GetWindowKeyboardGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowKeyboardGrab");
-        _virtualTable.SDL_GetWindowGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowGrab");
-        _virtualTable.SDL_SetWindowMouseGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowMouseGrab");
-        _virtualTable.SDL_SetWindowKeyboardGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowKeyboardGrab");
-        _virtualTable.SDL_SetWindowGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowGrab");
-        _virtualTable.SDL_UpdateWindowSurfaceRects = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Rect*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UpdateWindowSurfaceRects");
-        _virtualTable.SDL_UpdateWindowSurface = (delegate* unmanaged[Cdecl]<SDL_Window*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UpdateWindowSurface");
-        _virtualTable.SDL_GetWindowSurface = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Surface*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowSurface");
-        _virtualTable.SDL_SetWindowFullscreen = (delegate* unmanaged[Cdecl]<SDL_Window*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowFullscreen");
-        _virtualTable.SDL_RestoreWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RestoreWindow");
-        _virtualTable.SDL_MinimizeWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MinimizeWindow");
-        _virtualTable.SDL_MaximizeWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MaximizeWindow");
-        _virtualTable.SDL_RaiseWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RaiseWindow");
-        _virtualTable.SDL_HideWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HideWindow");
-        _virtualTable.SDL_ShowWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ShowWindow");
-        _virtualTable.SDL_SetWindowAlwaysOnTop = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowAlwaysOnTop");
-        _virtualTable.SDL_SetWindowResizable = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowResizable");
-        _virtualTable.SDL_SetWindowBordered = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowBordered");
-        _virtualTable.SDL_GetWindowMaximumSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowMaximumSize");
-        _virtualTable.SDL_SetWindowMaximumSize = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowMaximumSize");
-        _virtualTable.SDL_GetWindowMinimumSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowMinimumSize");
-        _virtualTable.SDL_SetWindowMinimumSize = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowMinimumSize");
-        _virtualTable.SDL_GetWindowBordersSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, long*, long*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowBordersSize");
-        _virtualTable.SDL_GetWindowSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowSize");
-        _virtualTable.SDL_SetWindowSize = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowSize");
-        _virtualTable.SDL_GetWindowPosition = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowPosition");
-        _virtualTable.SDL_SetWindowPosition = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowPosition");
-        _virtualTable.SDL_GetWindowData = (delegate* unmanaged[Cdecl]<SDL_Window*, CString, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowData");
-        _virtualTable.SDL_SetWindowData = (delegate* unmanaged[Cdecl]<SDL_Window*, CString, void*, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowData");
-        _virtualTable.SDL_SetWindowIcon = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Surface*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowIcon");
-        _virtualTable.SDL_GetWindowTitle = (delegate* unmanaged[Cdecl]<SDL_Window*, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowTitle");
-        _virtualTable.SDL_SetWindowTitle = (delegate* unmanaged[Cdecl]<SDL_Window*, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowTitle");
-        _virtualTable.SDL_GetWindowFlags = (delegate* unmanaged[Cdecl]<SDL_Window*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowFlags");
-        _virtualTable.SDL_GetWindowFromID = (delegate* unmanaged[Cdecl]<uint, SDL_Window*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowFromID");
-        _virtualTable.SDL_GetWindowID = (delegate* unmanaged[Cdecl]<SDL_Window*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowID");
-        _virtualTable.SDL_CreateWindowFrom = (delegate* unmanaged[Cdecl]<void*, SDL_Window*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateWindowFrom");
-        _virtualTable.SDL_CreateWindow = (delegate* unmanaged[Cdecl]<CString, int, int, int, int, uint, SDL_Window*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateWindow");
-        _virtualTable.SDL_GetWindowPixelFormat = (delegate* unmanaged[Cdecl]<SDL_Window*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowPixelFormat");
-        _virtualTable.SDL_GetWindowDisplayMode = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_DisplayMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowDisplayMode");
-        _virtualTable.SDL_SetWindowDisplayMode = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_DisplayMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetWindowDisplayMode");
-        _virtualTable.SDL_GetWindowDisplayIndex = (delegate* unmanaged[Cdecl]<SDL_Window*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetWindowDisplayIndex");
-        _virtualTable.SDL_GetClosestDisplayMode = (delegate* unmanaged[Cdecl]<int, SDL_DisplayMode*, SDL_DisplayMode*, SDL_DisplayMode*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetClosestDisplayMode");
-        _virtualTable.SDL_GetCurrentDisplayMode = (delegate* unmanaged[Cdecl]<int, SDL_DisplayMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetCurrentDisplayMode");
-        _virtualTable.SDL_GetDesktopDisplayMode = (delegate* unmanaged[Cdecl]<int, SDL_DisplayMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetDesktopDisplayMode");
-        _virtualTable.SDL_GetDisplayMode = (delegate* unmanaged[Cdecl]<int, int, SDL_DisplayMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetDisplayMode");
-        _virtualTable.SDL_GetNumDisplayModes = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetNumDisplayModes");
-        _virtualTable.SDL_GetDisplayOrientation = (delegate* unmanaged[Cdecl]<int, SDL_DisplayOrientation>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetDisplayOrientation");
-        _virtualTable.SDL_GetDisplayDPI = (delegate* unmanaged[Cdecl]<int, float*, float*, float*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetDisplayDPI");
-        _virtualTable.SDL_GetDisplayUsableBounds = (delegate* unmanaged[Cdecl]<int, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetDisplayUsableBounds");
-        _virtualTable.SDL_GetDisplayBounds = (delegate* unmanaged[Cdecl]<int, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetDisplayBounds");
-        _virtualTable.SDL_GetDisplayName = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetDisplayName");
-        _virtualTable.SDL_GetNumVideoDisplays = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetNumVideoDisplays");
-        _virtualTable.SDL_GetCurrentVideoDriver = (delegate* unmanaged[Cdecl]<CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetCurrentVideoDriver");
-        _virtualTable.SDL_VideoQuit = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_VideoQuit");
-        _virtualTable.SDL_VideoInit = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_VideoInit");
-        _virtualTable.SDL_GetVideoDriver = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetVideoDriver");
-        _virtualTable.SDL_GetNumVideoDrivers = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetNumVideoDrivers");
-        _virtualTable.SDL_GetYUVConversionModeForResolution = (delegate* unmanaged[Cdecl]<int, int, SDL_YUV_CONVERSION_MODE>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetYUVConversionModeForResolution");
-        _virtualTable.SDL_GetYUVConversionMode = (delegate* unmanaged[Cdecl]<SDL_YUV_CONVERSION_MODE>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetYUVConversionMode");
-        _virtualTable.SDL_SetYUVConversionMode = (delegate* unmanaged[Cdecl]<SDL_YUV_CONVERSION_MODE, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetYUVConversionMode");
-        _virtualTable.SDL_LowerBlitScaled = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LowerBlitScaled");
-        _virtualTable.SDL_UpperBlitScaled = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UpperBlitScaled");
-        _virtualTable.SDL_SoftStretchLinear = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SoftStretchLinear");
-        _virtualTable.SDL_SoftStretch = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SoftStretch");
-        _virtualTable.SDL_LowerBlit = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LowerBlit");
-        _virtualTable.SDL_UpperBlit = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UpperBlit");
-        _virtualTable.SDL_FillRects = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, int, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FillRects");
-        _virtualTable.SDL_FillRect = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FillRect");
-        _virtualTable.SDL_ConvertPixels = (delegate* unmanaged[Cdecl]<int, int, uint, void*, int, uint, void*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ConvertPixels");
-        _virtualTable.SDL_ConvertSurfaceFormat = (delegate* unmanaged[Cdecl]<SDL_Surface*, uint, uint, SDL_Surface*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ConvertSurfaceFormat");
-        _virtualTable.SDL_ConvertSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_PixelFormat*, uint, SDL_Surface*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ConvertSurface");
-        _virtualTable.SDL_DuplicateSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Surface*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DuplicateSurface");
-        _virtualTable.SDL_GetClipRect = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetClipRect");
-        _virtualTable.SDL_SetClipRect = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetClipRect");
-        _virtualTable.SDL_GetSurfaceBlendMode = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_BlendMode*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetSurfaceBlendMode");
-        _virtualTable.SDL_SetSurfaceBlendMode = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_BlendMode, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetSurfaceBlendMode");
-        _virtualTable.SDL_GetSurfaceAlphaMod = (delegate* unmanaged[Cdecl]<SDL_Surface*, byte*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetSurfaceAlphaMod");
-        _virtualTable.SDL_SetSurfaceAlphaMod = (delegate* unmanaged[Cdecl]<SDL_Surface*, byte, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetSurfaceAlphaMod");
-        _virtualTable.SDL_GetSurfaceColorMod = (delegate* unmanaged[Cdecl]<SDL_Surface*, byte*, byte*, byte*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetSurfaceColorMod");
-        _virtualTable.SDL_SetSurfaceColorMod = (delegate* unmanaged[Cdecl]<SDL_Surface*, byte, byte, byte, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetSurfaceColorMod");
-        _virtualTable.SDL_GetColorKey = (delegate* unmanaged[Cdecl]<SDL_Surface*, uint*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetColorKey");
-        _virtualTable.SDL_HasColorKey = (delegate* unmanaged[Cdecl]<SDL_Surface*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasColorKey");
-        _virtualTable.SDL_SetColorKey = (delegate* unmanaged[Cdecl]<SDL_Surface*, int, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetColorKey");
-        _virtualTable.SDL_HasSurfaceRLE = (delegate* unmanaged[Cdecl]<SDL_Surface*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasSurfaceRLE");
-        _virtualTable.SDL_SetSurfaceRLE = (delegate* unmanaged[Cdecl]<SDL_Surface*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetSurfaceRLE");
-        _virtualTable.SDL_SaveBMP_RW = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_RWops*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SaveBMP_RW");
-        _virtualTable.SDL_LoadBMP_RW = (delegate* unmanaged[Cdecl]<SDL_RWops*, int, SDL_Surface*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LoadBMP_RW");
-        _virtualTable.SDL_UnlockSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UnlockSurface");
-        _virtualTable.SDL_LockSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LockSurface");
-        _virtualTable.SDL_SetSurfacePalette = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Palette*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetSurfacePalette");
-        _virtualTable.SDL_FreeSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FreeSurface");
-        _virtualTable.SDL_CreateRGBSurfaceWithFormatFrom = (delegate* unmanaged[Cdecl]<void*, int, int, int, int, uint, SDL_Surface*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateRGBSurfaceWithFormatFrom");
-        _virtualTable.SDL_CreateRGBSurfaceFrom = (delegate* unmanaged[Cdecl]<void*, int, int, int, int, uint, uint, uint, uint, SDL_Surface*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateRGBSurfaceFrom");
-        _virtualTable.SDL_CreateRGBSurfaceWithFormat = (delegate* unmanaged[Cdecl]<uint, int, int, int, uint, SDL_Surface*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateRGBSurfaceWithFormat");
-        _virtualTable.SDL_CreateRGBSurface = (delegate* unmanaged[Cdecl]<uint, int, int, int, uint, uint, uint, uint, SDL_Surface*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateRGBSurface");
-        _virtualTable.SDL_ComposeCustomBlendMode = (delegate* unmanaged[Cdecl]<SDL_BlendFactor, SDL_BlendFactor, SDL_BlendOperation, SDL_BlendFactor, SDL_BlendFactor, SDL_BlendOperation, SDL_BlendMode>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ComposeCustomBlendMode");
-        _virtualTable.SDL_IntersectRectAndLine = (delegate* unmanaged[Cdecl]<SDL_Rect*, long*, long*, long*, long*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_IntersectRectAndLine");
-        _virtualTable.SDL_EnclosePoints = (delegate* unmanaged[Cdecl]<SDL_Point*, int, SDL_Rect*, SDL_Rect*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_EnclosePoints");
-        _virtualTable.SDL_UnionRect = (delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, SDL_Rect*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UnionRect");
-        _virtualTable.SDL_IntersectRect = (delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, SDL_Rect*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_IntersectRect");
-        _virtualTable.SDL_HasIntersection = (delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasIntersection");
-        _virtualTable.SDL_RectEquals = (delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RectEquals");
-        _virtualTable.SDL_RectEmpty = (delegate* unmanaged[Cdecl]<SDL_Rect*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RectEmpty");
-        _virtualTable.SDL_PointInRect = (delegate* unmanaged[Cdecl]<SDL_Point*, SDL_Rect*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_PointInRect");
-        _virtualTable.SDL_CalculateGammaRamp = (delegate* unmanaged[Cdecl]<float, ushort*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CalculateGammaRamp");
-        _virtualTable.SDL_GetRGBA = (delegate* unmanaged[Cdecl]<uint, SDL_PixelFormat*, byte*, byte*, byte*, byte*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRGBA");
-        _virtualTable.SDL_GetRGB = (delegate* unmanaged[Cdecl]<uint, SDL_PixelFormat*, byte*, byte*, byte*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetRGB");
-        _virtualTable.SDL_MapRGBA = (delegate* unmanaged[Cdecl]<SDL_PixelFormat*, byte, byte, byte, byte, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MapRGBA");
-        _virtualTable.SDL_MapRGB = (delegate* unmanaged[Cdecl]<SDL_PixelFormat*, byte, byte, byte, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MapRGB");
-        _virtualTable.SDL_FreePalette = (delegate* unmanaged[Cdecl]<SDL_Palette*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FreePalette");
-        _virtualTable.SDL_SetPaletteColors = (delegate* unmanaged[Cdecl]<SDL_Palette*, SDL_Color*, int, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetPaletteColors");
-        _virtualTable.SDL_SetPixelFormatPalette = (delegate* unmanaged[Cdecl]<SDL_PixelFormat*, SDL_Palette*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetPixelFormatPalette");
-        _virtualTable.SDL_AllocPalette = (delegate* unmanaged[Cdecl]<int, SDL_Palette*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AllocPalette");
-        _virtualTable.SDL_FreeFormat = (delegate* unmanaged[Cdecl]<SDL_PixelFormat*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FreeFormat");
-        _virtualTable.SDL_AllocFormat = (delegate* unmanaged[Cdecl]<uint, SDL_PixelFormat*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AllocFormat");
-        _virtualTable.SDL_MasksToPixelFormatEnum = (delegate* unmanaged[Cdecl]<int, uint, uint, uint, uint, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MasksToPixelFormatEnum");
-        _virtualTable.SDL_PixelFormatEnumToMasks = (delegate* unmanaged[Cdecl]<uint, long*, uint*, uint*, uint*, uint*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_PixelFormatEnumToMasks");
-        _virtualTable.SDL_GetPixelFormatName = (delegate* unmanaged[Cdecl]<uint, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetPixelFormatName");
-        _virtualTable.SDL_SIMDFree = (delegate* unmanaged[Cdecl]<void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SIMDFree");
-        _virtualTable.SDL_SIMDRealloc = (delegate* unmanaged[Cdecl]<void*, ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SIMDRealloc");
-        _virtualTable.SDL_SIMDAlloc = (delegate* unmanaged[Cdecl]<ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SIMDAlloc");
-        _virtualTable.SDL_SIMDGetAlignment = (delegate* unmanaged[Cdecl]<ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SIMDGetAlignment");
-        _virtualTable.SDL_GetSystemRAM = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetSystemRAM");
-        _virtualTable.SDL_HasNEON = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasNEON");
-        _virtualTable.SDL_HasARMSIMD = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasARMSIMD");
-        _virtualTable.SDL_HasAVX512F = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasAVX512F");
-        _virtualTable.SDL_HasAVX2 = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasAVX2");
-        _virtualTable.SDL_HasAVX = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasAVX");
-        _virtualTable.SDL_HasSSE42 = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasSSE42");
-        _virtualTable.SDL_HasSSE41 = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasSSE41");
-        _virtualTable.SDL_HasSSE3 = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasSSE3");
-        _virtualTable.SDL_HasSSE2 = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasSSE2");
-        _virtualTable.SDL_HasSSE = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasSSE");
-        _virtualTable.SDL_Has3DNow = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Has3DNow");
-        _virtualTable.SDL_HasMMX = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasMMX");
-        _virtualTable.SDL_HasAltiVec = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasAltiVec");
-        _virtualTable.SDL_HasRDTSC = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasRDTSC");
-        _virtualTable.SDL_GetCPUCacheLineSize = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetCPUCacheLineSize");
-        _virtualTable.SDL_GetCPUCount = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetCPUCount");
-        _virtualTable.SDL_HasClipboardText = (delegate* unmanaged[Cdecl]<CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_HasClipboardText");
-        _virtualTable.SDL_GetClipboardText = (delegate* unmanaged[Cdecl]<CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetClipboardText");
-        _virtualTable.SDL_SetClipboardText = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetClipboardText");
-        _virtualTable.SDL_CloseAudioDevice = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CloseAudioDevice");
-        _virtualTable.SDL_CloseAudio = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CloseAudio");
-        _virtualTable.SDL_UnlockAudioDevice = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UnlockAudioDevice");
-        _virtualTable.SDL_UnlockAudio = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UnlockAudio");
-        _virtualTable.SDL_LockAudioDevice = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LockAudioDevice");
-        _virtualTable.SDL_LockAudio = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LockAudio");
-        _virtualTable.SDL_ClearQueuedAudio = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ClearQueuedAudio");
-        _virtualTable.SDL_GetQueuedAudioSize = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetQueuedAudioSize");
-        _virtualTable.SDL_DequeueAudio = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void*, uint, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DequeueAudio");
-        _virtualTable.SDL_QueueAudio = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_QueueAudio");
-        _virtualTable.SDL_MixAudioFormat = (delegate* unmanaged[Cdecl]<byte*, byte*, SDL_AudioFormat, uint, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MixAudioFormat");
-        _virtualTable.SDL_MixAudio = (delegate* unmanaged[Cdecl]<byte*, byte*, uint, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MixAudio");
-        _virtualTable.SDL_FreeAudioStream = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FreeAudioStream");
-        _virtualTable.SDL_AudioStreamClear = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AudioStreamClear");
-        _virtualTable.SDL_AudioStreamFlush = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AudioStreamFlush");
-        _virtualTable.SDL_AudioStreamAvailable = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AudioStreamAvailable");
-        _virtualTable.SDL_AudioStreamGet = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, void*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AudioStreamGet");
-        _virtualTable.SDL_AudioStreamPut = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, void*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AudioStreamPut");
-        _virtualTable.SDL_NewAudioStream = (delegate* unmanaged[Cdecl]<SDL_AudioFormat, byte, int, SDL_AudioFormat, byte, int, SDL_AudioStream*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_NewAudioStream");
-        _virtualTable.SDL_ConvertAudio = (delegate* unmanaged[Cdecl]<SDL_AudioCVT*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ConvertAudio");
-        _virtualTable.SDL_BuildAudioCVT = (delegate* unmanaged[Cdecl]<SDL_AudioCVT*, SDL_AudioFormat, byte, int, SDL_AudioFormat, byte, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_BuildAudioCVT");
-        _virtualTable.SDL_FreeWAV = (delegate* unmanaged[Cdecl]<byte*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FreeWAV");
-        _virtualTable.SDL_LoadWAV_RW = (delegate* unmanaged[Cdecl]<SDL_RWops*, int, SDL_AudioSpec*, byte**, uint*, SDL_AudioSpec*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LoadWAV_RW");
-        _virtualTable.SDL_PauseAudioDevice = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_PauseAudioDevice");
-        _virtualTable.SDL_PauseAudio = (delegate* unmanaged[Cdecl]<int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_PauseAudio");
-        _virtualTable.SDL_GetAudioDeviceStatus = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, SDL_AudioStatus>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetAudioDeviceStatus");
-        _virtualTable.SDL_GetAudioStatus = (delegate* unmanaged[Cdecl]<SDL_AudioStatus>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetAudioStatus");
-        _virtualTable.SDL_OpenAudioDevice = (delegate* unmanaged[Cdecl]<CString, int, SDL_AudioSpec*, SDL_AudioSpec*, int, SDL_AudioDeviceID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_OpenAudioDevice");
-        _virtualTable.SDL_GetAudioDeviceSpec = (delegate* unmanaged[Cdecl]<int, int, SDL_AudioSpec*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetAudioDeviceSpec");
-        _virtualTable.SDL_GetAudioDeviceName = (delegate* unmanaged[Cdecl]<int, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetAudioDeviceName");
-        _virtualTable.SDL_GetNumAudioDevices = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetNumAudioDevices");
-        _virtualTable.SDL_OpenAudio = (delegate* unmanaged[Cdecl]<SDL_AudioSpec*, SDL_AudioSpec*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_OpenAudio");
-        _virtualTable.SDL_GetCurrentAudioDriver = (delegate* unmanaged[Cdecl]<CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetCurrentAudioDriver");
-        _virtualTable.SDL_AudioQuit = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AudioQuit");
-        _virtualTable.SDL_AudioInit = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AudioInit");
-        _virtualTable.SDL_GetAudioDriver = (delegate* unmanaged[Cdecl]<int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetAudioDriver");
-        _virtualTable.SDL_GetNumAudioDrivers = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetNumAudioDrivers");
-        _virtualTable.SDL_WriteBE64 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WriteBE64");
-        _virtualTable.SDL_WriteLE64 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WriteLE64");
-        _virtualTable.SDL_WriteBE32 = (delegate* unmanaged[Cdecl]<SDL_RWops*, uint, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WriteBE32");
-        _virtualTable.SDL_WriteLE32 = (delegate* unmanaged[Cdecl]<SDL_RWops*, uint, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WriteLE32");
-        _virtualTable.SDL_WriteBE16 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ushort, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WriteBE16");
-        _virtualTable.SDL_WriteLE16 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ushort, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WriteLE16");
-        _virtualTable.SDL_WriteU8 = (delegate* unmanaged[Cdecl]<SDL_RWops*, byte, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WriteU8");
-        _virtualTable.SDL_ReadBE64 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ReadBE64");
-        _virtualTable.SDL_ReadLE64 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ReadLE64");
-        _virtualTable.SDL_ReadBE32 = (delegate* unmanaged[Cdecl]<SDL_RWops*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ReadBE32");
-        _virtualTable.SDL_ReadLE32 = (delegate* unmanaged[Cdecl]<SDL_RWops*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ReadLE32");
-        _virtualTable.SDL_ReadBE16 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ReadBE16");
-        _virtualTable.SDL_ReadLE16 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ushort>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ReadLE16");
-        _virtualTable.SDL_ReadU8 = (delegate* unmanaged[Cdecl]<SDL_RWops*, byte>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ReadU8");
-        _virtualTable.SDL_LoadFile = (delegate* unmanaged[Cdecl]<CString, ulong*, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LoadFile");
-        _virtualTable.SDL_LoadFile_RW = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong*, int, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LoadFile_RW");
-        _virtualTable.SDL_RWclose = (delegate* unmanaged[Cdecl]<SDL_RWops*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWclose");
-        _virtualTable.SDL_RWwrite = (delegate* unmanaged[Cdecl]<SDL_RWops*, void*, ulong, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWwrite");
-        _virtualTable.SDL_RWread = (delegate* unmanaged[Cdecl]<SDL_RWops*, void*, ulong, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWread");
-        _virtualTable.SDL_RWtell = (delegate* unmanaged[Cdecl]<SDL_RWops*, long>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWtell");
-        _virtualTable.SDL_RWseek = (delegate* unmanaged[Cdecl]<SDL_RWops*, long, int, long>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWseek");
-        _virtualTable.SDL_RWsize = (delegate* unmanaged[Cdecl]<SDL_RWops*, long>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWsize");
-        _virtualTable.SDL_FreeRW = (delegate* unmanaged[Cdecl]<SDL_RWops*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_FreeRW");
-        _virtualTable.SDL_AllocRW = (delegate* unmanaged[Cdecl]<SDL_RWops*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AllocRW");
-        _virtualTable.SDL_RWFromConstMem = (delegate* unmanaged[Cdecl]<void*, int, SDL_RWops*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWFromConstMem");
-        _virtualTable.SDL_RWFromMem = (delegate* unmanaged[Cdecl]<void*, int, SDL_RWops*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWFromMem");
-        _virtualTable.SDL_RWFromFP = (delegate* unmanaged[Cdecl]<void*, CBool, SDL_RWops*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWFromFP");
-        _virtualTable.SDL_RWFromFile = (delegate* unmanaged[Cdecl]<CString, CString, SDL_RWops*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_RWFromFile");
-        _virtualTable.SDL_TLSCleanup = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_TLSCleanup");
-        _virtualTable.SDL_TLSSet = (delegate* unmanaged[Cdecl]<SDL_TLSID, void*, FnPtr_SDL_VoidPtr_Void, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_TLSSet");
-        _virtualTable.SDL_TLSGet = (delegate* unmanaged[Cdecl]<SDL_TLSID, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_TLSGet");
-        _virtualTable.SDL_TLSCreate = (delegate* unmanaged[Cdecl]<SDL_TLSID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_TLSCreate");
-        _virtualTable.SDL_DetachThread = (delegate* unmanaged[Cdecl]<SDL_Thread*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DetachThread");
-        _virtualTable.SDL_WaitThread = (delegate* unmanaged[Cdecl]<SDL_Thread*, long*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_WaitThread");
-        _virtualTable.SDL_SetThreadPriority = (delegate* unmanaged[Cdecl]<SDL_ThreadPriority, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetThreadPriority");
-        _virtualTable.SDL_GetThreadID = (delegate* unmanaged[Cdecl]<SDL_Thread*, SDL_threadID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetThreadID");
-        _virtualTable.SDL_ThreadID = (delegate* unmanaged[Cdecl]<SDL_threadID>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ThreadID");
-        _virtualTable.SDL_GetThreadName = (delegate* unmanaged[Cdecl]<SDL_Thread*, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetThreadName");
-        _virtualTable.SDL_CreateThreadWithStackSize = (delegate* unmanaged[Cdecl]<FnPtr_SDL_VoidPtr_Int, CString, ulong, void*, pfnSDL_CurrentBeginThread, pfnSDL_CurrentEndThread, SDL_Thread*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateThreadWithStackSize");
-        _virtualTable.SDL_CreateThread = (delegate* unmanaged[Cdecl]<SDL_ThreadFunction, CString, void*, pfnSDL_CurrentBeginThread, pfnSDL_CurrentEndThread, SDL_Thread*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateThread");
-        _virtualTable.SDL_CondWaitTimeout = (delegate* unmanaged[Cdecl]<SDL_cond*, SDL_mutex*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CondWaitTimeout");
-        _virtualTable.SDL_CondWait = (delegate* unmanaged[Cdecl]<SDL_cond*, SDL_mutex*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CondWait");
-        _virtualTable.SDL_CondBroadcast = (delegate* unmanaged[Cdecl]<SDL_cond*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CondBroadcast");
-        _virtualTable.SDL_CondSignal = (delegate* unmanaged[Cdecl]<SDL_cond*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CondSignal");
-        _virtualTable.SDL_DestroyCond = (delegate* unmanaged[Cdecl]<SDL_cond*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DestroyCond");
-        _virtualTable.SDL_CreateCond = (delegate* unmanaged[Cdecl]<SDL_cond*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateCond");
-        _virtualTable.SDL_SemValue = (delegate* unmanaged[Cdecl]<SDL_sem*, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SemValue");
-        _virtualTable.SDL_SemPost = (delegate* unmanaged[Cdecl]<SDL_sem*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SemPost");
-        _virtualTable.SDL_SemWaitTimeout = (delegate* unmanaged[Cdecl]<SDL_sem*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SemWaitTimeout");
-        _virtualTable.SDL_SemTryWait = (delegate* unmanaged[Cdecl]<SDL_sem*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SemTryWait");
-        _virtualTable.SDL_SemWait = (delegate* unmanaged[Cdecl]<SDL_sem*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SemWait");
-        _virtualTable.SDL_DestroySemaphore = (delegate* unmanaged[Cdecl]<SDL_sem*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DestroySemaphore");
-        _virtualTable.SDL_CreateSemaphore = (delegate* unmanaged[Cdecl]<uint, SDL_sem*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateSemaphore");
-        _virtualTable.SDL_DestroyMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_DestroyMutex");
-        _virtualTable.SDL_UnlockMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_UnlockMutex");
-        _virtualTable.SDL_TryLockMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_TryLockMutex");
-        _virtualTable.SDL_LockMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_LockMutex");
-        _virtualTable.SDL_CreateMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_CreateMutex");
-        _virtualTable.SDL_SwapFloat = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SwapFloat");
-        _virtualTable.SDL_Error = (delegate* unmanaged[Cdecl]<SDL_errorcode, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_Error");
-        _virtualTable.SDL_ClearError = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ClearError");
-        _virtualTable.SDL_GetErrorMsg = (delegate* unmanaged[Cdecl]<CString, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetErrorMsg");
-        _virtualTable.SDL_GetError = (delegate* unmanaged[Cdecl]<CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetError");
-        _virtualTable.SDL_SetError = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetError");
-        _virtualTable.SDL_AtomicGetPtr = (delegate* unmanaged[Cdecl]<void**, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicGetPtr");
-        _virtualTable.SDL_AtomicSetPtr = (delegate* unmanaged[Cdecl]<void**, void*, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicSetPtr");
-        _virtualTable.SDL_AtomicCASPtr = (delegate* unmanaged[Cdecl]<void**, void*, void*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicCASPtr");
-        _virtualTable.SDL_AtomicAdd = (delegate* unmanaged[Cdecl]<SDL_atomic_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicAdd");
-        _virtualTable.SDL_AtomicGet = (delegate* unmanaged[Cdecl]<SDL_atomic_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicGet");
-        _virtualTable.SDL_AtomicSet = (delegate* unmanaged[Cdecl]<SDL_atomic_t*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicSet");
-        _virtualTable.SDL_AtomicCAS = (delegate* unmanaged[Cdecl]<SDL_atomic_t*, int, int, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicCAS");
-        _virtualTable.SDL_MemoryBarrierAcquireFunction = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MemoryBarrierAcquireFunction");
-        _virtualTable.SDL_MemoryBarrierReleaseFunction = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_MemoryBarrierReleaseFunction");
-        _virtualTable.SDL_AtomicUnlock = (delegate* unmanaged[Cdecl]<SDL_SpinLock*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicUnlock");
-        _virtualTable.SDL_AtomicLock = (delegate* unmanaged[Cdecl]<SDL_SpinLock*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicLock");
-        _virtualTable.SDL_AtomicTryLock = (delegate* unmanaged[Cdecl]<SDL_SpinLock*, CBool>)Runtime.LibraryGetExport(_libraryHandle, "SDL_AtomicTryLock");
-        _virtualTable.SDL_ResetAssertionReport = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ResetAssertionReport");
-        _virtualTable.SDL_GetAssertionReport = (delegate* unmanaged[Cdecl]<SDL_AssertData*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetAssertionReport");
-        _virtualTable.SDL_GetAssertionHandler = (delegate* unmanaged[Cdecl]<void**, SDL_AssertionHandler>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetAssertionHandler");
-        _virtualTable.SDL_GetDefaultAssertionHandler = (delegate* unmanaged[Cdecl]<SDL_AssertionHandler>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetDefaultAssertionHandler");
-        _virtualTable.SDL_SetAssertionHandler = (delegate* unmanaged[Cdecl]<SDL_AssertionHandler, void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetAssertionHandler");
-        _virtualTable.SDL_ReportAssertion = (delegate* unmanaged[Cdecl]<SDL_AssertData*, CString, CString, int, SDL_AssertState>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ReportAssertion");
-        _virtualTable.__debugbreak = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "__debugbreak");
-        _virtualTable.SDL_memcpy4 = (delegate* unmanaged[Cdecl]<void*, void*, ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_memcpy4");
-        _virtualTable.SDL_iconv_string = (delegate* unmanaged[Cdecl]<CString, CString, CString, ulong, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_iconv_string");
-        _virtualTable.SDL_iconv = (delegate* unmanaged[Cdecl]<SDL_iconv_t, CString*, ulong*, CString*, ulong*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_iconv");
-        _virtualTable.SDL_iconv_close = (delegate* unmanaged[Cdecl]<SDL_iconv_t, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_iconv_close");
-        _virtualTable.SDL_iconv_open = (delegate* unmanaged[Cdecl]<CString, CString, SDL_iconv_t>)Runtime.LibraryGetExport(_libraryHandle, "SDL_iconv_open");
-        _virtualTable.SDL_tanf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_tanf");
-        _virtualTable.SDL_tan = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_tan");
-        _virtualTable.SDL_sqrtf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_sqrtf");
-        _virtualTable.SDL_sqrt = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_sqrt");
-        _virtualTable.SDL_sinf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_sinf");
-        _virtualTable.SDL_sin = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_sin");
-        _virtualTable.SDL_scalbnf = (delegate* unmanaged[Cdecl]<float, int, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_scalbnf");
-        _virtualTable.SDL_scalbn = (delegate* unmanaged[Cdecl]<double, int, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_scalbn");
-        _virtualTable.SDL_lroundf = (delegate* unmanaged[Cdecl]<float, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_lroundf");
-        _virtualTable.SDL_lround = (delegate* unmanaged[Cdecl]<double, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_lround");
-        _virtualTable.SDL_roundf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_roundf");
-        _virtualTable.SDL_round = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_round");
-        _virtualTable.SDL_powf = (delegate* unmanaged[Cdecl]<float, float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_powf");
-        _virtualTable.SDL_pow = (delegate* unmanaged[Cdecl]<double, double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_pow");
-        _virtualTable.SDL_log10f = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_log10f");
-        _virtualTable.SDL_log10 = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_log10");
-        _virtualTable.SDL_logf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_logf");
-        _virtualTable.SDL_log = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_log");
-        _virtualTable.SDL_fmodf = (delegate* unmanaged[Cdecl]<float, float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_fmodf");
-        _virtualTable.SDL_fmod = (delegate* unmanaged[Cdecl]<double, double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_fmod");
-        _virtualTable.SDL_truncf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_truncf");
-        _virtualTable.SDL_trunc = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_trunc");
-        _virtualTable.SDL_floorf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_floorf");
-        _virtualTable.SDL_floor = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_floor");
-        _virtualTable.SDL_fabsf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_fabsf");
-        _virtualTable.SDL_fabs = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_fabs");
-        _virtualTable.SDL_expf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_expf");
-        _virtualTable.SDL_exp = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_exp");
-        _virtualTable.SDL_cosf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_cosf");
-        _virtualTable.SDL_cos = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_cos");
-        _virtualTable.SDL_copysignf = (delegate* unmanaged[Cdecl]<float, float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_copysignf");
-        _virtualTable.SDL_copysign = (delegate* unmanaged[Cdecl]<double, double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_copysign");
-        _virtualTable.SDL_ceilf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ceilf");
-        _virtualTable.SDL_ceil = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ceil");
-        _virtualTable.SDL_atan2f = (delegate* unmanaged[Cdecl]<float, float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_atan2f");
-        _virtualTable.SDL_atan2 = (delegate* unmanaged[Cdecl]<double, double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_atan2");
-        _virtualTable.SDL_atanf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_atanf");
-        _virtualTable.SDL_atan = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_atan");
-        _virtualTable.SDL_asinf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_asinf");
-        _virtualTable.SDL_asin = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_asin");
-        _virtualTable.SDL_acosf = (delegate* unmanaged[Cdecl]<float, float>)Runtime.LibraryGetExport(_libraryHandle, "SDL_acosf");
-        _virtualTable.SDL_acos = (delegate* unmanaged[Cdecl]<double, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_acos");
-        _virtualTable.SDL_vsnprintf = (delegate* unmanaged[Cdecl]<CString, ulong, CString, IntPtr, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_vsnprintf");
-        _virtualTable.SDL_snprintf = (delegate* unmanaged[Cdecl]<CString, ulong, CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_snprintf");
-        _virtualTable.SDL_vsscanf = (delegate* unmanaged[Cdecl]<CString, CString, IntPtr, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_vsscanf");
-        _virtualTable.SDL_sscanf = (delegate* unmanaged[Cdecl]<CString, CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_sscanf");
-        _virtualTable.SDL_strncasecmp = (delegate* unmanaged[Cdecl]<CString, CString, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strncasecmp");
-        _virtualTable.SDL_strcasecmp = (delegate* unmanaged[Cdecl]<CString, CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strcasecmp");
-        _virtualTable.SDL_strncmp = (delegate* unmanaged[Cdecl]<CString, CString, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strncmp");
-        _virtualTable.SDL_strcmp = (delegate* unmanaged[Cdecl]<CString, CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strcmp");
-        _virtualTable.SDL_strtod = (delegate* unmanaged[Cdecl]<CString, CString*, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strtod");
-        _virtualTable.SDL_strtoull = (delegate* unmanaged[Cdecl]<CString, CString*, int, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strtoull");
-        _virtualTable.SDL_strtoll = (delegate* unmanaged[Cdecl]<CString, CString*, int, long>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strtoll");
-        _virtualTable.SDL_strtoul = (delegate* unmanaged[Cdecl]<CString, CString*, int, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strtoul");
-        _virtualTable.SDL_strtol = (delegate* unmanaged[Cdecl]<CString, CString*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strtol");
-        _virtualTable.SDL_atof = (delegate* unmanaged[Cdecl]<CString, double>)Runtime.LibraryGetExport(_libraryHandle, "SDL_atof");
-        _virtualTable.SDL_atoi = (delegate* unmanaged[Cdecl]<CString, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_atoi");
-        _virtualTable.SDL_ulltoa = (delegate* unmanaged[Cdecl]<ulong, CString, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ulltoa");
-        _virtualTable.SDL_lltoa = (delegate* unmanaged[Cdecl]<long, CString, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_lltoa");
-        _virtualTable.SDL_ultoa = (delegate* unmanaged[Cdecl]<uint, CString, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ultoa");
-        _virtualTable.SDL_ltoa = (delegate* unmanaged[Cdecl]<int, CString, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ltoa");
-        _virtualTable.SDL_uitoa = (delegate* unmanaged[Cdecl]<uint, CString, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_uitoa");
-        _virtualTable.SDL_itoa = (delegate* unmanaged[Cdecl]<int, CString, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_itoa");
-        _virtualTable.SDL_utf8strlen = (delegate* unmanaged[Cdecl]<CString, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_utf8strlen");
-        _virtualTable.SDL_strtokr = (delegate* unmanaged[Cdecl]<CString, CString, CString*, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strtokr");
-        _virtualTable.SDL_strstr = (delegate* unmanaged[Cdecl]<CString, CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strstr");
-        _virtualTable.SDL_strrchr = (delegate* unmanaged[Cdecl]<CString, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strrchr");
-        _virtualTable.SDL_strchr = (delegate* unmanaged[Cdecl]<CString, int, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strchr");
-        _virtualTable.SDL_strlwr = (delegate* unmanaged[Cdecl]<CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strlwr");
-        _virtualTable.SDL_strupr = (delegate* unmanaged[Cdecl]<CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strupr");
-        _virtualTable.SDL_strrev = (delegate* unmanaged[Cdecl]<CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strrev");
-        _virtualTable.SDL_strdup = (delegate* unmanaged[Cdecl]<CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strdup");
-        _virtualTable.SDL_strlcat = (delegate* unmanaged[Cdecl]<CString, CString, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strlcat");
-        _virtualTable.SDL_utf8strlcpy = (delegate* unmanaged[Cdecl]<CString, CString, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_utf8strlcpy");
-        _virtualTable.SDL_strlcpy = (delegate* unmanaged[Cdecl]<CString, CString, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strlcpy");
-        _virtualTable.SDL_strlen = (delegate* unmanaged[Cdecl]<CString, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_strlen");
-        _virtualTable.SDL_wcsncasecmp = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_wcsncasecmp");
-        _virtualTable.SDL_wcscasecmp = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_wcscasecmp");
-        _virtualTable.SDL_wcsncmp = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_wcsncmp");
-        _virtualTable.SDL_wcscmp = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_wcscmp");
-        _virtualTable.SDL_wcsstr = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, wchar_t*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_wcsstr");
-        _virtualTable.SDL_wcsdup = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_wcsdup");
-        _virtualTable.SDL_wcslcat = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_wcslcat");
-        _virtualTable.SDL_wcslcpy = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_wcslcpy");
-        _virtualTable.SDL_wcslen = (delegate* unmanaged[Cdecl]<wchar_t*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "SDL_wcslen");
-        _virtualTable.SDL_memcmp = (delegate* unmanaged[Cdecl]<void*, void*, ulong, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_memcmp");
-        _virtualTable.SDL_memmove = (delegate* unmanaged[Cdecl]<void*, void*, ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_memmove");
-        _virtualTable.SDL_memcpy = (delegate* unmanaged[Cdecl]<void*, void*, ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_memcpy");
-        _virtualTable.SDL_memset4 = (delegate* unmanaged[Cdecl]<void*, uint, ulong, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_memset4");
-        _virtualTable.SDL_memset = (delegate* unmanaged[Cdecl]<void*, int, ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_memset");
-        _virtualTable.SDL_crc32 = (delegate* unmanaged[Cdecl]<uint, void*, ulong, uint>)Runtime.LibraryGetExport(_libraryHandle, "SDL_crc32");
-        _virtualTable.SDL_tolower = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_tolower");
-        _virtualTable.SDL_toupper = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_toupper");
-        _virtualTable.SDL_isgraph = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_isgraph");
-        _virtualTable.SDL_isprint = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_isprint");
-        _virtualTable.SDL_islower = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_islower");
-        _virtualTable.SDL_isupper = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_isupper");
-        _virtualTable.SDL_isspace = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_isspace");
-        _virtualTable.SDL_ispunct = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_ispunct");
-        _virtualTable.SDL_isxdigit = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_isxdigit");
-        _virtualTable.SDL_isdigit = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_isdigit");
-        _virtualTable.SDL_iscntrl = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_iscntrl");
-        _virtualTable.SDL_isblank = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_isblank");
-        _virtualTable.SDL_isalnum = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_isalnum");
-        _virtualTable.SDL_isalpha = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_isalpha");
-        _virtualTable.SDL_abs = (delegate* unmanaged[Cdecl]<int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_abs");
-        _virtualTable.SDL_qsort = (delegate* unmanaged[Cdecl]<void*, ulong, ulong, FnPtr_SDL_VoidPtr_VoidPtr_Int, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_qsort");
-        _virtualTable.SDL_setenv = (delegate* unmanaged[Cdecl]<CString, CString, int, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_setenv");
-        _virtualTable.SDL_getenv = (delegate* unmanaged[Cdecl]<CString, CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_getenv");
-        _virtualTable.SDL_GetNumAllocations = (delegate* unmanaged[Cdecl]<int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetNumAllocations");
-        _virtualTable.SDL_SetMemoryFunctions = (delegate* unmanaged[Cdecl]<SDL_malloc_func, SDL_calloc_func, SDL_realloc_func, SDL_free_func, int>)Runtime.LibraryGetExport(_libraryHandle, "SDL_SetMemoryFunctions");
-        _virtualTable.SDL_GetMemoryFunctions = (delegate* unmanaged[Cdecl]<SDL_malloc_func*, SDL_calloc_func*, SDL_realloc_func*, SDL_free_func*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetMemoryFunctions");
-        _virtualTable.SDL_free = (delegate* unmanaged[Cdecl]<void*, void>)Runtime.LibraryGetExport(_libraryHandle, "SDL_free");
-        _virtualTable.SDL_realloc = (delegate* unmanaged[Cdecl]<void*, ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_realloc");
-        _virtualTable.SDL_calloc = (delegate* unmanaged[Cdecl]<ulong, ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_calloc");
-        _virtualTable.SDL_malloc = (delegate* unmanaged[Cdecl]<ulong, void*>)Runtime.LibraryGetExport(_libraryHandle, "SDL_malloc");
-        _virtualTable.SDL_GetPlatform = (delegate* unmanaged[Cdecl]<CString>)Runtime.LibraryGetExport(_libraryHandle, "SDL_GetPlatform");
-        #endregion
-
-        #region "Variables"
-
-        #endregion
-    }
-
-    private static void _UnloadVirtualTable()
-    {
-        #region "Functions"
-
-        _virtualTable.SDL_Quit = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_WasInit = (delegate* unmanaged[Cdecl]<uint, uint>)IntPtr.Zero;
-        _virtualTable.SDL_QuitSubSystem = (delegate* unmanaged[Cdecl]<uint, void>)IntPtr.Zero;
-        _virtualTable.SDL_InitSubSystem = (delegate* unmanaged[Cdecl]<uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_Init = (delegate* unmanaged[Cdecl]<uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_OpenURL = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetPreferredLocales = (delegate* unmanaged[Cdecl]<SDL_Locale*>)IntPtr.Zero;
-        _virtualTable.SDL_GetRevisionNumber = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_GetRevision = (delegate* unmanaged[Cdecl]<CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetVersion = (delegate* unmanaged[Cdecl]<SDL_version*, void>)IntPtr.Zero;
-        _virtualTable.SDL_RemoveTimer = (delegate* unmanaged[Cdecl]<SDL_TimerID, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_AddTimer = (delegate* unmanaged[Cdecl]<uint, SDL_TimerCallback, void*, SDL_TimerID>)IntPtr.Zero;
-        _virtualTable.SDL_Delay = (delegate* unmanaged[Cdecl]<uint, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetPerformanceFrequency = (delegate* unmanaged[Cdecl]<ulong>)IntPtr.Zero;
-        _virtualTable.SDL_GetPerformanceCounter = (delegate* unmanaged[Cdecl]<ulong>)IntPtr.Zero;
-        _virtualTable.SDL_GetTicks = (delegate* unmanaged[Cdecl]<uint>)IntPtr.Zero;
-        _virtualTable.SDL_GetShapedWindowMode = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_WindowShapeMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowShape = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Surface*, SDL_WindowShapeMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_IsShapedWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_CreateShapedWindow = (delegate* unmanaged[Cdecl]<CString, uint, uint, uint, uint, uint, SDL_Window*>)IntPtr.Zero;
-        _virtualTable.SDL_RenderGetMetalCommandEncoder = (delegate* unmanaged[Cdecl]<SDL_Renderer*, void*>)IntPtr.Zero;
-        _virtualTable.SDL_RenderGetMetalLayer = (delegate* unmanaged[Cdecl]<SDL_Renderer*, void*>)IntPtr.Zero;
-        _virtualTable.SDL_GL_UnbindTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GL_BindTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, float*, float*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderFlush = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int>)IntPtr.Zero;
-        _virtualTable.SDL_DestroyRenderer = (delegate* unmanaged[Cdecl]<SDL_Renderer*, void>)IntPtr.Zero;
-        _virtualTable.SDL_DestroyTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, void>)IntPtr.Zero;
-        _virtualTable.SDL_RenderPresent = (delegate* unmanaged[Cdecl]<SDL_Renderer*, void>)IntPtr.Zero;
-        _virtualTable.SDL_RenderReadPixels = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, uint, void*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderCopyExF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_FRect*, double, SDL_FPoint*, SDL_RendererFlip, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderCopyF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_FRect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderFillRectsF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderFillRectF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawRectsF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawRectF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawLinesF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FPoint*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawLineF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, float, float, float, float, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawPointsF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FPoint*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawPointF = (delegate* unmanaged[Cdecl]<SDL_Renderer*, float, float, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderCopyEx = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_Rect*, double, SDL_Point*, SDL_RendererFlip, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderCopy = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderFillRects = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderFillRect = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawRects = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawRect = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawLines = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Point*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawLine = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int, int, int, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawPoints = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Point*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderDrawPoint = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderClear = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetRenderDrawBlendMode = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_BlendMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetRenderDrawBlendMode = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_BlendMode, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetRenderDrawColor = (delegate* unmanaged[Cdecl]<SDL_Renderer*, byte*, byte*, byte*, byte*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetRenderDrawColor = (delegate* unmanaged[Cdecl]<SDL_Renderer*, byte, byte, byte, byte, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderGetScale = (delegate* unmanaged[Cdecl]<SDL_Renderer*, float*, float*, void>)IntPtr.Zero;
-        _virtualTable.SDL_RenderSetScale = (delegate* unmanaged[Cdecl]<SDL_Renderer*, float, float, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderIsClipEnabled = (delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_RenderGetClipRect = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, void>)IntPtr.Zero;
-        _virtualTable.SDL_RenderSetClipRect = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderGetViewport = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, void>)IntPtr.Zero;
-        _virtualTable.SDL_RenderSetViewport = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderGetIntegerScale = (delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_RenderSetIntegerScale = (delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderGetLogicalSize = (delegate* unmanaged[Cdecl]<SDL_Renderer*, long*, long*, void>)IntPtr.Zero;
-        _virtualTable.SDL_RenderSetLogicalSize = (delegate* unmanaged[Cdecl]<SDL_Renderer*, int, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetRenderTarget = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*>)IntPtr.Zero;
-        _virtualTable.SDL_SetRenderTarget = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RenderTargetSupported = (delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_UnlockTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, void>)IntPtr.Zero;
-        _virtualTable.SDL_LockTextureToSurface = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, SDL_Surface**, int>)IntPtr.Zero;
-        _virtualTable.SDL_LockTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, void**, long*, int>)IntPtr.Zero;
-        _virtualTable.SDL_UpdateNVTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, byte*, int, byte*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_UpdateYUVTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, byte*, int, byte*, int, byte*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_UpdateTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, void*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetTextureScaleMode = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_ScaleMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetTextureScaleMode = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_ScaleMode, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetTextureBlendMode = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_BlendMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetTextureBlendMode = (delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_BlendMode, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetTextureAlphaMod = (delegate* unmanaged[Cdecl]<SDL_Texture*, byte*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetTextureAlphaMod = (delegate* unmanaged[Cdecl]<SDL_Texture*, byte, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetTextureColorMod = (delegate* unmanaged[Cdecl]<SDL_Texture*, byte*, byte*, byte*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetTextureColorMod = (delegate* unmanaged[Cdecl]<SDL_Texture*, byte, byte, byte, int>)IntPtr.Zero;
-        _virtualTable.SDL_QueryTexture = (delegate* unmanaged[Cdecl]<SDL_Texture*, uint*, long*, long*, long*, int>)IntPtr.Zero;
-        _virtualTable.SDL_CreateTextureFromSurface = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Surface*, SDL_Texture*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateTexture = (delegate* unmanaged[Cdecl]<SDL_Renderer*, uint, int, int, int, SDL_Texture*>)IntPtr.Zero;
-        _virtualTable.SDL_GetRendererOutputSize = (delegate* unmanaged[Cdecl]<SDL_Renderer*, long*, long*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetRendererInfo = (delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_RendererInfo*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetRenderer = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Renderer*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateSoftwareRenderer = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Renderer*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateRenderer = (delegate* unmanaged[Cdecl]<SDL_Window*, int, uint, SDL_Renderer*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateWindowAndRenderer = (delegate* unmanaged[Cdecl]<int, int, uint, SDL_Window**, SDL_Renderer**, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetRenderDriverInfo = (delegate* unmanaged[Cdecl]<int, SDL_RendererInfo*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetNumRenderDrivers = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_GetPowerInfo = (delegate* unmanaged[Cdecl]<long*, long*, SDL_PowerState>)IntPtr.Zero;
-        _virtualTable.SDL_Metal_GetDrawableSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)IntPtr.Zero;
-        _virtualTable.SDL_Metal_GetLayer = (delegate* unmanaged[Cdecl]<SDL_MetalView, void*>)IntPtr.Zero;
-        _virtualTable.SDL_Metal_DestroyView = (delegate* unmanaged[Cdecl]<SDL_MetalView, void>)IntPtr.Zero;
-        _virtualTable.SDL_Metal_CreateView = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_MetalView>)IntPtr.Zero;
-        _virtualTable.SDL_ShowSimpleMessageBox = (delegate* unmanaged[Cdecl]<uint, CString, CString, SDL_Window*, int>)IntPtr.Zero;
-        _virtualTable.SDL_ShowMessageBox = (delegate* unmanaged[Cdecl]<SDL_MessageBoxData*, long*, int>)IntPtr.Zero;
-        _virtualTable.SDL_LogSetOutputFunction = (delegate* unmanaged[Cdecl]<SDL_LogOutputFunction, void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogGetOutputFunction = (delegate* unmanaged[Cdecl]<SDL_LogOutputFunction*, void**, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogMessageV = (delegate* unmanaged[Cdecl]<int, SDL_LogPriority, CString, IntPtr, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogMessage = (delegate* unmanaged[Cdecl]<int, SDL_LogPriority, CString, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogCritical = (delegate* unmanaged[Cdecl]<int, CString, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogError = (delegate* unmanaged[Cdecl]<int, CString, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogWarn = (delegate* unmanaged[Cdecl]<int, CString, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogInfo = (delegate* unmanaged[Cdecl]<int, CString, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogDebug = (delegate* unmanaged[Cdecl]<int, CString, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogVerbose = (delegate* unmanaged[Cdecl]<int, CString, void>)IntPtr.Zero;
-        _virtualTable.SDL_Log = (delegate* unmanaged[Cdecl]<CString, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogResetPriorities = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_LogGetPriority = (delegate* unmanaged[Cdecl]<int, SDL_LogPriority>)IntPtr.Zero;
-        _virtualTable.SDL_LogSetPriority = (delegate* unmanaged[Cdecl]<int, SDL_LogPriority, void>)IntPtr.Zero;
-        _virtualTable.SDL_LogSetAllPriority = (delegate* unmanaged[Cdecl]<SDL_LogPriority, void>)IntPtr.Zero;
-        _virtualTable.SDL_UnloadObject = (delegate* unmanaged[Cdecl]<void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_LoadFunction = (delegate* unmanaged[Cdecl]<void*, CString, void*>)IntPtr.Zero;
-        _virtualTable.SDL_LoadObject = (delegate* unmanaged[Cdecl]<CString, void*>)IntPtr.Zero;
-        _virtualTable.SDL_ClearHints = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_DelHintCallback = (delegate* unmanaged[Cdecl]<CString, SDL_HintCallback, void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_AddHintCallback = (delegate* unmanaged[Cdecl]<CString, SDL_HintCallback, void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetHintBoolean = (delegate* unmanaged[Cdecl]<CString, CBool, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GetHint = (delegate* unmanaged[Cdecl]<CString, CString>)IntPtr.Zero;
-        _virtualTable.SDL_SetHint = (delegate* unmanaged[Cdecl]<CString, CString, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_SetHintWithPriority = (delegate* unmanaged[Cdecl]<CString, CString, SDL_HintPriority, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HapticRumbleStop = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticRumblePlay = (delegate* unmanaged[Cdecl]<SDL_Haptic*, float, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticRumbleInit = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticRumbleSupported = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticStopAll = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticUnpause = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticPause = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticSetAutocenter = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticSetGain = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticGetEffectStatus = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticDestroyEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_HapticStopEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticRunEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticUpdateEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int, SDL_HapticEffect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticNewEffect = (delegate* unmanaged[Cdecl]<SDL_Haptic*, SDL_HapticEffect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticEffectSupported = (delegate* unmanaged[Cdecl]<SDL_Haptic*, SDL_HapticEffect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticNumAxes = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticQuery = (delegate* unmanaged[Cdecl]<SDL_Haptic*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_HapticNumEffectsPlaying = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticNumEffects = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticClose = (delegate* unmanaged[Cdecl]<SDL_Haptic*, void>)IntPtr.Zero;
-        _virtualTable.SDL_HapticOpenFromJoystick = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_Haptic*>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickIsHaptic = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticOpenFromMouse = (delegate* unmanaged[Cdecl]<SDL_Haptic*>)IntPtr.Zero;
-        _virtualTable.SDL_MouseIsHaptic = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticIndex = (delegate* unmanaged[Cdecl]<SDL_Haptic*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticOpened = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_HapticOpen = (delegate* unmanaged[Cdecl]<int, SDL_Haptic*>)IntPtr.Zero;
-        _virtualTable.SDL_HapticName = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_NumHaptics = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_GetPrefPath = (delegate* unmanaged[Cdecl]<CString, CString, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetBasePath = (delegate* unmanaged[Cdecl]<CString>)IntPtr.Zero;
-        _virtualTable.SDL_RegisterEvents = (delegate* unmanaged[Cdecl]<int, uint>)IntPtr.Zero;
-        _virtualTable.SDL_EventState = (delegate* unmanaged[Cdecl]<uint, int, byte>)IntPtr.Zero;
-        _virtualTable.SDL_FilterEvents = (delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_DelEventWatch = (delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_AddEventWatch = (delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetEventFilter = (delegate* unmanaged[Cdecl]<SDL_EventFilter*, void**, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_SetEventFilter = (delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_PushEvent = (delegate* unmanaged[Cdecl]<SDL_Event*, int>)IntPtr.Zero;
-        _virtualTable.SDL_WaitEventTimeout = (delegate* unmanaged[Cdecl]<SDL_Event*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_WaitEvent = (delegate* unmanaged[Cdecl]<SDL_Event*, int>)IntPtr.Zero;
-        _virtualTable.SDL_PollEvent = (delegate* unmanaged[Cdecl]<SDL_Event*, int>)IntPtr.Zero;
-        _virtualTable.SDL_FlushEvents = (delegate* unmanaged[Cdecl]<uint, uint, void>)IntPtr.Zero;
-        _virtualTable.SDL_FlushEvent = (delegate* unmanaged[Cdecl]<uint, void>)IntPtr.Zero;
-        _virtualTable.SDL_HasEvents = (delegate* unmanaged[Cdecl]<uint, uint, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasEvent = (delegate* unmanaged[Cdecl]<uint, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_PeepEvents = (delegate* unmanaged[Cdecl]<SDL_Event*, int, SDL_eventaction, uint, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_PumpEvents = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_LoadDollarTemplates = (delegate* unmanaged[Cdecl]<SDL_TouchID, SDL_RWops*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SaveDollarTemplate = (delegate* unmanaged[Cdecl]<SDL_GestureID, SDL_RWops*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SaveAllDollarTemplates = (delegate* unmanaged[Cdecl]<SDL_RWops*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RecordGesture = (delegate* unmanaged[Cdecl]<SDL_TouchID, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetTouchFinger = (delegate* unmanaged[Cdecl]<SDL_TouchID, int, SDL_Finger*>)IntPtr.Zero;
-        _virtualTable.SDL_GetNumTouchFingers = (delegate* unmanaged[Cdecl]<SDL_TouchID, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetTouchDeviceType = (delegate* unmanaged[Cdecl]<SDL_TouchID, SDL_TouchDeviceType>)IntPtr.Zero;
-        _virtualTable.SDL_GetTouchDevice = (delegate* unmanaged[Cdecl]<int, SDL_TouchID>)IntPtr.Zero;
-        _virtualTable.SDL_GetNumTouchDevices = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerClose = (delegate* unmanaged[Cdecl]<SDL_GameController*, void>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerSetLED = (delegate* unmanaged[Cdecl]<SDL_GameController*, byte, byte, byte, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerHasLED = (delegate* unmanaged[Cdecl]<SDL_GameController*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerRumbleTriggers = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort, ushort, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerRumble = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort, ushort, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetSensorData = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, float*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerIsSensorEnabled = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerSetSensorEnabled = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, CBool, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerHasSensor = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetTouchpadFinger = (delegate* unmanaged[Cdecl]<SDL_GameController*, int, int, byte*, float*, float*, float*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetNumTouchpadFingers = (delegate* unmanaged[Cdecl]<SDL_GameController*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetNumTouchpads = (delegate* unmanaged[Cdecl]<SDL_GameController*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetButton = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerButton, byte>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerHasButton = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerButton, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetBindForButton = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerButton, SDL_GameControllerButtonBind>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetStringForButton = (delegate* unmanaged[Cdecl]<SDL_GameControllerButton, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetButtonFromString = (delegate* unmanaged[Cdecl]<CString, SDL_GameControllerButton>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetAxis = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerAxis, short>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerHasAxis = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerAxis, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetBindForAxis = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerAxis, SDL_GameControllerButtonBind>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetStringForAxis = (delegate* unmanaged[Cdecl]<SDL_GameControllerAxis, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetAxisFromString = (delegate* unmanaged[Cdecl]<CString, SDL_GameControllerAxis>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerUpdate = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerEventState = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetJoystick = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_Joystick*>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetAttached = (delegate* unmanaged[Cdecl]<SDL_GameController*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetSerial = (delegate* unmanaged[Cdecl]<SDL_GameController*, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetProductVersion = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetProduct = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetVendor = (delegate* unmanaged[Cdecl]<SDL_GameController*, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerSetPlayerIndex = (delegate* unmanaged[Cdecl]<SDL_GameController*, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetPlayerIndex = (delegate* unmanaged[Cdecl]<SDL_GameController*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerGetType = (delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerType>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerName = (delegate* unmanaged[Cdecl]<SDL_GameController*, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerFromPlayerIndex = (delegate* unmanaged[Cdecl]<int, SDL_GameController*>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerFromInstanceID = (delegate* unmanaged[Cdecl]<SDL_JoystickID, SDL_GameController*>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerOpen = (delegate* unmanaged[Cdecl]<int, SDL_GameController*>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerMappingForDeviceIndex = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerTypeForIndex = (delegate* unmanaged[Cdecl]<int, SDL_GameControllerType>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerNameForIndex = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_IsGameController = (delegate* unmanaged[Cdecl]<int, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerMapping = (delegate* unmanaged[Cdecl]<SDL_GameController*, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerMappingForGUID = (delegate* unmanaged[Cdecl]<SDL_JoystickGUID, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerMappingForIndex = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerNumMappings = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerAddMapping = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_GameControllerAddMappingsFromRW = (delegate* unmanaged[Cdecl]<SDL_RWops*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_SensorUpdate = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_SensorClose = (delegate* unmanaged[Cdecl]<SDL_Sensor*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SensorGetData = (delegate* unmanaged[Cdecl]<SDL_Sensor*, float*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_SensorGetInstanceID = (delegate* unmanaged[Cdecl]<SDL_Sensor*, SDL_SensorID>)IntPtr.Zero;
-        _virtualTable.SDL_SensorGetNonPortableType = (delegate* unmanaged[Cdecl]<SDL_Sensor*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SensorGetType = (delegate* unmanaged[Cdecl]<SDL_Sensor*, SDL_SensorType>)IntPtr.Zero;
-        _virtualTable.SDL_SensorGetName = (delegate* unmanaged[Cdecl]<SDL_Sensor*, CString>)IntPtr.Zero;
-        _virtualTable.SDL_SensorFromInstanceID = (delegate* unmanaged[Cdecl]<SDL_SensorID, SDL_Sensor*>)IntPtr.Zero;
-        _virtualTable.SDL_SensorOpen = (delegate* unmanaged[Cdecl]<int, SDL_Sensor*>)IntPtr.Zero;
-        _virtualTable.SDL_SensorGetDeviceInstanceID = (delegate* unmanaged[Cdecl]<int, SDL_SensorID>)IntPtr.Zero;
-        _virtualTable.SDL_SensorGetDeviceNonPortableType = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_SensorGetDeviceType = (delegate* unmanaged[Cdecl]<int, SDL_SensorType>)IntPtr.Zero;
-        _virtualTable.SDL_SensorGetDeviceName = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_NumSensors = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_UnlockSensors = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_LockSensors = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickCurrentPowerLevel = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickPowerLevel>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickClose = (delegate* unmanaged[Cdecl]<SDL_Joystick*, void>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickSetLED = (delegate* unmanaged[Cdecl]<SDL_Joystick*, byte, byte, byte, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickHasLED = (delegate* unmanaged[Cdecl]<SDL_Joystick*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickRumbleTriggers = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort, ushort, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickRumble = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort, ushort, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetButton = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetBall = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, long*, long*, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetHat = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetAxisInitialState = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, short*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetAxis = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, short>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickEventState = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickUpdate = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickNumButtons = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickNumHats = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickNumBalls = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickNumAxes = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickInstanceID = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickID>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetAttached = (delegate* unmanaged[Cdecl]<SDL_Joystick*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetGUIDFromString = (delegate* unmanaged[Cdecl]<CString, SDL_JoystickGUID>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetGUIDString = (delegate* unmanaged[Cdecl]<SDL_JoystickGUID, CString, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetType = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickType>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetSerial = (delegate* unmanaged[Cdecl]<SDL_Joystick*, CString>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetProductVersion = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetProduct = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetVendor = (delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetGUID = (delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickGUID>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickSetPlayerIndex = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetPlayerIndex = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickName = (delegate* unmanaged[Cdecl]<SDL_Joystick*, CString>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickSetVirtualHat = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickSetVirtualButton = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickSetVirtualAxis = (delegate* unmanaged[Cdecl]<SDL_Joystick*, int, short, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickIsVirtual = (delegate* unmanaged[Cdecl]<int, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickDetachVirtual = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickAttachVirtual = (delegate* unmanaged[Cdecl]<SDL_JoystickType, int, int, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickFromPlayerIndex = (delegate* unmanaged[Cdecl]<int, SDL_Joystick*>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickFromInstanceID = (delegate* unmanaged[Cdecl]<SDL_JoystickID, SDL_Joystick*>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickOpen = (delegate* unmanaged[Cdecl]<int, SDL_Joystick*>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetDeviceInstanceID = (delegate* unmanaged[Cdecl]<int, SDL_JoystickID>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetDeviceType = (delegate* unmanaged[Cdecl]<int, SDL_JoystickType>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetDeviceProductVersion = (delegate* unmanaged[Cdecl]<int, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetDeviceProduct = (delegate* unmanaged[Cdecl]<int, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetDeviceVendor = (delegate* unmanaged[Cdecl]<int, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetDeviceGUID = (delegate* unmanaged[Cdecl]<int, SDL_JoystickGUID>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickGetDevicePlayerIndex = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_JoystickNameForIndex = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_NumJoysticks = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_UnlockJoysticks = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_LockJoysticks = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_ShowCursor = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_FreeCursor = (delegate* unmanaged[Cdecl]<SDL_Cursor*, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetDefaultCursor = (delegate* unmanaged[Cdecl]<SDL_Cursor*>)IntPtr.Zero;
-        _virtualTable.SDL_GetCursor = (delegate* unmanaged[Cdecl]<SDL_Cursor*>)IntPtr.Zero;
-        _virtualTable.SDL_SetCursor = (delegate* unmanaged[Cdecl]<SDL_Cursor*, void>)IntPtr.Zero;
-        _virtualTable.SDL_CreateSystemCursor = (delegate* unmanaged[Cdecl]<SDL_SystemCursor, SDL_Cursor*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateColorCursor = (delegate* unmanaged[Cdecl]<SDL_Surface*, int, int, SDL_Cursor*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateCursor = (delegate* unmanaged[Cdecl]<byte*, byte*, int, int, int, int, SDL_Cursor*>)IntPtr.Zero;
-        _virtualTable.SDL_GetRelativeMouseMode = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_CaptureMouse = (delegate* unmanaged[Cdecl]<CBool, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetRelativeMouseMode = (delegate* unmanaged[Cdecl]<CBool, int>)IntPtr.Zero;
-        _virtualTable.SDL_WarpMouseGlobal = (delegate* unmanaged[Cdecl]<int, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_WarpMouseInWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetRelativeMouseState = (delegate* unmanaged[Cdecl]<long*, long*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_GetGlobalMouseState = (delegate* unmanaged[Cdecl]<long*, long*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_GetMouseState = (delegate* unmanaged[Cdecl]<long*, long*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_GetMouseFocus = (delegate* unmanaged[Cdecl]<SDL_Window*>)IntPtr.Zero;
-        _virtualTable.SDL_IsScreenKeyboardShown = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasScreenKeyboardSupport = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_SetTextInputRect = (delegate* unmanaged[Cdecl]<SDL_Rect*, void>)IntPtr.Zero;
-        _virtualTable.SDL_StopTextInput = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_IsTextInputActive = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_StartTextInput = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_GetKeyFromName = (delegate* unmanaged[Cdecl]<CString, SDL_Keycode>)IntPtr.Zero;
-        _virtualTable.SDL_GetKeyName = (delegate* unmanaged[Cdecl]<SDL_Keycode, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetScancodeFromName = (delegate* unmanaged[Cdecl]<CString, SDL_Scancode>)IntPtr.Zero;
-        _virtualTable.SDL_GetScancodeName = (delegate* unmanaged[Cdecl]<SDL_Scancode, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetScancodeFromKey = (delegate* unmanaged[Cdecl]<SDL_Keycode, SDL_Scancode>)IntPtr.Zero;
-        _virtualTable.SDL_GetKeyFromScancode = (delegate* unmanaged[Cdecl]<SDL_Scancode, SDL_Keycode>)IntPtr.Zero;
-        _virtualTable.SDL_SetModState = (delegate* unmanaged[Cdecl]<SDL_Keymod, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetModState = (delegate* unmanaged[Cdecl]<SDL_Keymod>)IntPtr.Zero;
-        _virtualTable.SDL_GetKeyboardState = (delegate* unmanaged[Cdecl]<long*, byte*>)IntPtr.Zero;
-        _virtualTable.SDL_GetKeyboardFocus = (delegate* unmanaged[Cdecl]<SDL_Window*>)IntPtr.Zero;
-        _virtualTable.SDL_GL_DeleteContext = (delegate* unmanaged[Cdecl]<SDL_GLContext, void>)IntPtr.Zero;
-        _virtualTable.SDL_GL_SwapWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)IntPtr.Zero;
-        _virtualTable.SDL_GL_GetSwapInterval = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_GL_SetSwapInterval = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_GL_GetDrawableSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)IntPtr.Zero;
-        _virtualTable.SDL_GL_GetCurrentContext = (delegate* unmanaged[Cdecl]<SDL_GLContext>)IntPtr.Zero;
-        _virtualTable.SDL_GL_GetCurrentWindow = (delegate* unmanaged[Cdecl]<SDL_Window*>)IntPtr.Zero;
-        _virtualTable.SDL_GL_MakeCurrent = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_GLContext, int>)IntPtr.Zero;
-        _virtualTable.SDL_GL_CreateContext = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_GLContext>)IntPtr.Zero;
-        _virtualTable.SDL_GL_GetAttribute = (delegate* unmanaged[Cdecl]<SDL_GLattr, long*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GL_SetAttribute = (delegate* unmanaged[Cdecl]<SDL_GLattr, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_GL_ResetAttributes = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_GL_ExtensionSupported = (delegate* unmanaged[Cdecl]<CString, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GL_UnloadLibrary = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_GL_GetProcAddress = (delegate* unmanaged[Cdecl]<CString, void*>)IntPtr.Zero;
-        _virtualTable.SDL_GL_LoadLibrary = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_DisableScreenSaver = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_EnableScreenSaver = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_IsScreenSaverEnabled = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_DestroyWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowHitTest = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_HitTest, void*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowGammaRamp = (delegate* unmanaged[Cdecl]<SDL_Window*, ushort*, ushort*, ushort*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowGammaRamp = (delegate* unmanaged[Cdecl]<SDL_Window*, ushort*, ushort*, ushort*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowInputFocus = (delegate* unmanaged[Cdecl]<SDL_Window*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowModalFor = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Window*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowOpacity = (delegate* unmanaged[Cdecl]<SDL_Window*, float*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowOpacity = (delegate* unmanaged[Cdecl]<SDL_Window*, float, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowBrightness = (delegate* unmanaged[Cdecl]<SDL_Window*, float>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowBrightness = (delegate* unmanaged[Cdecl]<SDL_Window*, float, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetGrabbedWindow = (delegate* unmanaged[Cdecl]<SDL_Window*>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowMouseGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowKeyboardGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowMouseGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowKeyboardGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowGrab = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)IntPtr.Zero;
-        _virtualTable.SDL_UpdateWindowSurfaceRects = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Rect*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_UpdateWindowSurface = (delegate* unmanaged[Cdecl]<SDL_Window*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowSurface = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Surface*>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowFullscreen = (delegate* unmanaged[Cdecl]<SDL_Window*, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_RestoreWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)IntPtr.Zero;
-        _virtualTable.SDL_MinimizeWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)IntPtr.Zero;
-        _virtualTable.SDL_MaximizeWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)IntPtr.Zero;
-        _virtualTable.SDL_RaiseWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)IntPtr.Zero;
-        _virtualTable.SDL_HideWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)IntPtr.Zero;
-        _virtualTable.SDL_ShowWindow = (delegate* unmanaged[Cdecl]<SDL_Window*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowAlwaysOnTop = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowResizable = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowBordered = (delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowMaximumSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowMaximumSize = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowMinimumSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowMinimumSize = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowBordersSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, long*, long*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowSize = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowSize = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowPosition = (delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowPosition = (delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowData = (delegate* unmanaged[Cdecl]<SDL_Window*, CString, void*>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowData = (delegate* unmanaged[Cdecl]<SDL_Window*, CString, void*, void*>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowIcon = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Surface*, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowTitle = (delegate* unmanaged[Cdecl]<SDL_Window*, CString>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowTitle = (delegate* unmanaged[Cdecl]<SDL_Window*, CString, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowFlags = (delegate* unmanaged[Cdecl]<SDL_Window*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowFromID = (delegate* unmanaged[Cdecl]<uint, SDL_Window*>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowID = (delegate* unmanaged[Cdecl]<SDL_Window*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_CreateWindowFrom = (delegate* unmanaged[Cdecl]<void*, SDL_Window*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateWindow = (delegate* unmanaged[Cdecl]<CString, int, int, int, int, uint, SDL_Window*>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowPixelFormat = (delegate* unmanaged[Cdecl]<SDL_Window*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowDisplayMode = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_DisplayMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetWindowDisplayMode = (delegate* unmanaged[Cdecl]<SDL_Window*, SDL_DisplayMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetWindowDisplayIndex = (delegate* unmanaged[Cdecl]<SDL_Window*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetClosestDisplayMode = (delegate* unmanaged[Cdecl]<int, SDL_DisplayMode*, SDL_DisplayMode*, SDL_DisplayMode*>)IntPtr.Zero;
-        _virtualTable.SDL_GetCurrentDisplayMode = (delegate* unmanaged[Cdecl]<int, SDL_DisplayMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetDesktopDisplayMode = (delegate* unmanaged[Cdecl]<int, SDL_DisplayMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetDisplayMode = (delegate* unmanaged[Cdecl]<int, int, SDL_DisplayMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetNumDisplayModes = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetDisplayOrientation = (delegate* unmanaged[Cdecl]<int, SDL_DisplayOrientation>)IntPtr.Zero;
-        _virtualTable.SDL_GetDisplayDPI = (delegate* unmanaged[Cdecl]<int, float*, float*, float*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetDisplayUsableBounds = (delegate* unmanaged[Cdecl]<int, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetDisplayBounds = (delegate* unmanaged[Cdecl]<int, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetDisplayName = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetNumVideoDisplays = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_GetCurrentVideoDriver = (delegate* unmanaged[Cdecl]<CString>)IntPtr.Zero;
-        _virtualTable.SDL_VideoQuit = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_VideoInit = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetVideoDriver = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetNumVideoDrivers = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_GetYUVConversionModeForResolution = (delegate* unmanaged[Cdecl]<int, int, SDL_YUV_CONVERSION_MODE>)IntPtr.Zero;
-        _virtualTable.SDL_GetYUVConversionMode = (delegate* unmanaged[Cdecl]<SDL_YUV_CONVERSION_MODE>)IntPtr.Zero;
-        _virtualTable.SDL_SetYUVConversionMode = (delegate* unmanaged[Cdecl]<SDL_YUV_CONVERSION_MODE, void>)IntPtr.Zero;
-        _virtualTable.SDL_LowerBlitScaled = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_UpperBlitScaled = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SoftStretchLinear = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SoftStretch = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_LowerBlit = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_UpperBlit = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int>)IntPtr.Zero;
-        _virtualTable.SDL_FillRects = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, int, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_FillRect = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_ConvertPixels = (delegate* unmanaged[Cdecl]<int, int, uint, void*, int, uint, void*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_ConvertSurfaceFormat = (delegate* unmanaged[Cdecl]<SDL_Surface*, uint, uint, SDL_Surface*>)IntPtr.Zero;
-        _virtualTable.SDL_ConvertSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_PixelFormat*, uint, SDL_Surface*>)IntPtr.Zero;
-        _virtualTable.SDL_DuplicateSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Surface*>)IntPtr.Zero;
-        _virtualTable.SDL_GetClipRect = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetClipRect = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GetSurfaceBlendMode = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_BlendMode*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetSurfaceBlendMode = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_BlendMode, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetSurfaceAlphaMod = (delegate* unmanaged[Cdecl]<SDL_Surface*, byte*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetSurfaceAlphaMod = (delegate* unmanaged[Cdecl]<SDL_Surface*, byte, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetSurfaceColorMod = (delegate* unmanaged[Cdecl]<SDL_Surface*, byte*, byte*, byte*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetSurfaceColorMod = (delegate* unmanaged[Cdecl]<SDL_Surface*, byte, byte, byte, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetColorKey = (delegate* unmanaged[Cdecl]<SDL_Surface*, uint*, int>)IntPtr.Zero;
-        _virtualTable.SDL_HasColorKey = (delegate* unmanaged[Cdecl]<SDL_Surface*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_SetColorKey = (delegate* unmanaged[Cdecl]<SDL_Surface*, int, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_HasSurfaceRLE = (delegate* unmanaged[Cdecl]<SDL_Surface*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_SetSurfaceRLE = (delegate* unmanaged[Cdecl]<SDL_Surface*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_SaveBMP_RW = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_RWops*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_LoadBMP_RW = (delegate* unmanaged[Cdecl]<SDL_RWops*, int, SDL_Surface*>)IntPtr.Zero;
-        _virtualTable.SDL_UnlockSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, void>)IntPtr.Zero;
-        _virtualTable.SDL_LockSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetSurfacePalette = (delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Palette*, int>)IntPtr.Zero;
-        _virtualTable.SDL_FreeSurface = (delegate* unmanaged[Cdecl]<SDL_Surface*, void>)IntPtr.Zero;
-        _virtualTable.SDL_CreateRGBSurfaceWithFormatFrom = (delegate* unmanaged[Cdecl]<void*, int, int, int, int, uint, SDL_Surface*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateRGBSurfaceFrom = (delegate* unmanaged[Cdecl]<void*, int, int, int, int, uint, uint, uint, uint, SDL_Surface*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateRGBSurfaceWithFormat = (delegate* unmanaged[Cdecl]<uint, int, int, int, uint, SDL_Surface*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateRGBSurface = (delegate* unmanaged[Cdecl]<uint, int, int, int, uint, uint, uint, uint, SDL_Surface*>)IntPtr.Zero;
-        _virtualTable.SDL_ComposeCustomBlendMode = (delegate* unmanaged[Cdecl]<SDL_BlendFactor, SDL_BlendFactor, SDL_BlendOperation, SDL_BlendFactor, SDL_BlendFactor, SDL_BlendOperation, SDL_BlendMode>)IntPtr.Zero;
-        _virtualTable.SDL_IntersectRectAndLine = (delegate* unmanaged[Cdecl]<SDL_Rect*, long*, long*, long*, long*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_EnclosePoints = (delegate* unmanaged[Cdecl]<SDL_Point*, int, SDL_Rect*, SDL_Rect*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_UnionRect = (delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, SDL_Rect*, void>)IntPtr.Zero;
-        _virtualTable.SDL_IntersectRect = (delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, SDL_Rect*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasIntersection = (delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_RectEquals = (delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_RectEmpty = (delegate* unmanaged[Cdecl]<SDL_Rect*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_PointInRect = (delegate* unmanaged[Cdecl]<SDL_Point*, SDL_Rect*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_CalculateGammaRamp = (delegate* unmanaged[Cdecl]<float, ushort*, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetRGBA = (delegate* unmanaged[Cdecl]<uint, SDL_PixelFormat*, byte*, byte*, byte*, byte*, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetRGB = (delegate* unmanaged[Cdecl]<uint, SDL_PixelFormat*, byte*, byte*, byte*, void>)IntPtr.Zero;
-        _virtualTable.SDL_MapRGBA = (delegate* unmanaged[Cdecl]<SDL_PixelFormat*, byte, byte, byte, byte, uint>)IntPtr.Zero;
-        _virtualTable.SDL_MapRGB = (delegate* unmanaged[Cdecl]<SDL_PixelFormat*, byte, byte, byte, uint>)IntPtr.Zero;
-        _virtualTable.SDL_FreePalette = (delegate* unmanaged[Cdecl]<SDL_Palette*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetPaletteColors = (delegate* unmanaged[Cdecl]<SDL_Palette*, SDL_Color*, int, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_SetPixelFormatPalette = (delegate* unmanaged[Cdecl]<SDL_PixelFormat*, SDL_Palette*, int>)IntPtr.Zero;
-        _virtualTable.SDL_AllocPalette = (delegate* unmanaged[Cdecl]<int, SDL_Palette*>)IntPtr.Zero;
-        _virtualTable.SDL_FreeFormat = (delegate* unmanaged[Cdecl]<SDL_PixelFormat*, void>)IntPtr.Zero;
-        _virtualTable.SDL_AllocFormat = (delegate* unmanaged[Cdecl]<uint, SDL_PixelFormat*>)IntPtr.Zero;
-        _virtualTable.SDL_MasksToPixelFormatEnum = (delegate* unmanaged[Cdecl]<int, uint, uint, uint, uint, uint>)IntPtr.Zero;
-        _virtualTable.SDL_PixelFormatEnumToMasks = (delegate* unmanaged[Cdecl]<uint, long*, uint*, uint*, uint*, uint*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GetPixelFormatName = (delegate* unmanaged[Cdecl]<uint, CString>)IntPtr.Zero;
-        _virtualTable.SDL_SIMDFree = (delegate* unmanaged[Cdecl]<void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SIMDRealloc = (delegate* unmanaged[Cdecl]<void*, ulong, void*>)IntPtr.Zero;
-        _virtualTable.SDL_SIMDAlloc = (delegate* unmanaged[Cdecl]<ulong, void*>)IntPtr.Zero;
-        _virtualTable.SDL_SIMDGetAlignment = (delegate* unmanaged[Cdecl]<ulong>)IntPtr.Zero;
-        _virtualTable.SDL_GetSystemRAM = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_HasNEON = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasARMSIMD = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasAVX512F = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasAVX2 = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasAVX = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasSSE42 = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasSSE41 = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasSSE3 = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasSSE2 = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasSSE = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_Has3DNow = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasMMX = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasAltiVec = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_HasRDTSC = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GetCPUCacheLineSize = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_GetCPUCount = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_HasClipboardText = (delegate* unmanaged[Cdecl]<CBool>)IntPtr.Zero;
-        _virtualTable.SDL_GetClipboardText = (delegate* unmanaged[Cdecl]<CString>)IntPtr.Zero;
-        _virtualTable.SDL_SetClipboardText = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_CloseAudioDevice = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void>)IntPtr.Zero;
-        _virtualTable.SDL_CloseAudio = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_UnlockAudioDevice = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void>)IntPtr.Zero;
-        _virtualTable.SDL_UnlockAudio = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_LockAudioDevice = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void>)IntPtr.Zero;
-        _virtualTable.SDL_LockAudio = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_ClearQueuedAudio = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetQueuedAudioSize = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, uint>)IntPtr.Zero;
-        _virtualTable.SDL_DequeueAudio = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void*, uint, uint>)IntPtr.Zero;
-        _virtualTable.SDL_QueueAudio = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void*, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_MixAudioFormat = (delegate* unmanaged[Cdecl]<byte*, byte*, SDL_AudioFormat, uint, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_MixAudio = (delegate* unmanaged[Cdecl]<byte*, byte*, uint, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_FreeAudioStream = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, void>)IntPtr.Zero;
-        _virtualTable.SDL_AudioStreamClear = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, void>)IntPtr.Zero;
-        _virtualTable.SDL_AudioStreamFlush = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, int>)IntPtr.Zero;
-        _virtualTable.SDL_AudioStreamAvailable = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, int>)IntPtr.Zero;
-        _virtualTable.SDL_AudioStreamGet = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, void*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_AudioStreamPut = (delegate* unmanaged[Cdecl]<SDL_AudioStream*, void*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_NewAudioStream = (delegate* unmanaged[Cdecl]<SDL_AudioFormat, byte, int, SDL_AudioFormat, byte, int, SDL_AudioStream*>)IntPtr.Zero;
-        _virtualTable.SDL_ConvertAudio = (delegate* unmanaged[Cdecl]<SDL_AudioCVT*, int>)IntPtr.Zero;
-        _virtualTable.SDL_BuildAudioCVT = (delegate* unmanaged[Cdecl]<SDL_AudioCVT*, SDL_AudioFormat, byte, int, SDL_AudioFormat, byte, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_FreeWAV = (delegate* unmanaged[Cdecl]<byte*, void>)IntPtr.Zero;
-        _virtualTable.SDL_LoadWAV_RW = (delegate* unmanaged[Cdecl]<SDL_RWops*, int, SDL_AudioSpec*, byte**, uint*, SDL_AudioSpec*>)IntPtr.Zero;
-        _virtualTable.SDL_PauseAudioDevice = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, int, void>)IntPtr.Zero;
-        _virtualTable.SDL_PauseAudio = (delegate* unmanaged[Cdecl]<int, void>)IntPtr.Zero;
-        _virtualTable.SDL_GetAudioDeviceStatus = (delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, SDL_AudioStatus>)IntPtr.Zero;
-        _virtualTable.SDL_GetAudioStatus = (delegate* unmanaged[Cdecl]<SDL_AudioStatus>)IntPtr.Zero;
-        _virtualTable.SDL_OpenAudioDevice = (delegate* unmanaged[Cdecl]<CString, int, SDL_AudioSpec*, SDL_AudioSpec*, int, SDL_AudioDeviceID>)IntPtr.Zero;
-        _virtualTable.SDL_GetAudioDeviceSpec = (delegate* unmanaged[Cdecl]<int, int, SDL_AudioSpec*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetAudioDeviceName = (delegate* unmanaged[Cdecl]<int, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetNumAudioDevices = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_OpenAudio = (delegate* unmanaged[Cdecl]<SDL_AudioSpec*, SDL_AudioSpec*, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetCurrentAudioDriver = (delegate* unmanaged[Cdecl]<CString>)IntPtr.Zero;
-        _virtualTable.SDL_AudioQuit = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_AudioInit = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetAudioDriver = (delegate* unmanaged[Cdecl]<int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetNumAudioDrivers = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_WriteBE64 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_WriteLE64 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_WriteBE32 = (delegate* unmanaged[Cdecl]<SDL_RWops*, uint, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_WriteLE32 = (delegate* unmanaged[Cdecl]<SDL_RWops*, uint, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_WriteBE16 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ushort, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_WriteLE16 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ushort, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_WriteU8 = (delegate* unmanaged[Cdecl]<SDL_RWops*, byte, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_ReadBE64 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_ReadLE64 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_ReadBE32 = (delegate* unmanaged[Cdecl]<SDL_RWops*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_ReadLE32 = (delegate* unmanaged[Cdecl]<SDL_RWops*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_ReadBE16 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_ReadLE16 = (delegate* unmanaged[Cdecl]<SDL_RWops*, ushort>)IntPtr.Zero;
-        _virtualTable.SDL_ReadU8 = (delegate* unmanaged[Cdecl]<SDL_RWops*, byte>)IntPtr.Zero;
-        _virtualTable.SDL_LoadFile = (delegate* unmanaged[Cdecl]<CString, ulong*, void*>)IntPtr.Zero;
-        _virtualTable.SDL_LoadFile_RW = (delegate* unmanaged[Cdecl]<SDL_RWops*, ulong*, int, void*>)IntPtr.Zero;
-        _virtualTable.SDL_RWclose = (delegate* unmanaged[Cdecl]<SDL_RWops*, int>)IntPtr.Zero;
-        _virtualTable.SDL_RWwrite = (delegate* unmanaged[Cdecl]<SDL_RWops*, void*, ulong, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_RWread = (delegate* unmanaged[Cdecl]<SDL_RWops*, void*, ulong, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_RWtell = (delegate* unmanaged[Cdecl]<SDL_RWops*, long>)IntPtr.Zero;
-        _virtualTable.SDL_RWseek = (delegate* unmanaged[Cdecl]<SDL_RWops*, long, int, long>)IntPtr.Zero;
-        _virtualTable.SDL_RWsize = (delegate* unmanaged[Cdecl]<SDL_RWops*, long>)IntPtr.Zero;
-        _virtualTable.SDL_FreeRW = (delegate* unmanaged[Cdecl]<SDL_RWops*, void>)IntPtr.Zero;
-        _virtualTable.SDL_AllocRW = (delegate* unmanaged[Cdecl]<SDL_RWops*>)IntPtr.Zero;
-        _virtualTable.SDL_RWFromConstMem = (delegate* unmanaged[Cdecl]<void*, int, SDL_RWops*>)IntPtr.Zero;
-        _virtualTable.SDL_RWFromMem = (delegate* unmanaged[Cdecl]<void*, int, SDL_RWops*>)IntPtr.Zero;
-        _virtualTable.SDL_RWFromFP = (delegate* unmanaged[Cdecl]<void*, CBool, SDL_RWops*>)IntPtr.Zero;
-        _virtualTable.SDL_RWFromFile = (delegate* unmanaged[Cdecl]<CString, CString, SDL_RWops*>)IntPtr.Zero;
-        _virtualTable.SDL_TLSCleanup = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_TLSSet = (delegate* unmanaged[Cdecl]<SDL_TLSID, void*, FnPtr_SDL_VoidPtr_Void, int>)IntPtr.Zero;
-        _virtualTable.SDL_TLSGet = (delegate* unmanaged[Cdecl]<SDL_TLSID, void*>)IntPtr.Zero;
-        _virtualTable.SDL_TLSCreate = (delegate* unmanaged[Cdecl]<SDL_TLSID>)IntPtr.Zero;
-        _virtualTable.SDL_DetachThread = (delegate* unmanaged[Cdecl]<SDL_Thread*, void>)IntPtr.Zero;
-        _virtualTable.SDL_WaitThread = (delegate* unmanaged[Cdecl]<SDL_Thread*, long*, void>)IntPtr.Zero;
-        _virtualTable.SDL_SetThreadPriority = (delegate* unmanaged[Cdecl]<SDL_ThreadPriority, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetThreadID = (delegate* unmanaged[Cdecl]<SDL_Thread*, SDL_threadID>)IntPtr.Zero;
-        _virtualTable.SDL_ThreadID = (delegate* unmanaged[Cdecl]<SDL_threadID>)IntPtr.Zero;
-        _virtualTable.SDL_GetThreadName = (delegate* unmanaged[Cdecl]<SDL_Thread*, CString>)IntPtr.Zero;
-        _virtualTable.SDL_CreateThreadWithStackSize = (delegate* unmanaged[Cdecl]<FnPtr_SDL_VoidPtr_Int, CString, ulong, void*, pfnSDL_CurrentBeginThread, pfnSDL_CurrentEndThread, SDL_Thread*>)IntPtr.Zero;
-        _virtualTable.SDL_CreateThread = (delegate* unmanaged[Cdecl]<SDL_ThreadFunction, CString, void*, pfnSDL_CurrentBeginThread, pfnSDL_CurrentEndThread, SDL_Thread*>)IntPtr.Zero;
-        _virtualTable.SDL_CondWaitTimeout = (delegate* unmanaged[Cdecl]<SDL_cond*, SDL_mutex*, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_CondWait = (delegate* unmanaged[Cdecl]<SDL_cond*, SDL_mutex*, int>)IntPtr.Zero;
-        _virtualTable.SDL_CondBroadcast = (delegate* unmanaged[Cdecl]<SDL_cond*, int>)IntPtr.Zero;
-        _virtualTable.SDL_CondSignal = (delegate* unmanaged[Cdecl]<SDL_cond*, int>)IntPtr.Zero;
-        _virtualTable.SDL_DestroyCond = (delegate* unmanaged[Cdecl]<SDL_cond*, void>)IntPtr.Zero;
-        _virtualTable.SDL_CreateCond = (delegate* unmanaged[Cdecl]<SDL_cond*>)IntPtr.Zero;
-        _virtualTable.SDL_SemValue = (delegate* unmanaged[Cdecl]<SDL_sem*, uint>)IntPtr.Zero;
-        _virtualTable.SDL_SemPost = (delegate* unmanaged[Cdecl]<SDL_sem*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SemWaitTimeout = (delegate* unmanaged[Cdecl]<SDL_sem*, uint, int>)IntPtr.Zero;
-        _virtualTable.SDL_SemTryWait = (delegate* unmanaged[Cdecl]<SDL_sem*, int>)IntPtr.Zero;
-        _virtualTable.SDL_SemWait = (delegate* unmanaged[Cdecl]<SDL_sem*, int>)IntPtr.Zero;
-        _virtualTable.SDL_DestroySemaphore = (delegate* unmanaged[Cdecl]<SDL_sem*, void>)IntPtr.Zero;
-        _virtualTable.SDL_CreateSemaphore = (delegate* unmanaged[Cdecl]<uint, SDL_sem*>)IntPtr.Zero;
-        _virtualTable.SDL_DestroyMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*, void>)IntPtr.Zero;
-        _virtualTable.SDL_UnlockMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*, int>)IntPtr.Zero;
-        _virtualTable.SDL_TryLockMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*, int>)IntPtr.Zero;
-        _virtualTable.SDL_LockMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*, int>)IntPtr.Zero;
-        _virtualTable.SDL_CreateMutex = (delegate* unmanaged[Cdecl]<SDL_mutex*>)IntPtr.Zero;
-        _virtualTable.SDL_SwapFloat = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_Error = (delegate* unmanaged[Cdecl]<SDL_errorcode, int>)IntPtr.Zero;
-        _virtualTable.SDL_ClearError = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_GetErrorMsg = (delegate* unmanaged[Cdecl]<CString, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetError = (delegate* unmanaged[Cdecl]<CString>)IntPtr.Zero;
-        _virtualTable.SDL_SetError = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicGetPtr = (delegate* unmanaged[Cdecl]<void**, void*>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicSetPtr = (delegate* unmanaged[Cdecl]<void**, void*, void*>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicCASPtr = (delegate* unmanaged[Cdecl]<void**, void*, void*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicAdd = (delegate* unmanaged[Cdecl]<SDL_atomic_t*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicGet = (delegate* unmanaged[Cdecl]<SDL_atomic_t*, int>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicSet = (delegate* unmanaged[Cdecl]<SDL_atomic_t*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicCAS = (delegate* unmanaged[Cdecl]<SDL_atomic_t*, int, int, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_MemoryBarrierAcquireFunction = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_MemoryBarrierReleaseFunction = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicUnlock = (delegate* unmanaged[Cdecl]<SDL_SpinLock*, void>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicLock = (delegate* unmanaged[Cdecl]<SDL_SpinLock*, void>)IntPtr.Zero;
-        _virtualTable.SDL_AtomicTryLock = (delegate* unmanaged[Cdecl]<SDL_SpinLock*, CBool>)IntPtr.Zero;
-        _virtualTable.SDL_ResetAssertionReport = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_GetAssertionReport = (delegate* unmanaged[Cdecl]<SDL_AssertData*>)IntPtr.Zero;
-        _virtualTable.SDL_GetAssertionHandler = (delegate* unmanaged[Cdecl]<void**, SDL_AssertionHandler>)IntPtr.Zero;
-        _virtualTable.SDL_GetDefaultAssertionHandler = (delegate* unmanaged[Cdecl]<SDL_AssertionHandler>)IntPtr.Zero;
-        _virtualTable.SDL_SetAssertionHandler = (delegate* unmanaged[Cdecl]<SDL_AssertionHandler, void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_ReportAssertion = (delegate* unmanaged[Cdecl]<SDL_AssertData*, CString, CString, int, SDL_AssertState>)IntPtr.Zero;
-        _virtualTable.__debugbreak = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.SDL_memcpy4 = (delegate* unmanaged[Cdecl]<void*, void*, ulong, void*>)IntPtr.Zero;
-        _virtualTable.SDL_iconv_string = (delegate* unmanaged[Cdecl]<CString, CString, CString, ulong, CString>)IntPtr.Zero;
-        _virtualTable.SDL_iconv = (delegate* unmanaged[Cdecl]<SDL_iconv_t, CString*, ulong*, CString*, ulong*, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_iconv_close = (delegate* unmanaged[Cdecl]<SDL_iconv_t, int>)IntPtr.Zero;
-        _virtualTable.SDL_iconv_open = (delegate* unmanaged[Cdecl]<CString, CString, SDL_iconv_t>)IntPtr.Zero;
-        _virtualTable.SDL_tanf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_tan = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_sqrtf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_sqrt = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_sinf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_sin = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_scalbnf = (delegate* unmanaged[Cdecl]<float, int, float>)IntPtr.Zero;
-        _virtualTable.SDL_scalbn = (delegate* unmanaged[Cdecl]<double, int, double>)IntPtr.Zero;
-        _virtualTable.SDL_lroundf = (delegate* unmanaged[Cdecl]<float, int>)IntPtr.Zero;
-        _virtualTable.SDL_lround = (delegate* unmanaged[Cdecl]<double, int>)IntPtr.Zero;
-        _virtualTable.SDL_roundf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_round = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_powf = (delegate* unmanaged[Cdecl]<float, float, float>)IntPtr.Zero;
-        _virtualTable.SDL_pow = (delegate* unmanaged[Cdecl]<double, double, double>)IntPtr.Zero;
-        _virtualTable.SDL_log10f = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_log10 = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_logf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_log = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_fmodf = (delegate* unmanaged[Cdecl]<float, float, float>)IntPtr.Zero;
-        _virtualTable.SDL_fmod = (delegate* unmanaged[Cdecl]<double, double, double>)IntPtr.Zero;
-        _virtualTable.SDL_truncf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_trunc = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_floorf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_floor = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_fabsf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_fabs = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_expf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_exp = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_cosf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_cos = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_copysignf = (delegate* unmanaged[Cdecl]<float, float, float>)IntPtr.Zero;
-        _virtualTable.SDL_copysign = (delegate* unmanaged[Cdecl]<double, double, double>)IntPtr.Zero;
-        _virtualTable.SDL_ceilf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_ceil = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_atan2f = (delegate* unmanaged[Cdecl]<float, float, float>)IntPtr.Zero;
-        _virtualTable.SDL_atan2 = (delegate* unmanaged[Cdecl]<double, double, double>)IntPtr.Zero;
-        _virtualTable.SDL_atanf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_atan = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_asinf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_asin = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_acosf = (delegate* unmanaged[Cdecl]<float, float>)IntPtr.Zero;
-        _virtualTable.SDL_acos = (delegate* unmanaged[Cdecl]<double, double>)IntPtr.Zero;
-        _virtualTable.SDL_vsnprintf = (delegate* unmanaged[Cdecl]<CString, ulong, CString, IntPtr, int>)IntPtr.Zero;
-        _virtualTable.SDL_snprintf = (delegate* unmanaged[Cdecl]<CString, ulong, CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_vsscanf = (delegate* unmanaged[Cdecl]<CString, CString, IntPtr, int>)IntPtr.Zero;
-        _virtualTable.SDL_sscanf = (delegate* unmanaged[Cdecl]<CString, CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_strncasecmp = (delegate* unmanaged[Cdecl]<CString, CString, ulong, int>)IntPtr.Zero;
-        _virtualTable.SDL_strcasecmp = (delegate* unmanaged[Cdecl]<CString, CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_strncmp = (delegate* unmanaged[Cdecl]<CString, CString, ulong, int>)IntPtr.Zero;
-        _virtualTable.SDL_strcmp = (delegate* unmanaged[Cdecl]<CString, CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_strtod = (delegate* unmanaged[Cdecl]<CString, CString*, double>)IntPtr.Zero;
-        _virtualTable.SDL_strtoull = (delegate* unmanaged[Cdecl]<CString, CString*, int, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_strtoll = (delegate* unmanaged[Cdecl]<CString, CString*, int, long>)IntPtr.Zero;
-        _virtualTable.SDL_strtoul = (delegate* unmanaged[Cdecl]<CString, CString*, int, uint>)IntPtr.Zero;
-        _virtualTable.SDL_strtol = (delegate* unmanaged[Cdecl]<CString, CString*, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_atof = (delegate* unmanaged[Cdecl]<CString, double>)IntPtr.Zero;
-        _virtualTable.SDL_atoi = (delegate* unmanaged[Cdecl]<CString, int>)IntPtr.Zero;
-        _virtualTable.SDL_ulltoa = (delegate* unmanaged[Cdecl]<ulong, CString, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_lltoa = (delegate* unmanaged[Cdecl]<long, CString, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_ultoa = (delegate* unmanaged[Cdecl]<uint, CString, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_ltoa = (delegate* unmanaged[Cdecl]<int, CString, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_uitoa = (delegate* unmanaged[Cdecl]<uint, CString, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_itoa = (delegate* unmanaged[Cdecl]<int, CString, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_utf8strlen = (delegate* unmanaged[Cdecl]<CString, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_strtokr = (delegate* unmanaged[Cdecl]<CString, CString, CString*, CString>)IntPtr.Zero;
-        _virtualTable.SDL_strstr = (delegate* unmanaged[Cdecl]<CString, CString, CString>)IntPtr.Zero;
-        _virtualTable.SDL_strrchr = (delegate* unmanaged[Cdecl]<CString, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_strchr = (delegate* unmanaged[Cdecl]<CString, int, CString>)IntPtr.Zero;
-        _virtualTable.SDL_strlwr = (delegate* unmanaged[Cdecl]<CString, CString>)IntPtr.Zero;
-        _virtualTable.SDL_strupr = (delegate* unmanaged[Cdecl]<CString, CString>)IntPtr.Zero;
-        _virtualTable.SDL_strrev = (delegate* unmanaged[Cdecl]<CString, CString>)IntPtr.Zero;
-        _virtualTable.SDL_strdup = (delegate* unmanaged[Cdecl]<CString, CString>)IntPtr.Zero;
-        _virtualTable.SDL_strlcat = (delegate* unmanaged[Cdecl]<CString, CString, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_utf8strlcpy = (delegate* unmanaged[Cdecl]<CString, CString, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_strlcpy = (delegate* unmanaged[Cdecl]<CString, CString, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_strlen = (delegate* unmanaged[Cdecl]<CString, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_wcsncasecmp = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, int>)IntPtr.Zero;
-        _virtualTable.SDL_wcscasecmp = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, int>)IntPtr.Zero;
-        _virtualTable.SDL_wcsncmp = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, int>)IntPtr.Zero;
-        _virtualTable.SDL_wcscmp = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, int>)IntPtr.Zero;
-        _virtualTable.SDL_wcsstr = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, wchar_t*>)IntPtr.Zero;
-        _virtualTable.SDL_wcsdup = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*>)IntPtr.Zero;
-        _virtualTable.SDL_wcslcat = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_wcslcpy = (delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_wcslen = (delegate* unmanaged[Cdecl]<wchar_t*, ulong>)IntPtr.Zero;
-        _virtualTable.SDL_memcmp = (delegate* unmanaged[Cdecl]<void*, void*, ulong, int>)IntPtr.Zero;
-        _virtualTable.SDL_memmove = (delegate* unmanaged[Cdecl]<void*, void*, ulong, void*>)IntPtr.Zero;
-        _virtualTable.SDL_memcpy = (delegate* unmanaged[Cdecl]<void*, void*, ulong, void*>)IntPtr.Zero;
-        _virtualTable.SDL_memset4 = (delegate* unmanaged[Cdecl]<void*, uint, ulong, void>)IntPtr.Zero;
-        _virtualTable.SDL_memset = (delegate* unmanaged[Cdecl]<void*, int, ulong, void*>)IntPtr.Zero;
-        _virtualTable.SDL_crc32 = (delegate* unmanaged[Cdecl]<uint, void*, ulong, uint>)IntPtr.Zero;
-        _virtualTable.SDL_tolower = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_toupper = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_isgraph = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_isprint = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_islower = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_isupper = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_isspace = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_ispunct = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_isxdigit = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_isdigit = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_iscntrl = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_isblank = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_isalnum = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_isalpha = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_abs = (delegate* unmanaged[Cdecl]<int, int>)IntPtr.Zero;
-        _virtualTable.SDL_qsort = (delegate* unmanaged[Cdecl]<void*, ulong, ulong, FnPtr_SDL_VoidPtr_VoidPtr_Int, void>)IntPtr.Zero;
-        _virtualTable.SDL_setenv = (delegate* unmanaged[Cdecl]<CString, CString, int, int>)IntPtr.Zero;
-        _virtualTable.SDL_getenv = (delegate* unmanaged[Cdecl]<CString, CString>)IntPtr.Zero;
-        _virtualTable.SDL_GetNumAllocations = (delegate* unmanaged[Cdecl]<int>)IntPtr.Zero;
-        _virtualTable.SDL_SetMemoryFunctions = (delegate* unmanaged[Cdecl]<SDL_malloc_func, SDL_calloc_func, SDL_realloc_func, SDL_free_func, int>)IntPtr.Zero;
-        _virtualTable.SDL_GetMemoryFunctions = (delegate* unmanaged[Cdecl]<SDL_malloc_func*, SDL_calloc_func*, SDL_realloc_func*, SDL_free_func*, void>)IntPtr.Zero;
-        _virtualTable.SDL_free = (delegate* unmanaged[Cdecl]<void*, void>)IntPtr.Zero;
-        _virtualTable.SDL_realloc = (delegate* unmanaged[Cdecl]<void*, ulong, void*>)IntPtr.Zero;
-        _virtualTable.SDL_calloc = (delegate* unmanaged[Cdecl]<ulong, ulong, void*>)IntPtr.Zero;
-        _virtualTable.SDL_malloc = (delegate* unmanaged[Cdecl]<ulong, void*>)IntPtr.Zero;
-        _virtualTable.SDL_GetPlatform = (delegate* unmanaged[Cdecl]<CString>)IntPtr.Zero;
-
-        #endregion
-
-        #region "Variables"
-
-
-
-        #endregion
-    }
-
-    // The virtual table represents a list of pointers to functions or variables which are resolved in a late manner.
-    //	This allows for flexibility in swapping implementations at runtime.
-    //	You can think of it in traditional OOP terms in C# as the locations of the virtual methods and/or properties of an object.
-    public struct _VirtualTable
-    {
-        #region "Function Pointers"
-        // These pointers hold the locations in the native library where functions are located at runtime.
-        // See: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
-
-        public delegate* unmanaged[Cdecl]<void> SDL_Quit;
-        public delegate* unmanaged[Cdecl]<uint, uint> SDL_WasInit;
-        public delegate* unmanaged[Cdecl]<uint, void> SDL_QuitSubSystem;
-        public delegate* unmanaged[Cdecl]<uint, int> SDL_InitSubSystem;
-        public delegate* unmanaged[Cdecl]<uint, int> SDL_Init;
-        public delegate* unmanaged[Cdecl]<CString, int> SDL_OpenURL;
-        public delegate* unmanaged[Cdecl]<SDL_Locale*> SDL_GetPreferredLocales;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetRevisionNumber;
-        public delegate* unmanaged[Cdecl]<CString> SDL_GetRevision;
-        public delegate* unmanaged[Cdecl]<SDL_version*, void> SDL_GetVersion;
-        public delegate* unmanaged[Cdecl]<SDL_TimerID, CBool> SDL_RemoveTimer;
-        public delegate* unmanaged[Cdecl]<uint, SDL_TimerCallback, void*, SDL_TimerID> SDL_AddTimer;
-        public delegate* unmanaged[Cdecl]<uint, void> SDL_Delay;
-        public delegate* unmanaged[Cdecl]<ulong> SDL_GetPerformanceFrequency;
-        public delegate* unmanaged[Cdecl]<ulong> SDL_GetPerformanceCounter;
-        public delegate* unmanaged[Cdecl]<uint> SDL_GetTicks;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_WindowShapeMode*, int> SDL_GetShapedWindowMode;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Surface*, SDL_WindowShapeMode*, int> SDL_SetWindowShape;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool> SDL_IsShapedWindow;
-        public delegate* unmanaged[Cdecl]<CString, uint, uint, uint, uint, uint, SDL_Window*> SDL_CreateShapedWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, void*> SDL_RenderGetMetalCommandEncoder;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, void*> SDL_RenderGetMetalLayer;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, int> SDL_GL_UnbindTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, float*, float*, int> SDL_GL_BindTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, int> SDL_RenderFlush;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, void> SDL_DestroyRenderer;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, void> SDL_DestroyTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, void> SDL_RenderPresent;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, uint, void*, int, int> SDL_RenderReadPixels;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_FRect*, double, SDL_FPoint*, SDL_RendererFlip, int> SDL_RenderCopyExF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_FRect*, int> SDL_RenderCopyF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int, int> SDL_RenderFillRectsF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int> SDL_RenderFillRectF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int, int> SDL_RenderDrawRectsF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FRect*, int> SDL_RenderDrawRectF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FPoint*, int, int> SDL_RenderDrawLinesF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, float, float, float, float, int> SDL_RenderDrawLineF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_FPoint*, int, int> SDL_RenderDrawPointsF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, float, float, int> SDL_RenderDrawPointF;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_Rect*, double, SDL_Point*, SDL_RendererFlip, int> SDL_RenderCopyEx;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, SDL_Rect*, SDL_Rect*, int> SDL_RenderCopy;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int, int> SDL_RenderFillRects;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int> SDL_RenderFillRect;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int, int> SDL_RenderDrawRects;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int> SDL_RenderDrawRect;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Point*, int, int> SDL_RenderDrawLines;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, int, int, int, int, int> SDL_RenderDrawLine;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Point*, int, int> SDL_RenderDrawPoints;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, int, int, int> SDL_RenderDrawPoint;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, int> SDL_RenderClear;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_BlendMode*, int> SDL_GetRenderDrawBlendMode;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_BlendMode, int> SDL_SetRenderDrawBlendMode;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, byte*, byte*, byte*, byte*, int> SDL_GetRenderDrawColor;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, byte, byte, byte, byte, int> SDL_SetRenderDrawColor;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, float*, float*, void> SDL_RenderGetScale;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, float, float, int> SDL_RenderSetScale;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool> SDL_RenderIsClipEnabled;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, void> SDL_RenderGetClipRect;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int> SDL_RenderSetClipRect;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, void> SDL_RenderGetViewport;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Rect*, int> SDL_RenderSetViewport;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool> SDL_RenderGetIntegerScale;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool, int> SDL_RenderSetIntegerScale;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, long*, long*, void> SDL_RenderGetLogicalSize;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, int, int, int> SDL_RenderSetLogicalSize;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*> SDL_GetRenderTarget;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Texture*, int> SDL_SetRenderTarget;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, CBool> SDL_RenderTargetSupported;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, void> SDL_UnlockTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, SDL_Surface**, int> SDL_LockTextureToSurface;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, void**, long*, int> SDL_LockTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, byte*, int, byte*, int, int> SDL_UpdateNVTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, byte*, int, byte*, int, byte*, int, int> SDL_UpdateYUVTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_Rect*, void*, int, int> SDL_UpdateTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_ScaleMode*, int> SDL_GetTextureScaleMode;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_ScaleMode, int> SDL_SetTextureScaleMode;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_BlendMode*, int> SDL_GetTextureBlendMode;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, SDL_BlendMode, int> SDL_SetTextureBlendMode;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, byte*, int> SDL_GetTextureAlphaMod;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, byte, int> SDL_SetTextureAlphaMod;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, byte*, byte*, byte*, int> SDL_GetTextureColorMod;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, byte, byte, byte, int> SDL_SetTextureColorMod;
-        public delegate* unmanaged[Cdecl]<SDL_Texture*, uint*, long*, long*, long*, int> SDL_QueryTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_Surface*, SDL_Texture*> SDL_CreateTextureFromSurface;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, uint, int, int, int, SDL_Texture*> SDL_CreateTexture;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, long*, long*, int> SDL_GetRendererOutputSize;
-        public delegate* unmanaged[Cdecl]<SDL_Renderer*, SDL_RendererInfo*, int> SDL_GetRendererInfo;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Renderer*> SDL_GetRenderer;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Renderer*> SDL_CreateSoftwareRenderer;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, int, uint, SDL_Renderer*> SDL_CreateRenderer;
-        public delegate* unmanaged[Cdecl]<int, int, uint, SDL_Window**, SDL_Renderer**, int> SDL_CreateWindowAndRenderer;
-        public delegate* unmanaged[Cdecl]<int, SDL_RendererInfo*, int> SDL_GetRenderDriverInfo;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetNumRenderDrivers;
-        public delegate* unmanaged[Cdecl]<long*, long*, SDL_PowerState> SDL_GetPowerInfo;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void> SDL_Metal_GetDrawableSize;
-        public delegate* unmanaged[Cdecl]<SDL_MetalView, void*> SDL_Metal_GetLayer;
-        public delegate* unmanaged[Cdecl]<SDL_MetalView, void> SDL_Metal_DestroyView;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_MetalView> SDL_Metal_CreateView;
-        public delegate* unmanaged[Cdecl]<uint, CString, CString, SDL_Window*, int> SDL_ShowSimpleMessageBox;
-        public delegate* unmanaged[Cdecl]<SDL_MessageBoxData*, long*, int> SDL_ShowMessageBox;
-        public delegate* unmanaged[Cdecl]<SDL_LogOutputFunction, void*, void> SDL_LogSetOutputFunction;
-        public delegate* unmanaged[Cdecl]<SDL_LogOutputFunction*, void**, void> SDL_LogGetOutputFunction;
-        public delegate* unmanaged[Cdecl]<int, SDL_LogPriority, CString, IntPtr, void> SDL_LogMessageV;
-        public delegate* unmanaged[Cdecl]<int, SDL_LogPriority, CString, void> SDL_LogMessage;
-        public delegate* unmanaged[Cdecl]<int, CString, void> SDL_LogCritical;
-        public delegate* unmanaged[Cdecl]<int, CString, void> SDL_LogError;
-        public delegate* unmanaged[Cdecl]<int, CString, void> SDL_LogWarn;
-        public delegate* unmanaged[Cdecl]<int, CString, void> SDL_LogInfo;
-        public delegate* unmanaged[Cdecl]<int, CString, void> SDL_LogDebug;
-        public delegate* unmanaged[Cdecl]<int, CString, void> SDL_LogVerbose;
-        public delegate* unmanaged[Cdecl]<CString, void> SDL_Log;
-        public delegate* unmanaged[Cdecl]<void> SDL_LogResetPriorities;
-        public delegate* unmanaged[Cdecl]<int, SDL_LogPriority> SDL_LogGetPriority;
-        public delegate* unmanaged[Cdecl]<int, SDL_LogPriority, void> SDL_LogSetPriority;
-        public delegate* unmanaged[Cdecl]<SDL_LogPriority, void> SDL_LogSetAllPriority;
-        public delegate* unmanaged[Cdecl]<void*, void> SDL_UnloadObject;
-        public delegate* unmanaged[Cdecl]<void*, CString, void*> SDL_LoadFunction;
-        public delegate* unmanaged[Cdecl]<CString, void*> SDL_LoadObject;
-        public delegate* unmanaged[Cdecl]<void> SDL_ClearHints;
-        public delegate* unmanaged[Cdecl]<CString, SDL_HintCallback, void*, void> SDL_DelHintCallback;
-        public delegate* unmanaged[Cdecl]<CString, SDL_HintCallback, void*, void> SDL_AddHintCallback;
-        public delegate* unmanaged[Cdecl]<CString, CBool, CBool> SDL_GetHintBoolean;
-        public delegate* unmanaged[Cdecl]<CString, CString> SDL_GetHint;
-        public delegate* unmanaged[Cdecl]<CString, CString, CBool> SDL_SetHint;
-        public delegate* unmanaged[Cdecl]<CString, CString, SDL_HintPriority, CBool> SDL_SetHintWithPriority;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticRumbleStop;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, float, uint, int> SDL_HapticRumblePlay;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticRumbleInit;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticRumbleSupported;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticStopAll;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticUnpause;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticPause;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int> SDL_HapticSetAutocenter;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int> SDL_HapticSetGain;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int> SDL_HapticGetEffectStatus;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int, void> SDL_HapticDestroyEffect;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int, int> SDL_HapticStopEffect;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int, uint, int> SDL_HapticRunEffect;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int, SDL_HapticEffect*, int> SDL_HapticUpdateEffect;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, SDL_HapticEffect*, int> SDL_HapticNewEffect;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, SDL_HapticEffect*, int> SDL_HapticEffectSupported;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticNumAxes;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, uint> SDL_HapticQuery;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticNumEffectsPlaying;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticNumEffects;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, void> SDL_HapticClose;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_Haptic*> SDL_HapticOpenFromJoystick;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int> SDL_JoystickIsHaptic;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*> SDL_HapticOpenFromMouse;
-        public delegate* unmanaged[Cdecl]<int> SDL_MouseIsHaptic;
-        public delegate* unmanaged[Cdecl]<SDL_Haptic*, int> SDL_HapticIndex;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_HapticOpened;
-        public delegate* unmanaged[Cdecl]<int, SDL_Haptic*> SDL_HapticOpen;
-        public delegate* unmanaged[Cdecl]<int, CString> SDL_HapticName;
-        public delegate* unmanaged[Cdecl]<int> SDL_NumHaptics;
-        public delegate* unmanaged[Cdecl]<CString, CString, CString> SDL_GetPrefPath;
-        public delegate* unmanaged[Cdecl]<CString> SDL_GetBasePath;
-        public delegate* unmanaged[Cdecl]<int, uint> SDL_RegisterEvents;
-        public delegate* unmanaged[Cdecl]<uint, int, byte> SDL_EventState;
-        public delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void> SDL_FilterEvents;
-        public delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void> SDL_DelEventWatch;
-        public delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void> SDL_AddEventWatch;
-        public delegate* unmanaged[Cdecl]<SDL_EventFilter*, void**, CBool> SDL_GetEventFilter;
-        public delegate* unmanaged[Cdecl]<SDL_EventFilter, void*, void> SDL_SetEventFilter;
-        public delegate* unmanaged[Cdecl]<SDL_Event*, int> SDL_PushEvent;
-        public delegate* unmanaged[Cdecl]<SDL_Event*, int, int> SDL_WaitEventTimeout;
-        public delegate* unmanaged[Cdecl]<SDL_Event*, int> SDL_WaitEvent;
-        public delegate* unmanaged[Cdecl]<SDL_Event*, int> SDL_PollEvent;
-        public delegate* unmanaged[Cdecl]<uint, uint, void> SDL_FlushEvents;
-        public delegate* unmanaged[Cdecl]<uint, void> SDL_FlushEvent;
-        public delegate* unmanaged[Cdecl]<uint, uint, CBool> SDL_HasEvents;
-        public delegate* unmanaged[Cdecl]<uint, CBool> SDL_HasEvent;
-        public delegate* unmanaged[Cdecl]<SDL_Event*, int, SDL_eventaction, uint, uint, int> SDL_PeepEvents;
-        public delegate* unmanaged[Cdecl]<void> SDL_PumpEvents;
-        public delegate* unmanaged[Cdecl]<SDL_TouchID, SDL_RWops*, int> SDL_LoadDollarTemplates;
-        public delegate* unmanaged[Cdecl]<SDL_GestureID, SDL_RWops*, int> SDL_SaveDollarTemplate;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, int> SDL_SaveAllDollarTemplates;
-        public delegate* unmanaged[Cdecl]<SDL_TouchID, int> SDL_RecordGesture;
-        public delegate* unmanaged[Cdecl]<SDL_TouchID, int, SDL_Finger*> SDL_GetTouchFinger;
-        public delegate* unmanaged[Cdecl]<SDL_TouchID, int> SDL_GetNumTouchFingers;
-        public delegate* unmanaged[Cdecl]<SDL_TouchID, SDL_TouchDeviceType> SDL_GetTouchDeviceType;
-        public delegate* unmanaged[Cdecl]<int, SDL_TouchID> SDL_GetTouchDevice;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetNumTouchDevices;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, void> SDL_GameControllerClose;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, byte, byte, byte, int> SDL_GameControllerSetLED;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, CBool> SDL_GameControllerHasLED;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, ushort, ushort, uint, int> SDL_GameControllerRumbleTriggers;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, ushort, ushort, uint, int> SDL_GameControllerRumble;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, float*, int, int> SDL_GameControllerGetSensorData;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, CBool> SDL_GameControllerIsSensorEnabled;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, CBool, int> SDL_GameControllerSetSensorEnabled;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_SensorType, CBool> SDL_GameControllerHasSensor;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, int, int, byte*, float*, float*, float*, int> SDL_GameControllerGetTouchpadFinger;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, int, int> SDL_GameControllerGetNumTouchpadFingers;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, int> SDL_GameControllerGetNumTouchpads;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerButton, byte> SDL_GameControllerGetButton;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerButton, CBool> SDL_GameControllerHasButton;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerButton, SDL_GameControllerButtonBind> SDL_GameControllerGetBindForButton;
-        public delegate* unmanaged[Cdecl]<SDL_GameControllerButton, CString> SDL_GameControllerGetStringForButton;
-        public delegate* unmanaged[Cdecl]<CString, SDL_GameControllerButton> SDL_GameControllerGetButtonFromString;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerAxis, short> SDL_GameControllerGetAxis;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerAxis, CBool> SDL_GameControllerHasAxis;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerAxis, SDL_GameControllerButtonBind> SDL_GameControllerGetBindForAxis;
-        public delegate* unmanaged[Cdecl]<SDL_GameControllerAxis, CString> SDL_GameControllerGetStringForAxis;
-        public delegate* unmanaged[Cdecl]<CString, SDL_GameControllerAxis> SDL_GameControllerGetAxisFromString;
-        public delegate* unmanaged[Cdecl]<void> SDL_GameControllerUpdate;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_GameControllerEventState;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_Joystick*> SDL_GameControllerGetJoystick;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, CBool> SDL_GameControllerGetAttached;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, CString> SDL_GameControllerGetSerial;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, ushort> SDL_GameControllerGetProductVersion;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, ushort> SDL_GameControllerGetProduct;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, ushort> SDL_GameControllerGetVendor;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, int, void> SDL_GameControllerSetPlayerIndex;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, int> SDL_GameControllerGetPlayerIndex;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, SDL_GameControllerType> SDL_GameControllerGetType;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, CString> SDL_GameControllerName;
-        public delegate* unmanaged[Cdecl]<int, SDL_GameController*> SDL_GameControllerFromPlayerIndex;
-        public delegate* unmanaged[Cdecl]<SDL_JoystickID, SDL_GameController*> SDL_GameControllerFromInstanceID;
-        public delegate* unmanaged[Cdecl]<int, SDL_GameController*> SDL_GameControllerOpen;
-        public delegate* unmanaged[Cdecl]<int, CString> SDL_GameControllerMappingForDeviceIndex;
-        public delegate* unmanaged[Cdecl]<int, SDL_GameControllerType> SDL_GameControllerTypeForIndex;
-        public delegate* unmanaged[Cdecl]<int, CString> SDL_GameControllerNameForIndex;
-        public delegate* unmanaged[Cdecl]<int, CBool> SDL_IsGameController;
-        public delegate* unmanaged[Cdecl]<SDL_GameController*, CString> SDL_GameControllerMapping;
-        public delegate* unmanaged[Cdecl]<SDL_JoystickGUID, CString> SDL_GameControllerMappingForGUID;
-        public delegate* unmanaged[Cdecl]<int, CString> SDL_GameControllerMappingForIndex;
-        public delegate* unmanaged[Cdecl]<int> SDL_GameControllerNumMappings;
-        public delegate* unmanaged[Cdecl]<CString, int> SDL_GameControllerAddMapping;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, int, int> SDL_GameControllerAddMappingsFromRW;
-        public delegate* unmanaged[Cdecl]<void> SDL_SensorUpdate;
-        public delegate* unmanaged[Cdecl]<SDL_Sensor*, void> SDL_SensorClose;
-        public delegate* unmanaged[Cdecl]<SDL_Sensor*, float*, int, int> SDL_SensorGetData;
-        public delegate* unmanaged[Cdecl]<SDL_Sensor*, SDL_SensorID> SDL_SensorGetInstanceID;
-        public delegate* unmanaged[Cdecl]<SDL_Sensor*, int> SDL_SensorGetNonPortableType;
-        public delegate* unmanaged[Cdecl]<SDL_Sensor*, SDL_SensorType> SDL_SensorGetType;
-        public delegate* unmanaged[Cdecl]<SDL_Sensor*, CString> SDL_SensorGetName;
-        public delegate* unmanaged[Cdecl]<SDL_SensorID, SDL_Sensor*> SDL_SensorFromInstanceID;
-        public delegate* unmanaged[Cdecl]<int, SDL_Sensor*> SDL_SensorOpen;
-        public delegate* unmanaged[Cdecl]<int, SDL_SensorID> SDL_SensorGetDeviceInstanceID;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_SensorGetDeviceNonPortableType;
-        public delegate* unmanaged[Cdecl]<int, SDL_SensorType> SDL_SensorGetDeviceType;
-        public delegate* unmanaged[Cdecl]<int, CString> SDL_SensorGetDeviceName;
-        public delegate* unmanaged[Cdecl]<int> SDL_NumSensors;
-        public delegate* unmanaged[Cdecl]<void> SDL_UnlockSensors;
-        public delegate* unmanaged[Cdecl]<void> SDL_LockSensors;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickPowerLevel> SDL_JoystickCurrentPowerLevel;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, void> SDL_JoystickClose;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, byte, byte, byte, int> SDL_JoystickSetLED;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, CBool> SDL_JoystickHasLED;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort, ushort, uint, int> SDL_JoystickRumbleTriggers;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort, ushort, uint, int> SDL_JoystickRumble;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte> SDL_JoystickGetButton;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int, long*, long*, int> SDL_JoystickGetBall;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte> SDL_JoystickGetHat;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int, short*, CBool> SDL_JoystickGetAxisInitialState;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int, short> SDL_JoystickGetAxis;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_JoystickEventState;
-        public delegate* unmanaged[Cdecl]<void> SDL_JoystickUpdate;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int> SDL_JoystickNumButtons;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int> SDL_JoystickNumHats;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int> SDL_JoystickNumBalls;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int> SDL_JoystickNumAxes;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickID> SDL_JoystickInstanceID;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, CBool> SDL_JoystickGetAttached;
-        public delegate* unmanaged[Cdecl]<CString, SDL_JoystickGUID> SDL_JoystickGetGUIDFromString;
-        public delegate* unmanaged[Cdecl]<SDL_JoystickGUID, CString, int, void> SDL_JoystickGetGUIDString;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickType> SDL_JoystickGetType;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, CString> SDL_JoystickGetSerial;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort> SDL_JoystickGetProductVersion;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort> SDL_JoystickGetProduct;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, ushort> SDL_JoystickGetVendor;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, SDL_JoystickGUID> SDL_JoystickGetGUID;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int, void> SDL_JoystickSetPlayerIndex;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int> SDL_JoystickGetPlayerIndex;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, CString> SDL_JoystickName;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte, int> SDL_JoystickSetVirtualHat;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int, byte, int> SDL_JoystickSetVirtualButton;
-        public delegate* unmanaged[Cdecl]<SDL_Joystick*, int, short, int> SDL_JoystickSetVirtualAxis;
-        public delegate* unmanaged[Cdecl]<int, CBool> SDL_JoystickIsVirtual;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_JoystickDetachVirtual;
-        public delegate* unmanaged[Cdecl]<SDL_JoystickType, int, int, int, int> SDL_JoystickAttachVirtual;
-        public delegate* unmanaged[Cdecl]<int, SDL_Joystick*> SDL_JoystickFromPlayerIndex;
-        public delegate* unmanaged[Cdecl]<SDL_JoystickID, SDL_Joystick*> SDL_JoystickFromInstanceID;
-        public delegate* unmanaged[Cdecl]<int, SDL_Joystick*> SDL_JoystickOpen;
-        public delegate* unmanaged[Cdecl]<int, SDL_JoystickID> SDL_JoystickGetDeviceInstanceID;
-        public delegate* unmanaged[Cdecl]<int, SDL_JoystickType> SDL_JoystickGetDeviceType;
-        public delegate* unmanaged[Cdecl]<int, ushort> SDL_JoystickGetDeviceProductVersion;
-        public delegate* unmanaged[Cdecl]<int, ushort> SDL_JoystickGetDeviceProduct;
-        public delegate* unmanaged[Cdecl]<int, ushort> SDL_JoystickGetDeviceVendor;
-        public delegate* unmanaged[Cdecl]<int, SDL_JoystickGUID> SDL_JoystickGetDeviceGUID;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_JoystickGetDevicePlayerIndex;
-        public delegate* unmanaged[Cdecl]<int, CString> SDL_JoystickNameForIndex;
-        public delegate* unmanaged[Cdecl]<int> SDL_NumJoysticks;
-        public delegate* unmanaged[Cdecl]<void> SDL_UnlockJoysticks;
-        public delegate* unmanaged[Cdecl]<void> SDL_LockJoysticks;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_ShowCursor;
-        public delegate* unmanaged[Cdecl]<SDL_Cursor*, void> SDL_FreeCursor;
-        public delegate* unmanaged[Cdecl]<SDL_Cursor*> SDL_GetDefaultCursor;
-        public delegate* unmanaged[Cdecl]<SDL_Cursor*> SDL_GetCursor;
-        public delegate* unmanaged[Cdecl]<SDL_Cursor*, void> SDL_SetCursor;
-        public delegate* unmanaged[Cdecl]<SDL_SystemCursor, SDL_Cursor*> SDL_CreateSystemCursor;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, int, int, SDL_Cursor*> SDL_CreateColorCursor;
-        public delegate* unmanaged[Cdecl]<byte*, byte*, int, int, int, int, SDL_Cursor*> SDL_CreateCursor;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_GetRelativeMouseMode;
-        public delegate* unmanaged[Cdecl]<CBool, int> SDL_CaptureMouse;
-        public delegate* unmanaged[Cdecl]<CBool, int> SDL_SetRelativeMouseMode;
-        public delegate* unmanaged[Cdecl]<int, int, int> SDL_WarpMouseGlobal;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void> SDL_WarpMouseInWindow;
-        public delegate* unmanaged[Cdecl]<long*, long*, uint> SDL_GetRelativeMouseState;
-        public delegate* unmanaged[Cdecl]<long*, long*, uint> SDL_GetGlobalMouseState;
-        public delegate* unmanaged[Cdecl]<long*, long*, uint> SDL_GetMouseState;
-        public delegate* unmanaged[Cdecl]<SDL_Window*> SDL_GetMouseFocus;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool> SDL_IsScreenKeyboardShown;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasScreenKeyboardSupport;
-        public delegate* unmanaged[Cdecl]<SDL_Rect*, void> SDL_SetTextInputRect;
-        public delegate* unmanaged[Cdecl]<void> SDL_StopTextInput;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_IsTextInputActive;
-        public delegate* unmanaged[Cdecl]<void> SDL_StartTextInput;
-        public delegate* unmanaged[Cdecl]<CString, SDL_Keycode> SDL_GetKeyFromName;
-        public delegate* unmanaged[Cdecl]<SDL_Keycode, CString> SDL_GetKeyName;
-        public delegate* unmanaged[Cdecl]<CString, SDL_Scancode> SDL_GetScancodeFromName;
-        public delegate* unmanaged[Cdecl]<SDL_Scancode, CString> SDL_GetScancodeName;
-        public delegate* unmanaged[Cdecl]<SDL_Keycode, SDL_Scancode> SDL_GetScancodeFromKey;
-        public delegate* unmanaged[Cdecl]<SDL_Scancode, SDL_Keycode> SDL_GetKeyFromScancode;
-        public delegate* unmanaged[Cdecl]<SDL_Keymod, void> SDL_SetModState;
-        public delegate* unmanaged[Cdecl]<SDL_Keymod> SDL_GetModState;
-        public delegate* unmanaged[Cdecl]<long*, byte*> SDL_GetKeyboardState;
-        public delegate* unmanaged[Cdecl]<SDL_Window*> SDL_GetKeyboardFocus;
-        public delegate* unmanaged[Cdecl]<SDL_GLContext, void> SDL_GL_DeleteContext;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, void> SDL_GL_SwapWindow;
-        public delegate* unmanaged[Cdecl]<int> SDL_GL_GetSwapInterval;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_GL_SetSwapInterval;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void> SDL_GL_GetDrawableSize;
-        public delegate* unmanaged[Cdecl]<SDL_GLContext> SDL_GL_GetCurrentContext;
-        public delegate* unmanaged[Cdecl]<SDL_Window*> SDL_GL_GetCurrentWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_GLContext, int> SDL_GL_MakeCurrent;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_GLContext> SDL_GL_CreateContext;
-        public delegate* unmanaged[Cdecl]<SDL_GLattr, long*, int> SDL_GL_GetAttribute;
-        public delegate* unmanaged[Cdecl]<SDL_GLattr, int, int> SDL_GL_SetAttribute;
-        public delegate* unmanaged[Cdecl]<void> SDL_GL_ResetAttributes;
-        public delegate* unmanaged[Cdecl]<CString, CBool> SDL_GL_ExtensionSupported;
-        public delegate* unmanaged[Cdecl]<void> SDL_GL_UnloadLibrary;
-        public delegate* unmanaged[Cdecl]<CString, void*> SDL_GL_GetProcAddress;
-        public delegate* unmanaged[Cdecl]<CString, int> SDL_GL_LoadLibrary;
-        public delegate* unmanaged[Cdecl]<void> SDL_DisableScreenSaver;
-        public delegate* unmanaged[Cdecl]<void> SDL_EnableScreenSaver;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_IsScreenSaverEnabled;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, void> SDL_DestroyWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_HitTest, void*, int> SDL_SetWindowHitTest;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, ushort*, ushort*, ushort*, int> SDL_GetWindowGammaRamp;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, ushort*, ushort*, ushort*, int> SDL_SetWindowGammaRamp;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, int> SDL_SetWindowInputFocus;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Window*, int> SDL_SetWindowModalFor;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, float*, int> SDL_GetWindowOpacity;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, float, int> SDL_SetWindowOpacity;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, float> SDL_GetWindowBrightness;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, float, int> SDL_SetWindowBrightness;
-        public delegate* unmanaged[Cdecl]<SDL_Window*> SDL_GetGrabbedWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool> SDL_GetWindowMouseGrab;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool> SDL_GetWindowKeyboardGrab;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool> SDL_GetWindowGrab;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void> SDL_SetWindowMouseGrab;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void> SDL_SetWindowKeyboardGrab;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void> SDL_SetWindowGrab;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Rect*, int, int> SDL_UpdateWindowSurfaceRects;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, int> SDL_UpdateWindowSurface;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Surface*> SDL_GetWindowSurface;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, uint, int> SDL_SetWindowFullscreen;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, void> SDL_RestoreWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, void> SDL_MinimizeWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, void> SDL_MaximizeWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, void> SDL_RaiseWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, void> SDL_HideWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, void> SDL_ShowWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void> SDL_SetWindowAlwaysOnTop;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void> SDL_SetWindowResizable;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CBool, void> SDL_SetWindowBordered;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void> SDL_GetWindowMaximumSize;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void> SDL_SetWindowMaximumSize;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void> SDL_GetWindowMinimumSize;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void> SDL_SetWindowMinimumSize;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, long*, long*, int> SDL_GetWindowBordersSize;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void> SDL_GetWindowSize;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void> SDL_SetWindowSize;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, long*, long*, void> SDL_GetWindowPosition;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, int, int, void> SDL_SetWindowPosition;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CString, void*> SDL_GetWindowData;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CString, void*, void*> SDL_SetWindowData;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_Surface*, void> SDL_SetWindowIcon;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CString> SDL_GetWindowTitle;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, CString, void> SDL_SetWindowTitle;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, uint> SDL_GetWindowFlags;
-        public delegate* unmanaged[Cdecl]<uint, SDL_Window*> SDL_GetWindowFromID;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, uint> SDL_GetWindowID;
-        public delegate* unmanaged[Cdecl]<void*, SDL_Window*> SDL_CreateWindowFrom;
-        public delegate* unmanaged[Cdecl]<CString, int, int, int, int, uint, SDL_Window*> SDL_CreateWindow;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, uint> SDL_GetWindowPixelFormat;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_DisplayMode*, int> SDL_GetWindowDisplayMode;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, SDL_DisplayMode*, int> SDL_SetWindowDisplayMode;
-        public delegate* unmanaged[Cdecl]<SDL_Window*, int> SDL_GetWindowDisplayIndex;
-        public delegate* unmanaged[Cdecl]<int, SDL_DisplayMode*, SDL_DisplayMode*, SDL_DisplayMode*> SDL_GetClosestDisplayMode;
-        public delegate* unmanaged[Cdecl]<int, SDL_DisplayMode*, int> SDL_GetCurrentDisplayMode;
-        public delegate* unmanaged[Cdecl]<int, SDL_DisplayMode*, int> SDL_GetDesktopDisplayMode;
-        public delegate* unmanaged[Cdecl]<int, int, SDL_DisplayMode*, int> SDL_GetDisplayMode;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_GetNumDisplayModes;
-        public delegate* unmanaged[Cdecl]<int, SDL_DisplayOrientation> SDL_GetDisplayOrientation;
-        public delegate* unmanaged[Cdecl]<int, float*, float*, float*, int> SDL_GetDisplayDPI;
-        public delegate* unmanaged[Cdecl]<int, SDL_Rect*, int> SDL_GetDisplayUsableBounds;
-        public delegate* unmanaged[Cdecl]<int, SDL_Rect*, int> SDL_GetDisplayBounds;
-        public delegate* unmanaged[Cdecl]<int, CString> SDL_GetDisplayName;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetNumVideoDisplays;
-        public delegate* unmanaged[Cdecl]<CString> SDL_GetCurrentVideoDriver;
-        public delegate* unmanaged[Cdecl]<void> SDL_VideoQuit;
-        public delegate* unmanaged[Cdecl]<CString, int> SDL_VideoInit;
-        public delegate* unmanaged[Cdecl]<int, CString> SDL_GetVideoDriver;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetNumVideoDrivers;
-        public delegate* unmanaged[Cdecl]<int, int, SDL_YUV_CONVERSION_MODE> SDL_GetYUVConversionModeForResolution;
-        public delegate* unmanaged[Cdecl]<SDL_YUV_CONVERSION_MODE> SDL_GetYUVConversionMode;
-        public delegate* unmanaged[Cdecl]<SDL_YUV_CONVERSION_MODE, void> SDL_SetYUVConversionMode;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int> SDL_LowerBlitScaled;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int> SDL_UpperBlitScaled;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int> SDL_SoftStretchLinear;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int> SDL_SoftStretch;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int> SDL_LowerBlit;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, SDL_Surface*, SDL_Rect*, int> SDL_UpperBlit;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, int, uint, int> SDL_FillRects;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, uint, int> SDL_FillRect;
-        public delegate* unmanaged[Cdecl]<int, int, uint, void*, int, uint, void*, int, int> SDL_ConvertPixels;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, uint, uint, SDL_Surface*> SDL_ConvertSurfaceFormat;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_PixelFormat*, uint, SDL_Surface*> SDL_ConvertSurface;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Surface*> SDL_DuplicateSurface;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, void> SDL_GetClipRect;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Rect*, CBool> SDL_SetClipRect;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_BlendMode*, int> SDL_GetSurfaceBlendMode;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_BlendMode, int> SDL_SetSurfaceBlendMode;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, byte*, int> SDL_GetSurfaceAlphaMod;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, byte, int> SDL_SetSurfaceAlphaMod;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, byte*, byte*, byte*, int> SDL_GetSurfaceColorMod;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, byte, byte, byte, int> SDL_SetSurfaceColorMod;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, uint*, int> SDL_GetColorKey;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, CBool> SDL_HasColorKey;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, int, uint, int> SDL_SetColorKey;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, CBool> SDL_HasSurfaceRLE;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, int, int> SDL_SetSurfaceRLE;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_RWops*, int, int> SDL_SaveBMP_RW;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, int, SDL_Surface*> SDL_LoadBMP_RW;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, void> SDL_UnlockSurface;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, int> SDL_LockSurface;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, SDL_Palette*, int> SDL_SetSurfacePalette;
-        public delegate* unmanaged[Cdecl]<SDL_Surface*, void> SDL_FreeSurface;
-        public delegate* unmanaged[Cdecl]<void*, int, int, int, int, uint, SDL_Surface*> SDL_CreateRGBSurfaceWithFormatFrom;
-        public delegate* unmanaged[Cdecl]<void*, int, int, int, int, uint, uint, uint, uint, SDL_Surface*> SDL_CreateRGBSurfaceFrom;
-        public delegate* unmanaged[Cdecl]<uint, int, int, int, uint, SDL_Surface*> SDL_CreateRGBSurfaceWithFormat;
-        public delegate* unmanaged[Cdecl]<uint, int, int, int, uint, uint, uint, uint, SDL_Surface*> SDL_CreateRGBSurface;
-        public delegate* unmanaged[Cdecl]<SDL_BlendFactor, SDL_BlendFactor, SDL_BlendOperation, SDL_BlendFactor, SDL_BlendFactor, SDL_BlendOperation, SDL_BlendMode> SDL_ComposeCustomBlendMode;
-        public delegate* unmanaged[Cdecl]<SDL_Rect*, long*, long*, long*, long*, CBool> SDL_IntersectRectAndLine;
-        public delegate* unmanaged[Cdecl]<SDL_Point*, int, SDL_Rect*, SDL_Rect*, CBool> SDL_EnclosePoints;
-        public delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, SDL_Rect*, void> SDL_UnionRect;
-        public delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, SDL_Rect*, CBool> SDL_IntersectRect;
-        public delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, CBool> SDL_HasIntersection;
-        public delegate* unmanaged[Cdecl]<SDL_Rect*, SDL_Rect*, CBool> SDL_RectEquals;
-        public delegate* unmanaged[Cdecl]<SDL_Rect*, CBool> SDL_RectEmpty;
-        public delegate* unmanaged[Cdecl]<SDL_Point*, SDL_Rect*, CBool> SDL_PointInRect;
-        public delegate* unmanaged[Cdecl]<float, ushort*, void> SDL_CalculateGammaRamp;
-        public delegate* unmanaged[Cdecl]<uint, SDL_PixelFormat*, byte*, byte*, byte*, byte*, void> SDL_GetRGBA;
-        public delegate* unmanaged[Cdecl]<uint, SDL_PixelFormat*, byte*, byte*, byte*, void> SDL_GetRGB;
-        public delegate* unmanaged[Cdecl]<SDL_PixelFormat*, byte, byte, byte, byte, uint> SDL_MapRGBA;
-        public delegate* unmanaged[Cdecl]<SDL_PixelFormat*, byte, byte, byte, uint> SDL_MapRGB;
-        public delegate* unmanaged[Cdecl]<SDL_Palette*, void> SDL_FreePalette;
-        public delegate* unmanaged[Cdecl]<SDL_Palette*, SDL_Color*, int, int, int> SDL_SetPaletteColors;
-        public delegate* unmanaged[Cdecl]<SDL_PixelFormat*, SDL_Palette*, int> SDL_SetPixelFormatPalette;
-        public delegate* unmanaged[Cdecl]<int, SDL_Palette*> SDL_AllocPalette;
-        public delegate* unmanaged[Cdecl]<SDL_PixelFormat*, void> SDL_FreeFormat;
-        public delegate* unmanaged[Cdecl]<uint, SDL_PixelFormat*> SDL_AllocFormat;
-        public delegate* unmanaged[Cdecl]<int, uint, uint, uint, uint, uint> SDL_MasksToPixelFormatEnum;
-        public delegate* unmanaged[Cdecl]<uint, long*, uint*, uint*, uint*, uint*, CBool> SDL_PixelFormatEnumToMasks;
-        public delegate* unmanaged[Cdecl]<uint, CString> SDL_GetPixelFormatName;
-        public delegate* unmanaged[Cdecl]<void*, void> SDL_SIMDFree;
-        public delegate* unmanaged[Cdecl]<void*, ulong, void*> SDL_SIMDRealloc;
-        public delegate* unmanaged[Cdecl]<ulong, void*> SDL_SIMDAlloc;
-        public delegate* unmanaged[Cdecl]<ulong> SDL_SIMDGetAlignment;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetSystemRAM;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasNEON;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasARMSIMD;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasAVX512F;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasAVX2;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasAVX;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasSSE42;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasSSE41;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasSSE3;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasSSE2;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasSSE;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_Has3DNow;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasMMX;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasAltiVec;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasRDTSC;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetCPUCacheLineSize;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetCPUCount;
-        public delegate* unmanaged[Cdecl]<CBool> SDL_HasClipboardText;
-        public delegate* unmanaged[Cdecl]<CString> SDL_GetClipboardText;
-        public delegate* unmanaged[Cdecl]<CString, int> SDL_SetClipboardText;
-        public delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void> SDL_CloseAudioDevice;
-        public delegate* unmanaged[Cdecl]<void> SDL_CloseAudio;
-        public delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void> SDL_UnlockAudioDevice;
-        public delegate* unmanaged[Cdecl]<void> SDL_UnlockAudio;
-        public delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void> SDL_LockAudioDevice;
-        public delegate* unmanaged[Cdecl]<void> SDL_LockAudio;
-        public delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void> SDL_ClearQueuedAudio;
-        public delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, uint> SDL_GetQueuedAudioSize;
-        public delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void*, uint, uint> SDL_DequeueAudio;
-        public delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, void*, uint, int> SDL_QueueAudio;
-        public delegate* unmanaged[Cdecl]<byte*, byte*, SDL_AudioFormat, uint, int, void> SDL_MixAudioFormat;
-        public delegate* unmanaged[Cdecl]<byte*, byte*, uint, int, void> SDL_MixAudio;
-        public delegate* unmanaged[Cdecl]<SDL_AudioStream*, void> SDL_FreeAudioStream;
-        public delegate* unmanaged[Cdecl]<SDL_AudioStream*, void> SDL_AudioStreamClear;
-        public delegate* unmanaged[Cdecl]<SDL_AudioStream*, int> SDL_AudioStreamFlush;
-        public delegate* unmanaged[Cdecl]<SDL_AudioStream*, int> SDL_AudioStreamAvailable;
-        public delegate* unmanaged[Cdecl]<SDL_AudioStream*, void*, int, int> SDL_AudioStreamGet;
-        public delegate* unmanaged[Cdecl]<SDL_AudioStream*, void*, int, int> SDL_AudioStreamPut;
-        public delegate* unmanaged[Cdecl]<SDL_AudioFormat, byte, int, SDL_AudioFormat, byte, int, SDL_AudioStream*> SDL_NewAudioStream;
-        public delegate* unmanaged[Cdecl]<SDL_AudioCVT*, int> SDL_ConvertAudio;
-        public delegate* unmanaged[Cdecl]<SDL_AudioCVT*, SDL_AudioFormat, byte, int, SDL_AudioFormat, byte, int, int> SDL_BuildAudioCVT;
-        public delegate* unmanaged[Cdecl]<byte*, void> SDL_FreeWAV;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, int, SDL_AudioSpec*, byte**, uint*, SDL_AudioSpec*> SDL_LoadWAV_RW;
-        public delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, int, void> SDL_PauseAudioDevice;
-        public delegate* unmanaged[Cdecl]<int, void> SDL_PauseAudio;
-        public delegate* unmanaged[Cdecl]<SDL_AudioDeviceID, SDL_AudioStatus> SDL_GetAudioDeviceStatus;
-        public delegate* unmanaged[Cdecl]<SDL_AudioStatus> SDL_GetAudioStatus;
-        public delegate* unmanaged[Cdecl]<CString, int, SDL_AudioSpec*, SDL_AudioSpec*, int, SDL_AudioDeviceID> SDL_OpenAudioDevice;
-        public delegate* unmanaged[Cdecl]<int, int, SDL_AudioSpec*, int> SDL_GetAudioDeviceSpec;
-        public delegate* unmanaged[Cdecl]<int, int, CString> SDL_GetAudioDeviceName;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_GetNumAudioDevices;
-        public delegate* unmanaged[Cdecl]<SDL_AudioSpec*, SDL_AudioSpec*, int> SDL_OpenAudio;
-        public delegate* unmanaged[Cdecl]<CString> SDL_GetCurrentAudioDriver;
-        public delegate* unmanaged[Cdecl]<void> SDL_AudioQuit;
-        public delegate* unmanaged[Cdecl]<CString, int> SDL_AudioInit;
-        public delegate* unmanaged[Cdecl]<int, CString> SDL_GetAudioDriver;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetNumAudioDrivers;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, ulong, ulong> SDL_WriteBE64;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, ulong, ulong> SDL_WriteLE64;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, uint, ulong> SDL_WriteBE32;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, uint, ulong> SDL_WriteLE32;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, ushort, ulong> SDL_WriteBE16;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, ushort, ulong> SDL_WriteLE16;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, byte, ulong> SDL_WriteU8;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, ulong> SDL_ReadBE64;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, ulong> SDL_ReadLE64;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, uint> SDL_ReadBE32;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, uint> SDL_ReadLE32;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, ushort> SDL_ReadBE16;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, ushort> SDL_ReadLE16;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, byte> SDL_ReadU8;
-        public delegate* unmanaged[Cdecl]<CString, ulong*, void*> SDL_LoadFile;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, ulong*, int, void*> SDL_LoadFile_RW;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, int> SDL_RWclose;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, void*, ulong, ulong, ulong> SDL_RWwrite;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, void*, ulong, ulong, ulong> SDL_RWread;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, long> SDL_RWtell;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, long, int, long> SDL_RWseek;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, long> SDL_RWsize;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*, void> SDL_FreeRW;
-        public delegate* unmanaged[Cdecl]<SDL_RWops*> SDL_AllocRW;
-        public delegate* unmanaged[Cdecl]<void*, int, SDL_RWops*> SDL_RWFromConstMem;
-        public delegate* unmanaged[Cdecl]<void*, int, SDL_RWops*> SDL_RWFromMem;
-        public delegate* unmanaged[Cdecl]<void*, CBool, SDL_RWops*> SDL_RWFromFP;
-        public delegate* unmanaged[Cdecl]<CString, CString, SDL_RWops*> SDL_RWFromFile;
-        public delegate* unmanaged[Cdecl]<void> SDL_TLSCleanup;
-        public delegate* unmanaged[Cdecl]<SDL_TLSID, void*, FnPtr_SDL_VoidPtr_Void, int> SDL_TLSSet;
-        public delegate* unmanaged[Cdecl]<SDL_TLSID, void*> SDL_TLSGet;
-        public delegate* unmanaged[Cdecl]<SDL_TLSID> SDL_TLSCreate;
-        public delegate* unmanaged[Cdecl]<SDL_Thread*, void> SDL_DetachThread;
-        public delegate* unmanaged[Cdecl]<SDL_Thread*, long*, void> SDL_WaitThread;
-        public delegate* unmanaged[Cdecl]<SDL_ThreadPriority, int> SDL_SetThreadPriority;
-        public delegate* unmanaged[Cdecl]<SDL_Thread*, SDL_threadID> SDL_GetThreadID;
-        public delegate* unmanaged[Cdecl]<SDL_threadID> SDL_ThreadID;
-        public delegate* unmanaged[Cdecl]<SDL_Thread*, CString> SDL_GetThreadName;
-        public delegate* unmanaged[Cdecl]<FnPtr_SDL_VoidPtr_Int, CString, ulong, void*, pfnSDL_CurrentBeginThread, pfnSDL_CurrentEndThread, SDL_Thread*> SDL_CreateThreadWithStackSize;
-        public delegate* unmanaged[Cdecl]<SDL_ThreadFunction, CString, void*, pfnSDL_CurrentBeginThread, pfnSDL_CurrentEndThread, SDL_Thread*> SDL_CreateThread;
-        public delegate* unmanaged[Cdecl]<SDL_cond*, SDL_mutex*, uint, int> SDL_CondWaitTimeout;
-        public delegate* unmanaged[Cdecl]<SDL_cond*, SDL_mutex*, int> SDL_CondWait;
-        public delegate* unmanaged[Cdecl]<SDL_cond*, int> SDL_CondBroadcast;
-        public delegate* unmanaged[Cdecl]<SDL_cond*, int> SDL_CondSignal;
-        public delegate* unmanaged[Cdecl]<SDL_cond*, void> SDL_DestroyCond;
-        public delegate* unmanaged[Cdecl]<SDL_cond*> SDL_CreateCond;
-        public delegate* unmanaged[Cdecl]<SDL_sem*, uint> SDL_SemValue;
-        public delegate* unmanaged[Cdecl]<SDL_sem*, int> SDL_SemPost;
-        public delegate* unmanaged[Cdecl]<SDL_sem*, uint, int> SDL_SemWaitTimeout;
-        public delegate* unmanaged[Cdecl]<SDL_sem*, int> SDL_SemTryWait;
-        public delegate* unmanaged[Cdecl]<SDL_sem*, int> SDL_SemWait;
-        public delegate* unmanaged[Cdecl]<SDL_sem*, void> SDL_DestroySemaphore;
-        public delegate* unmanaged[Cdecl]<uint, SDL_sem*> SDL_CreateSemaphore;
-        public delegate* unmanaged[Cdecl]<SDL_mutex*, void> SDL_DestroyMutex;
-        public delegate* unmanaged[Cdecl]<SDL_mutex*, int> SDL_UnlockMutex;
-        public delegate* unmanaged[Cdecl]<SDL_mutex*, int> SDL_TryLockMutex;
-        public delegate* unmanaged[Cdecl]<SDL_mutex*, int> SDL_LockMutex;
-        public delegate* unmanaged[Cdecl]<SDL_mutex*> SDL_CreateMutex;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_SwapFloat;
-        public delegate* unmanaged[Cdecl]<SDL_errorcode, int> SDL_Error;
-        public delegate* unmanaged[Cdecl]<void> SDL_ClearError;
-        public delegate* unmanaged[Cdecl]<CString, int, CString> SDL_GetErrorMsg;
-        public delegate* unmanaged[Cdecl]<CString> SDL_GetError;
-        public delegate* unmanaged[Cdecl]<CString, int> SDL_SetError;
-        public delegate* unmanaged[Cdecl]<void**, void*> SDL_AtomicGetPtr;
-        public delegate* unmanaged[Cdecl]<void**, void*, void*> SDL_AtomicSetPtr;
-        public delegate* unmanaged[Cdecl]<void**, void*, void*, CBool> SDL_AtomicCASPtr;
-        public delegate* unmanaged[Cdecl]<SDL_atomic_t*, int, int> SDL_AtomicAdd;
-        public delegate* unmanaged[Cdecl]<SDL_atomic_t*, int> SDL_AtomicGet;
-        public delegate* unmanaged[Cdecl]<SDL_atomic_t*, int, int> SDL_AtomicSet;
-        public delegate* unmanaged[Cdecl]<SDL_atomic_t*, int, int, CBool> SDL_AtomicCAS;
-        public delegate* unmanaged[Cdecl]<void> SDL_MemoryBarrierAcquireFunction;
-        public delegate* unmanaged[Cdecl]<void> SDL_MemoryBarrierReleaseFunction;
-        public delegate* unmanaged[Cdecl]<SDL_SpinLock*, void> SDL_AtomicUnlock;
-        public delegate* unmanaged[Cdecl]<SDL_SpinLock*, void> SDL_AtomicLock;
-        public delegate* unmanaged[Cdecl]<SDL_SpinLock*, CBool> SDL_AtomicTryLock;
-        public delegate* unmanaged[Cdecl]<void> SDL_ResetAssertionReport;
-        public delegate* unmanaged[Cdecl]<SDL_AssertData*> SDL_GetAssertionReport;
-        public delegate* unmanaged[Cdecl]<void**, SDL_AssertionHandler> SDL_GetAssertionHandler;
-        public delegate* unmanaged[Cdecl]<SDL_AssertionHandler> SDL_GetDefaultAssertionHandler;
-        public delegate* unmanaged[Cdecl]<SDL_AssertionHandler, void*, void> SDL_SetAssertionHandler;
-        public delegate* unmanaged[Cdecl]<SDL_AssertData*, CString, CString, int, SDL_AssertState> SDL_ReportAssertion;
-        public delegate* unmanaged[Cdecl]<void> __debugbreak;
-        public delegate* unmanaged[Cdecl]<void*, void*, ulong, void*> SDL_memcpy4;
-        public delegate* unmanaged[Cdecl]<CString, CString, CString, ulong, CString> SDL_iconv_string;
-        public delegate* unmanaged[Cdecl]<SDL_iconv_t, CString*, ulong*, CString*, ulong*, ulong> SDL_iconv;
-        public delegate* unmanaged[Cdecl]<SDL_iconv_t, int> SDL_iconv_close;
-        public delegate* unmanaged[Cdecl]<CString, CString, SDL_iconv_t> SDL_iconv_open;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_tanf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_tan;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_sqrtf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_sqrt;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_sinf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_sin;
-        public delegate* unmanaged[Cdecl]<float, int, float> SDL_scalbnf;
-        public delegate* unmanaged[Cdecl]<double, int, double> SDL_scalbn;
-        public delegate* unmanaged[Cdecl]<float, int> SDL_lroundf;
-        public delegate* unmanaged[Cdecl]<double, int> SDL_lround;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_roundf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_round;
-        public delegate* unmanaged[Cdecl]<float, float, float> SDL_powf;
-        public delegate* unmanaged[Cdecl]<double, double, double> SDL_pow;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_log10f;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_log10;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_logf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_log;
-        public delegate* unmanaged[Cdecl]<float, float, float> SDL_fmodf;
-        public delegate* unmanaged[Cdecl]<double, double, double> SDL_fmod;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_truncf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_trunc;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_floorf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_floor;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_fabsf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_fabs;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_expf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_exp;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_cosf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_cos;
-        public delegate* unmanaged[Cdecl]<float, float, float> SDL_copysignf;
-        public delegate* unmanaged[Cdecl]<double, double, double> SDL_copysign;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_ceilf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_ceil;
-        public delegate* unmanaged[Cdecl]<float, float, float> SDL_atan2f;
-        public delegate* unmanaged[Cdecl]<double, double, double> SDL_atan2;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_atanf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_atan;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_asinf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_asin;
-        public delegate* unmanaged[Cdecl]<float, float> SDL_acosf;
-        public delegate* unmanaged[Cdecl]<double, double> SDL_acos;
-        public delegate* unmanaged[Cdecl]<CString, ulong, CString, IntPtr, int> SDL_vsnprintf;
-        public delegate* unmanaged[Cdecl]<CString, ulong, CString, int> SDL_snprintf;
-        public delegate* unmanaged[Cdecl]<CString, CString, IntPtr, int> SDL_vsscanf;
-        public delegate* unmanaged[Cdecl]<CString, CString, int> SDL_sscanf;
-        public delegate* unmanaged[Cdecl]<CString, CString, ulong, int> SDL_strncasecmp;
-        public delegate* unmanaged[Cdecl]<CString, CString, int> SDL_strcasecmp;
-        public delegate* unmanaged[Cdecl]<CString, CString, ulong, int> SDL_strncmp;
-        public delegate* unmanaged[Cdecl]<CString, CString, int> SDL_strcmp;
-        public delegate* unmanaged[Cdecl]<CString, CString*, double> SDL_strtod;
-        public delegate* unmanaged[Cdecl]<CString, CString*, int, ulong> SDL_strtoull;
-        public delegate* unmanaged[Cdecl]<CString, CString*, int, long> SDL_strtoll;
-        public delegate* unmanaged[Cdecl]<CString, CString*, int, uint> SDL_strtoul;
-        public delegate* unmanaged[Cdecl]<CString, CString*, int, int> SDL_strtol;
-        public delegate* unmanaged[Cdecl]<CString, double> SDL_atof;
-        public delegate* unmanaged[Cdecl]<CString, int> SDL_atoi;
-        public delegate* unmanaged[Cdecl]<ulong, CString, int, CString> SDL_ulltoa;
-        public delegate* unmanaged[Cdecl]<long, CString, int, CString> SDL_lltoa;
-        public delegate* unmanaged[Cdecl]<uint, CString, int, CString> SDL_ultoa;
-        public delegate* unmanaged[Cdecl]<int, CString, int, CString> SDL_ltoa;
-        public delegate* unmanaged[Cdecl]<uint, CString, int, CString> SDL_uitoa;
-        public delegate* unmanaged[Cdecl]<int, CString, int, CString> SDL_itoa;
-        public delegate* unmanaged[Cdecl]<CString, ulong> SDL_utf8strlen;
-        public delegate* unmanaged[Cdecl]<CString, CString, CString*, CString> SDL_strtokr;
-        public delegate* unmanaged[Cdecl]<CString, CString, CString> SDL_strstr;
-        public delegate* unmanaged[Cdecl]<CString, int, CString> SDL_strrchr;
-        public delegate* unmanaged[Cdecl]<CString, int, CString> SDL_strchr;
-        public delegate* unmanaged[Cdecl]<CString, CString> SDL_strlwr;
-        public delegate* unmanaged[Cdecl]<CString, CString> SDL_strupr;
-        public delegate* unmanaged[Cdecl]<CString, CString> SDL_strrev;
-        public delegate* unmanaged[Cdecl]<CString, CString> SDL_strdup;
-        public delegate* unmanaged[Cdecl]<CString, CString, ulong, ulong> SDL_strlcat;
-        public delegate* unmanaged[Cdecl]<CString, CString, ulong, ulong> SDL_utf8strlcpy;
-        public delegate* unmanaged[Cdecl]<CString, CString, ulong, ulong> SDL_strlcpy;
-        public delegate* unmanaged[Cdecl]<CString, ulong> SDL_strlen;
-        public delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, int> SDL_wcsncasecmp;
-        public delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, int> SDL_wcscasecmp;
-        public delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, int> SDL_wcsncmp;
-        public delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, int> SDL_wcscmp;
-        public delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, wchar_t*> SDL_wcsstr;
-        public delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*> SDL_wcsdup;
-        public delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, ulong> SDL_wcslcat;
-        public delegate* unmanaged[Cdecl]<wchar_t*, wchar_t*, ulong, ulong> SDL_wcslcpy;
-        public delegate* unmanaged[Cdecl]<wchar_t*, ulong> SDL_wcslen;
-        public delegate* unmanaged[Cdecl]<void*, void*, ulong, int> SDL_memcmp;
-        public delegate* unmanaged[Cdecl]<void*, void*, ulong, void*> SDL_memmove;
-        public delegate* unmanaged[Cdecl]<void*, void*, ulong, void*> SDL_memcpy;
-        public delegate* unmanaged[Cdecl]<void*, uint, ulong, void> SDL_memset4;
-        public delegate* unmanaged[Cdecl]<void*, int, ulong, void*> SDL_memset;
-        public delegate* unmanaged[Cdecl]<uint, void*, ulong, uint> SDL_crc32;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_tolower;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_toupper;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_isgraph;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_isprint;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_islower;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_isupper;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_isspace;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_ispunct;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_isxdigit;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_isdigit;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_iscntrl;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_isblank;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_isalnum;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_isalpha;
-        public delegate* unmanaged[Cdecl]<int, int> SDL_abs;
-        public delegate* unmanaged[Cdecl]<void*, ulong, ulong, FnPtr_SDL_VoidPtr_VoidPtr_Int, void> SDL_qsort;
-        public delegate* unmanaged[Cdecl]<CString, CString, int, int> SDL_setenv;
-        public delegate* unmanaged[Cdecl]<CString, CString> SDL_getenv;
-        public delegate* unmanaged[Cdecl]<int> SDL_GetNumAllocations;
-        public delegate* unmanaged[Cdecl]<SDL_malloc_func, SDL_calloc_func, SDL_realloc_func, SDL_free_func, int> SDL_SetMemoryFunctions;
-        public delegate* unmanaged[Cdecl]<SDL_malloc_func*, SDL_calloc_func*, SDL_realloc_func*, SDL_free_func*, void> SDL_GetMemoryFunctions;
-        public delegate* unmanaged[Cdecl]<void*, void> SDL_free;
-        public delegate* unmanaged[Cdecl]<void*, ulong, void*> SDL_realloc;
-        public delegate* unmanaged[Cdecl]<ulong, ulong, void*> SDL_calloc;
-        public delegate* unmanaged[Cdecl]<ulong, void*> SDL_malloc;
-        public delegate* unmanaged[Cdecl]<CString> SDL_GetPlatform;
-
-        #endregion
-
-        #region "Variables"
-        // These pointers hold the locations in the native library where global variables are located at runtime.
-        //	The value pointed by these pointers are updated by reading/writing memory.
-
-
-
-        #endregion
-    }
-
-    private static _VirtualTable _virtualTable;
 }

--- a/src/cs/production/C2CS/UseCases/BindgenCSharp/Data/CSharpAbstractSyntaxTree.cs
+++ b/src/cs/production/C2CS/UseCases/BindgenCSharp/Data/CSharpAbstractSyntaxTree.cs
@@ -19,8 +19,6 @@ namespace C2CS.UseCases.BindgenCSharp
 
         public readonly ImmutableArray<CSharpEnum> Enums;
 
-        public readonly ImmutableArray<CSharpVariable> VariablesExtern;
-
         public CSharpAbstractSyntaxTree(
             ImmutableArray<CSharpFunction> functionExterns,
             ImmutableArray<CSharpFunctionPointer> functionPointers,
@@ -36,7 +34,6 @@ namespace C2CS.UseCases.BindgenCSharp
             Typedefs = typedefs;
             OpaqueDataTypes = opaqueDataTypes;
             Enums = enums;
-            VariablesExtern = variablesExtern;
         }
     }
 }

--- a/src/cs/production/clang-c/ast.json
+++ b/src/cs/production/clang-c/ast.json
@@ -1,5 +1,5 @@
 {
-  "fileName": "clang-c\\Index.h",
+  "fileName": "clang-c/Index.h",
   "functions": [
     {
       "name": "clang_Type_visitFields",
@@ -7935,9 +7935,9 @@
           "name": "size",
           "type": "size_t*",
           "location": {
-            "file": "vcruntime.h",
-            "line": 193,
-            "column": 30,
+            "file": "_size_t.h",
+            "line": 31,
+            "column": 32,
             "isSystem": true
           }
         }
@@ -9778,7 +9778,6 @@
           "name": "Length",
           "type": "unsigned long",
           "offset": 16,
-          "padding": 4,
           "location": {
             "file": "Index.h",
             "line": 117,
@@ -10547,6 +10546,7 @@
         {
           "name": "kind",
           "type": "CXTUResourceUsageKind",
+          "padding": 4,
           "location": {
             "file": "Index.h",
             "line": 1609,
@@ -10556,7 +10556,7 @@
         {
           "name": "amount",
           "type": "unsigned long",
-          "offset": 4,
+          "offset": 8,
           "location": {
             "file": "Index.h",
             "line": 1644,
@@ -10627,7 +10627,7 @@
     {
       "name": "CXVisitorResult",
       "type": "CXVisitorResult",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXVisit_Break",
@@ -10656,7 +10656,7 @@
     {
       "name": "CXCursorKind",
       "type": "CXCursorKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXCursor_UnexposedDecl",
@@ -13053,7 +13053,7 @@
     {
       "name": "CXTypeKind",
       "type": "CXTypeKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXType_Invalid",
@@ -14144,7 +14144,7 @@
     {
       "name": "CXSymbolRole",
       "type": "CXSymbolRole",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXSymbolRole_None",
@@ -14245,7 +14245,7 @@
     {
       "name": "CXIdxAttrKind",
       "type": "CXIdxAttrKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXIdxAttr_Unexposed",
@@ -14292,7 +14292,7 @@
     {
       "name": "CXIdxEntityLanguage",
       "type": "CXIdxEntityLanguage",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXIdxEntityLang_None",
@@ -14348,7 +14348,7 @@
     {
       "name": "CXIdxEntityCXXTemplateKind",
       "type": "CXIdxEntityCXXTemplateKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXIdxEntity_NonTemplate",
@@ -14395,7 +14395,7 @@
     {
       "name": "CXIdxEntityKind",
       "type": "CXIdxEntityKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXIdxEntity_Unexposed",
@@ -14649,7 +14649,7 @@
     {
       "name": "CXIdxEntityRefKind",
       "type": "CXIdxEntityRefKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXIdxEntityRef_Direct",
@@ -14679,7 +14679,7 @@
     {
       "name": "CXIdxObjCContainerKind",
       "type": "CXIdxObjCContainerKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXIdxObjCContainer_ForwardRef",
@@ -14717,7 +14717,7 @@
     {
       "name": "CXResult",
       "type": "CXResult",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXResult_Success",
@@ -14755,7 +14755,7 @@
     {
       "name": "CXEvalResultKind",
       "type": "CXEvalResultKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXEval_Int",
@@ -14829,7 +14829,7 @@
     {
       "name": "CXAvailabilityKind",
       "type": "CXAvailabilityKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXAvailability_Available",
@@ -14876,7 +14876,7 @@
     {
       "name": "CXCompletionChunkKind",
       "type": "CXCompletionChunkKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXCompletionChunk_Optional",
@@ -15076,7 +15076,7 @@
     {
       "name": "CXTokenKind",
       "type": "CXTokenKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXToken_Punctuation",
@@ -15132,7 +15132,7 @@
     {
       "name": "CXPrintingPolicyProperty",
       "type": "CXPrintingPolicyProperty",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXPrintingPolicy_Indentation",
@@ -15386,7 +15386,7 @@
     {
       "name": "CXChildVisitResult",
       "type": "CXChildVisitResult",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXChildVisit_Break",
@@ -15424,7 +15424,7 @@
     {
       "name": "CX_StorageClass",
       "type": "CX_StorageClass",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CX_SC_Invalid",
@@ -15507,7 +15507,7 @@
     {
       "name": "CX_CXXAccessSpecifier",
       "type": "CX_CXXAccessSpecifier",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CX_CXXInvalidAccessSpecifier",
@@ -15554,7 +15554,7 @@
     {
       "name": "CXRefQualifierKind",
       "type": "CXRefQualifierKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXRefQualifier_None",
@@ -15592,7 +15592,7 @@
     {
       "name": "CXTypeNullabilityKind",
       "type": "CXTypeNullabilityKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXTypeNullability_NonNull",
@@ -15648,7 +15648,7 @@
     {
       "name": "CXCallingConv",
       "type": "CXCallingConv",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXCallingConv_Default",
@@ -15839,7 +15839,7 @@
     {
       "name": "CXTemplateArgumentKind",
       "type": "CXTemplateArgumentKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXTemplateArgumentKind_Null",
@@ -15940,7 +15940,7 @@
     {
       "name": "CXTLSKind",
       "type": "CXTLSKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXTLS_None",
@@ -15978,7 +15978,7 @@
     {
       "name": "CXLanguageKind",
       "type": "CXLanguageKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXLanguage_Invalid",
@@ -16025,7 +16025,7 @@
     {
       "name": "CXVisibilityKind",
       "type": "CXVisibilityKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXVisibility_Invalid",
@@ -16072,7 +16072,7 @@
     {
       "name": "CXLinkageKind",
       "type": "CXLinkageKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXLinkage_Invalid",
@@ -16128,7 +16128,7 @@
     {
       "name": "CXTUResourceUsageKind",
       "type": "CXTUResourceUsageKind",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXTUResourceUsage_AST",
@@ -16302,7 +16302,7 @@
     {
       "name": "CXErrorCode",
       "type": "CXErrorCode",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXError_Success",
@@ -16358,7 +16358,7 @@
     {
       "name": "CXDiagnosticSeverity",
       "type": "CXDiagnosticSeverity",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXDiagnostic_Ignored",
@@ -16414,7 +16414,7 @@
     {
       "name": "CXLoadDiag_Error",
       "type": "CXLoadDiag_Error",
-      "typeInteger": "int",
+      "typeInteger": "unsigned int",
       "values": [
         {
           "name": "CXLoadDiag_None",
@@ -16760,13 +16760,6 @@
       }
     },
     {
-      "name": "int",
-      "kind": "primitive",
-      "sizeOf": 4,
-      "alignOf": 4,
-      "isSystem": true
-    },
-    {
       "name": "CXCursorKind",
       "kind": "enum",
       "sizeOf": 4,
@@ -16776,6 +16769,13 @@
         "line": 1706,
         "column": 6
       }
+    },
+    {
+      "name": "int",
+      "kind": "primitive",
+      "sizeOf": 4,
+      "alignOf": 4,
+      "isSystem": true
     },
     {
       "name": "void*[3]",
@@ -17363,8 +17363,8 @@
     {
       "name": "unsigned long",
       "kind": "primitive",
-      "sizeOf": 4,
-      "alignOf": 4,
+      "sizeOf": 8,
+      "alignOf": 8,
       "isSystem": true
     },
     {
@@ -18261,8 +18261,8 @@
     {
       "name": "CXTUResourceUsageEntry",
       "kind": "typedef",
-      "sizeOf": 8,
-      "alignOf": 4,
+      "sizeOf": 16,
+      "alignOf": 8,
       "location": {
         "file": "Index.h",
         "line": 1645,

--- a/src/cs/production/clang-cs/clang.cs
+++ b/src/cs/production/clang-cs/clang.cs
@@ -20,2038 +20,1346 @@ using C2CS;
 public static unsafe partial class clang
 {
     private const string LibraryName = "clang";
-    private static IntPtr _libraryHandle;
-
-    static clang()
-    {
-        TryLoadApi();
-    }
-
-    public static bool TryLoadApi(string? libraryName = LibraryName)
-    {
-        UnloadApi();
-        _libraryHandle = Runtime.LibraryLoad(libraryName!);
-        if (_libraryHandle == IntPtr.Zero) return false;
-        _LoadVirtualTable();
-        return true;
-    }
-
-    public static void UnloadApi()
-    {
-        if (_libraryHandle == IntPtr.Zero) return;
-        _UnloadVirtualTable();
-        Runtime.LibraryUnload(_libraryHandle);
-    }
 
     // Function @ Index.h:6768:25
-    public static uint clang_Type_visitFields(CXType T, CXFieldVisitor visitor, CXClientData client_data)
-    {
-        return _virtualTable.clang_Type_visitFields(T, visitor, client_data);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Type_visitFields(CXType T, CXFieldVisitor visitor, CXClientData client_data);
 
     // Function @ Index.h:6733:18
-    public static CXSourceLocation clang_indexLoc_getCXSourceLocation(CXIdxLoc loc)
-    {
-        return _virtualTable.clang_indexLoc_getCXSourceLocation(loc);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceLocation clang_indexLoc_getCXSourceLocation(CXIdxLoc loc);
 
     // Function @ Index.h:6723:21
-    public static void clang_indexLoc_getFileLocation(CXIdxLoc loc, CXIdxClientFile* indexFile, CXFile* file, ulong* line, ulong* column, ulong* offset)
-    {
-        _virtualTable.clang_indexLoc_getFileLocation(loc, indexFile, file, line, column, offset);
-    }
+    [DllImport("clang")]
+    public static extern void clang_indexLoc_getFileLocation(CXIdxLoc loc, CXIdxClientFile* indexFile, CXFile* file, ulong* line, ulong* column, ulong* offset);
 
     // Function @ Index.h:6711:20
-    public static int clang_indexTranslationUnit(CXIndexAction param, CXClientData client_data, IndexerCallbacks* index_callbacks, uint index_callbacks_size, uint index_options, CXTranslationUnit param2)
-    {
-        return _virtualTable.clang_indexTranslationUnit(param, client_data, index_callbacks, index_callbacks_size, index_options, param2);
-    }
+    [DllImport("clang")]
+    public static extern int clang_indexTranslationUnit(CXIndexAction param, CXClientData client_data, IndexerCallbacks* index_callbacks, uint index_callbacks_size, uint index_options, CXTranslationUnit param2);
 
     // Function @ Index.h:6688:20
-    public static int clang_indexSourceFileFullArgv(CXIndexAction param, CXClientData client_data, IndexerCallbacks* index_callbacks, uint index_callbacks_size, uint index_options, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, CXTranslationUnit* out_TU, uint TU_options)
-    {
-        return _virtualTable.clang_indexSourceFileFullArgv(param, client_data, index_callbacks, index_callbacks_size, index_options, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, out_TU, TU_options);
-    }
+    [DllImport("clang")]
+    public static extern int clang_indexSourceFileFullArgv(CXIndexAction param, CXClientData client_data, IndexerCallbacks* index_callbacks, uint index_callbacks_size, uint index_options, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, CXTranslationUnit* out_TU, uint TU_options);
 
     // Function @ Index.h:6676:20
-    public static int clang_indexSourceFile(CXIndexAction param, CXClientData client_data, IndexerCallbacks* index_callbacks, uint index_callbacks_size, uint index_options, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, CXTranslationUnit* out_TU, uint TU_options)
-    {
-        return _virtualTable.clang_indexSourceFile(param, client_data, index_callbacks, index_callbacks_size, index_options, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, out_TU, TU_options);
-    }
+    [DllImport("clang")]
+    public static extern int clang_indexSourceFile(CXIndexAction param, CXClientData client_data, IndexerCallbacks* index_callbacks, uint index_callbacks_size, uint index_options, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, CXTranslationUnit* out_TU, uint TU_options);
 
     // Function @ Index.h:6610:21
-    public static void clang_IndexAction_dispose(CXIndexAction param)
-    {
-        _virtualTable.clang_IndexAction_dispose(param);
-    }
+    [DllImport("clang")]
+    public static extern void clang_IndexAction_dispose(CXIndexAction param);
 
     // Function @ Index.h:6602:30
-    public static CXIndexAction clang_IndexAction_create(CXIndex CIdx)
-    {
-        return _virtualTable.clang_IndexAction_create(CIdx);
-    }
+    [DllImport("clang")]
+    public static extern CXIndexAction clang_IndexAction_create(CXIndex CIdx);
 
     // Function @ Index.h:6587:21
-    public static void clang_index_setClientEntity(CXIdxEntityInfo* param, CXIdxClientEntity param2)
-    {
-        _virtualTable.clang_index_setClientEntity(param, param2);
-    }
+    [DllImport("clang")]
+    public static extern void clang_index_setClientEntity(CXIdxEntityInfo* param, CXIdxClientEntity param2);
 
     // Function @ Index.h:6582:1
-    public static CXIdxClientEntity clang_index_getClientEntity(CXIdxEntityInfo* param)
-    {
-        return _virtualTable.clang_index_getClientEntity(param);
-    }
+    [DllImport("clang")]
+    public static extern CXIdxClientEntity clang_index_getClientEntity(CXIdxEntityInfo* param);
 
     // Function @ Index.h:6575:21
-    public static void clang_index_setClientContainer(CXIdxContainerInfo* param, CXIdxClientContainer param2)
-    {
-        _virtualTable.clang_index_setClientContainer(param, param2);
-    }
+    [DllImport("clang")]
+    public static extern void clang_index_setClientContainer(CXIdxContainerInfo* param, CXIdxClientContainer param2);
 
     // Function @ Index.h:6569:1
-    public static CXIdxClientContainer clang_index_getClientContainer(CXIdxContainerInfo* param)
-    {
-        return _virtualTable.clang_index_getClientContainer(param);
-    }
+    [DllImport("clang")]
+    public static extern CXIdxClientContainer clang_index_getClientContainer(CXIdxContainerInfo* param);
 
     // Function @ Index.h:6562:1
-    public static CXIdxCXXClassDeclInfo* clang_index_getCXXClassDeclInfo(CXIdxDeclInfo* param)
-    {
-        return _virtualTable.clang_index_getCXXClassDeclInfo(param);
-    }
+    [DllImport("clang")]
+    public static extern CXIdxCXXClassDeclInfo* clang_index_getCXXClassDeclInfo(CXIdxDeclInfo* param);
 
     // Function @ Index.h:6559:1
-    public static CXIdxIBOutletCollectionAttrInfo* clang_index_getIBOutletCollectionAttrInfo(CXIdxAttrInfo* param)
-    {
-        return _virtualTable.clang_index_getIBOutletCollectionAttrInfo(param);
-    }
+    [DllImport("clang")]
+    public static extern CXIdxIBOutletCollectionAttrInfo* clang_index_getIBOutletCollectionAttrInfo(CXIdxAttrInfo* param);
 
     // Function @ Index.h:6556:1
-    public static CXIdxObjCPropertyDeclInfo* clang_index_getObjCPropertyDeclInfo(CXIdxDeclInfo* param)
-    {
-        return _virtualTable.clang_index_getObjCPropertyDeclInfo(param);
-    }
+    [DllImport("clang")]
+    public static extern CXIdxObjCPropertyDeclInfo* clang_index_getObjCPropertyDeclInfo(CXIdxDeclInfo* param);
 
     // Function @ Index.h:6553:1
-    public static CXIdxObjCProtocolRefListInfo* clang_index_getObjCProtocolRefListInfo(CXIdxDeclInfo* param)
-    {
-        return _virtualTable.clang_index_getObjCProtocolRefListInfo(param);
-    }
+    [DllImport("clang")]
+    public static extern CXIdxObjCProtocolRefListInfo* clang_index_getObjCProtocolRefListInfo(CXIdxDeclInfo* param);
 
     // Function @ Index.h:6550:1
-    public static CXIdxObjCCategoryDeclInfo* clang_index_getObjCCategoryDeclInfo(CXIdxDeclInfo* param)
-    {
-        return _virtualTable.clang_index_getObjCCategoryDeclInfo(param);
-    }
+    [DllImport("clang")]
+    public static extern CXIdxObjCCategoryDeclInfo* clang_index_getObjCCategoryDeclInfo(CXIdxDeclInfo* param);
 
     // Function @ Index.h:6546:1
-    public static CXIdxObjCInterfaceDeclInfo* clang_index_getObjCInterfaceDeclInfo(CXIdxDeclInfo* param)
-    {
-        return _virtualTable.clang_index_getObjCInterfaceDeclInfo(param);
-    }
+    [DllImport("clang")]
+    public static extern CXIdxObjCInterfaceDeclInfo* clang_index_getObjCInterfaceDeclInfo(CXIdxDeclInfo* param);
 
     // Function @ Index.h:6543:1
-    public static CXIdxObjCContainerDeclInfo* clang_index_getObjCContainerDeclInfo(CXIdxDeclInfo* param)
-    {
-        return _virtualTable.clang_index_getObjCContainerDeclInfo(param);
-    }
+    [DllImport("clang")]
+    public static extern CXIdxObjCContainerDeclInfo* clang_index_getObjCContainerDeclInfo(CXIdxDeclInfo* param);
 
     // Function @ Index.h:6541:20
-    public static int clang_index_isEntityObjCContainerKind(CXIdxEntityKind param)
-    {
-        return _virtualTable.clang_index_isEntityObjCContainerKind(param);
-    }
+    [DllImport("clang")]
+    public static extern int clang_index_isEntityObjCContainerKind(CXIdxEntityKind param);
 
     // Function @ Index.h:6140:25
-    public static CXResult clang_findIncludesInFile(CXTranslationUnit TU, CXFile file, CXCursorAndRangeVisitor visitor)
-    {
-        return _virtualTable.clang_findIncludesInFile(TU, file, visitor);
-    }
+    [DllImport("clang")]
+    public static extern CXResult clang_findIncludesInFile(CXTranslationUnit TU, CXFile file, CXCursorAndRangeVisitor visitor);
 
     // Function @ Index.h:6125:25
-    public static CXResult clang_findReferencesInFile(CXCursor cursor, CXFile file, CXCursorAndRangeVisitor visitor)
-    {
-        return _virtualTable.clang_findReferencesInFile(cursor, file, visitor);
-    }
+    [DllImport("clang")]
+    public static extern CXResult clang_findReferencesInFile(CXCursor cursor, CXFile file, CXCursorAndRangeVisitor visitor);
 
     // Function @ Index.h:6076:21
-    public static void clang_remap_dispose(CXRemapping param)
-    {
-        _virtualTable.clang_remap_dispose(param);
-    }
+    [DllImport("clang")]
+    public static extern void clang_remap_dispose(CXRemapping param);
 
     // Function @ Index.h:6069:21
-    public static void clang_remap_getFilenames(CXRemapping param, uint index, CXString* original, CXString* transformed)
-    {
-        _virtualTable.clang_remap_getFilenames(param, index, original, transformed);
-    }
+    [DllImport("clang")]
+    public static extern void clang_remap_getFilenames(CXRemapping param, uint index, CXString* original, CXString* transformed);
 
     // Function @ Index.h:6059:25
-    public static uint clang_remap_getNumFiles(CXRemapping param)
-    {
-        return _virtualTable.clang_remap_getNumFiles(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_remap_getNumFiles(CXRemapping param);
 
     // Function @ Index.h:6053:13
-    public static CXRemapping clang_getRemappingsFromFileList(CString* filePaths, uint numFiles)
-    {
-        return _virtualTable.clang_getRemappingsFromFileList(filePaths, numFiles);
-    }
+    [DllImport("clang")]
+    public static extern CXRemapping clang_getRemappingsFromFileList(CString* filePaths, uint numFiles);
 
     // Function @ Index.h:6040:28
-    public static CXRemapping clang_getRemappings(CString path)
-    {
-        return _virtualTable.clang_getRemappings(path);
-    }
+    [DllImport("clang")]
+    public static extern CXRemapping clang_getRemappings(CString path);
 
     // Function @ Index.h:6017:21
-    public static void clang_EvalResult_dispose(CXEvalResult E)
-    {
-        _virtualTable.clang_EvalResult_dispose(E);
-    }
+    [DllImport("clang")]
+    public static extern void clang_EvalResult_dispose(CXEvalResult E);
 
     // Function @ Index.h:6012:28
-    public static CString clang_EvalResult_getAsStr(CXEvalResult E)
-    {
-        return _virtualTable.clang_EvalResult_getAsStr(E);
-    }
+    [DllImport("clang")]
+    public static extern CString clang_EvalResult_getAsStr(CXEvalResult E);
 
     // Function @ Index.h:6004:23
-    public static double clang_EvalResult_getAsDouble(CXEvalResult E)
-    {
-        return _virtualTable.clang_EvalResult_getAsDouble(E);
-    }
+    [DllImport("clang")]
+    public static extern double clang_EvalResult_getAsDouble(CXEvalResult E);
 
     // Function @ Index.h:5998:1
-    public static ulong clang_EvalResult_getAsUnsigned(CXEvalResult E)
-    {
-        return _virtualTable.clang_EvalResult_getAsUnsigned(E);
-    }
+    [DllImport("clang")]
+    public static extern ulong clang_EvalResult_getAsUnsigned(CXEvalResult E);
 
     // Function @ Index.h:5991:25
-    public static uint clang_EvalResult_isUnsignedInt(CXEvalResult E)
-    {
-        return _virtualTable.clang_EvalResult_isUnsignedInt(E);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_EvalResult_isUnsignedInt(CXEvalResult E);
 
     // Function @ Index.h:5985:26
-    public static long clang_EvalResult_getAsLongLong(CXEvalResult E)
-    {
-        return _virtualTable.clang_EvalResult_getAsLongLong(E);
-    }
+    [DllImport("clang")]
+    public static extern long clang_EvalResult_getAsLongLong(CXEvalResult E);
 
     // Function @ Index.h:5978:20
-    public static int clang_EvalResult_getAsInt(CXEvalResult E)
-    {
-        return _virtualTable.clang_EvalResult_getAsInt(E);
-    }
+    [DllImport("clang")]
+    public static extern int clang_EvalResult_getAsInt(CXEvalResult E);
 
     // Function @ Index.h:5972:33
-    public static CXEvalResultKind clang_EvalResult_getKind(CXEvalResult E)
-    {
-        return _virtualTable.clang_EvalResult_getKind(E);
-    }
+    [DllImport("clang")]
+    public static extern CXEvalResultKind clang_EvalResult_getKind(CXEvalResult E);
 
     // Function @ Index.h:5967:29
-    public static CXEvalResult clang_Cursor_Evaluate(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_Evaluate(C);
-    }
+    [DllImport("clang")]
+    public static extern CXEvalResult clang_Cursor_Evaluate(CXCursor C);
 
     // Function @ Index.h:5940:21
-    public static void clang_getInclusions(CXTranslationUnit tu, CXInclusionVisitor visitor, CXClientData client_data)
-    {
-        _virtualTable.clang_getInclusions(tu, visitor, client_data);
-    }
+    [DllImport("clang")]
+    public static extern void clang_getInclusions(CXTranslationUnit tu, CXInclusionVisitor visitor, CXClientData client_data);
 
     // Function @ Index.h:5916:21
-    public static void clang_toggleCrashRecovery(uint isEnabled)
-    {
-        _virtualTable.clang_toggleCrashRecovery(isEnabled);
-    }
+    [DllImport("clang")]
+    public static extern void clang_toggleCrashRecovery(uint isEnabled);
 
     // Function @ Index.h:5908:25
-    public static CXString clang_getClangVersion()
-    {
-        return _virtualTable.clang_getClangVersion();
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getClangVersion();
 
     // Function @ Index.h:5892:10
-    public static CXString clang_codeCompleteGetObjCSelector(CXCodeCompleteResults* Results)
-    {
-        return _virtualTable.clang_codeCompleteGetObjCSelector(Results);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_codeCompleteGetObjCSelector(CXCodeCompleteResults* Results);
 
     // Function @ Index.h:5878:10
-    public static CXString clang_codeCompleteGetContainerUSR(CXCodeCompleteResults* Results)
-    {
-        return _virtualTable.clang_codeCompleteGetContainerUSR(Results);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_codeCompleteGetContainerUSR(CXCodeCompleteResults* Results);
 
     // Function @ Index.h:5865:1
-    public static CXCursorKind clang_codeCompleteGetContainerKind(CXCodeCompleteResults* Results, ulong* IsIncomplete)
-    {
-        return _virtualTable.clang_codeCompleteGetContainerKind(Results, IsIncomplete);
-    }
+    [DllImport("clang")]
+    public static extern CXCursorKind clang_codeCompleteGetContainerKind(CXCodeCompleteResults* Results, ulong* IsIncomplete);
 
     // Function @ Index.h:5845:1
-    public static ulong clang_codeCompleteGetContexts(CXCodeCompleteResults* Results)
-    {
-        return _virtualTable.clang_codeCompleteGetContexts(Results);
-    }
+    [DllImport("clang")]
+    public static extern ulong clang_codeCompleteGetContexts(CXCodeCompleteResults* Results);
 
     // Function @ Index.h:5831:14
-    public static CXDiagnostic clang_codeCompleteGetDiagnostic(CXCodeCompleteResults* Results, uint Index)
-    {
-        return _virtualTable.clang_codeCompleteGetDiagnostic(Results, Index);
-    }
+    [DllImport("clang")]
+    public static extern CXDiagnostic clang_codeCompleteGetDiagnostic(CXCodeCompleteResults* Results, uint Index);
 
     // Function @ Index.h:5819:10
-    public static uint clang_codeCompleteGetNumDiagnostics(CXCodeCompleteResults* Results)
-    {
-        return _virtualTable.clang_codeCompleteGetNumDiagnostics(Results);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_codeCompleteGetNumDiagnostics(CXCodeCompleteResults* Results);
 
     // Function @ Index.h:5812:6
-    public static void clang_disposeCodeCompleteResults(CXCodeCompleteResults* Results)
-    {
-        _virtualTable.clang_disposeCodeCompleteResults(Results);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeCodeCompleteResults(CXCodeCompleteResults* Results);
 
     // Function @ Index.h:5805:6
-    public static void clang_sortCodeCompletionResults(CXCompletionResult* Results, uint NumResults)
-    {
-        _virtualTable.clang_sortCodeCompletionResults(Results, NumResults);
-    }
+    [DllImport("clang")]
+    public static extern void clang_sortCodeCompletionResults(CXCompletionResult* Results, uint NumResults);
 
     // Function @ Index.h:5792:1
-    public static CXCodeCompleteResults* clang_codeCompleteAt(CXTranslationUnit TU, CString complete_filename, uint complete_line, uint complete_column, CXUnsavedFile* unsaved_files, uint num_unsaved_files, uint options)
-    {
-        return _virtualTable.clang_codeCompleteAt(TU, complete_filename, complete_line, complete_column, unsaved_files, num_unsaved_files, options);
-    }
+    [DllImport("clang")]
+    public static extern CXCodeCompleteResults* clang_codeCompleteAt(CXTranslationUnit TU, CString complete_filename, uint complete_line, uint complete_column, CXUnsavedFile* unsaved_files, uint num_unsaved_files, uint options);
 
     // Function @ Index.h:5720:25
-    public static uint clang_defaultCodeCompleteOptions()
-    {
-        return _virtualTable.clang_defaultCodeCompleteOptions();
-    }
+    [DllImport("clang")]
+    public static extern uint clang_defaultCodeCompleteOptions();
 
     // Function @ Index.h:5536:25
-    public static CXString clang_getCompletionFixIt(CXCodeCompleteResults* results, uint completion_index, uint fixit_index, CXSourceRange* replacement_range)
-    {
-        return _virtualTable.clang_getCompletionFixIt(results, completion_index, fixit_index, replacement_range);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCompletionFixIt(CXCodeCompleteResults* results, uint completion_index, uint fixit_index, CXSourceRange* replacement_range);
 
     // Function @ Index.h:5490:1
-    public static uint clang_getCompletionNumFixIts(CXCodeCompleteResults* results, uint completion_index)
-    {
-        return _virtualTable.clang_getCompletionNumFixIts(results, completion_index);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getCompletionNumFixIts(CXCodeCompleteResults* results, uint completion_index);
 
     // Function @ Index.h:5454:1
-    public static CXCompletionString clang_getCursorCompletionString(CXCursor cursor)
-    {
-        return _virtualTable.clang_getCursorCompletionString(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXCompletionString clang_getCursorCompletionString(CXCursor cursor);
 
     // Function @ Index.h:5442:1
-    public static CXString clang_getCompletionBriefComment(CXCompletionString completion_string)
-    {
-        return _virtualTable.clang_getCompletionBriefComment(completion_string);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCompletionBriefComment(CXCompletionString completion_string);
 
     // Function @ Index.h:5434:25
-    public static CXString clang_getCompletionParent(CXCompletionString completion_string, CXCursorKind* kind)
-    {
-        return _virtualTable.clang_getCompletionParent(completion_string, kind);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCompletionParent(CXCompletionString completion_string, CXCursorKind* kind);
 
     // Function @ Index.h:5415:25
-    public static CXString clang_getCompletionAnnotation(CXCompletionString completion_string, uint annotation_number)
-    {
-        return _virtualTable.clang_getCompletionAnnotation(completion_string, annotation_number);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCompletionAnnotation(CXCompletionString completion_string, uint annotation_number);
 
     // Function @ Index.h:5402:1
-    public static uint clang_getCompletionNumAnnotations(CXCompletionString completion_string)
-    {
-        return _virtualTable.clang_getCompletionNumAnnotations(completion_string);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getCompletionNumAnnotations(CXCompletionString completion_string);
 
     // Function @ Index.h:5390:1
-    public static CXAvailabilityKind clang_getCompletionAvailability(CXCompletionString completion_string)
-    {
-        return _virtualTable.clang_getCompletionAvailability(completion_string);
-    }
+    [DllImport("clang")]
+    public static extern CXAvailabilityKind clang_getCompletionAvailability(CXCompletionString completion_string);
 
     // Function @ Index.h:5379:1
-    public static uint clang_getCompletionPriority(CXCompletionString completion_string)
-    {
-        return _virtualTable.clang_getCompletionPriority(completion_string);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getCompletionPriority(CXCompletionString completion_string);
 
     // Function @ Index.h:5364:1
-    public static uint clang_getNumCompletionChunks(CXCompletionString completion_string)
-    {
-        return _virtualTable.clang_getNumCompletionChunks(completion_string);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getNumCompletionChunks(CXCompletionString completion_string);
 
     // Function @ Index.h:5357:35
-    public static CXCompletionString clang_getCompletionChunkCompletionString(CXCompletionString completion_string, uint chunk_number)
-    {
-        return _virtualTable.clang_getCompletionChunkCompletionString(completion_string, chunk_number);
-    }
+    [DllImport("clang")]
+    public static extern CXCompletionString clang_getCompletionChunkCompletionString(CXCompletionString completion_string, uint chunk_number);
 
     // Function @ Index.h:5343:25
-    public static CXString clang_getCompletionChunkText(CXCompletionString completion_string, uint chunk_number)
-    {
-        return _virtualTable.clang_getCompletionChunkText(completion_string, chunk_number);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCompletionChunkText(CXCompletionString completion_string, uint chunk_number);
 
     // Function @ Index.h:5330:1
-    public static CXCompletionChunkKind clang_getCompletionChunkKind(CXCompletionString completion_string, uint chunk_number)
-    {
-        return _virtualTable.clang_getCompletionChunkKind(completion_string, chunk_number);
-    }
+    [DllImport("clang")]
+    public static extern CXCompletionChunkKind clang_getCompletionChunkKind(CXCompletionString completion_string, uint chunk_number);
 
     // Function @ Index.h:5092:21
-    public static void clang_executeOnThread(FnPtr_CLANG_VoidPtr_Void fn, void* user_data, uint stack_size)
-    {
-        _virtualTable.clang_executeOnThread(fn, user_data, stack_size);
-    }
+    [DllImport("clang")]
+    public static extern void clang_executeOnThread(FnPtr_CLANG_VoidPtr_Void fn, void* user_data, uint stack_size);
 
     // Function @ Index.h:5091:21
-    public static void clang_enableStackTraces()
-    {
-        _virtualTable.clang_enableStackTraces();
-    }
+    [DllImport("clang")]
+    public static extern void clang_enableStackTraces();
 
     // Function @ Index.h:5088:21
-    public static void clang_getDefinitionSpellingAndExtent(CXCursor param, CString* startBuf, CString* endBuf, ulong* startLine, ulong* startColumn, ulong* endLine, ulong* endColumn)
-    {
-        _virtualTable.clang_getDefinitionSpellingAndExtent(param, startBuf, endBuf, startLine, startColumn, endLine, endColumn);
-    }
+    [DllImport("clang")]
+    public static extern void clang_getDefinitionSpellingAndExtent(CXCursor param, CString* startBuf, CString* endBuf, ulong* startLine, ulong* startColumn, ulong* endLine, ulong* endColumn);
 
     // Function @ Index.h:5087:25
-    public static CXString clang_getCursorKindSpelling(CXCursorKind Kind)
-    {
-        return _virtualTable.clang_getCursorKindSpelling(Kind);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCursorKindSpelling(CXCursorKind Kind);
 
     // Function @ Index.h:5070:21
-    public static void clang_disposeTokens(CXTranslationUnit TU, CXToken* Tokens, uint NumTokens)
-    {
-        _virtualTable.clang_disposeTokens(TU, Tokens, NumTokens);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeTokens(CXTranslationUnit TU, CXToken* Tokens, uint NumTokens);
 
     // Function @ Index.h:5064:21
-    public static void clang_annotateTokens(CXTranslationUnit TU, CXToken* Tokens, uint NumTokens, CXCursor* Cursors)
-    {
-        _virtualTable.clang_annotateTokens(TU, Tokens, NumTokens, Cursors);
-    }
+    [DllImport("clang")]
+    public static extern void clang_annotateTokens(CXTranslationUnit TU, CXToken* Tokens, uint NumTokens, CXCursor* Cursors);
 
     // Function @ Index.h:5031:21
-    public static void clang_tokenize(CXTranslationUnit TU, CXSourceRange Range, CXToken** Tokens, ulong* NumTokens)
-    {
-        _virtualTable.clang_tokenize(TU, Range, Tokens, NumTokens);
-    }
+    [DllImport("clang")]
+    public static extern void clang_tokenize(CXTranslationUnit TU, CXSourceRange Range, CXToken** Tokens, ulong* NumTokens);
 
     // Function @ Index.h:5012:30
-    public static CXSourceRange clang_getTokenExtent(CXTranslationUnit param, CXToken param2)
-    {
-        return _virtualTable.clang_getTokenExtent(param, param2);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRange clang_getTokenExtent(CXTranslationUnit param, CXToken param2);
 
     // Function @ Index.h:5006:33
-    public static CXSourceLocation clang_getTokenLocation(CXTranslationUnit param, CXToken param2)
-    {
-        return _virtualTable.clang_getTokenLocation(param, param2);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceLocation clang_getTokenLocation(CXTranslationUnit param, CXToken param2);
 
     // Function @ Index.h:5001:25
-    public static CXString clang_getTokenSpelling(CXTranslationUnit param, CXToken param2)
-    {
-        return _virtualTable.clang_getTokenSpelling(param, param2);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getTokenSpelling(CXTranslationUnit param, CXToken param2);
 
     // Function @ Index.h:4993:28
-    public static CXTokenKind clang_getTokenKind(CXToken param)
-    {
-        return _virtualTable.clang_getTokenKind(param);
-    }
+    [DllImport("clang")]
+    public static extern CXTokenKind clang_getTokenKind(CXToken param);
 
     // Function @ Index.h:4987:25
-    public static CXToken* clang_getToken(CXTranslationUnit TU, CXSourceLocation Location)
-    {
-        return _virtualTable.clang_getToken(TU, Location);
-    }
+    [DllImport("clang")]
+    public static extern CXToken* clang_getToken(CXTranslationUnit TU, CXSourceLocation Location);
 
     // Function @ Index.h:4895:30
-    public static CXSourceRange clang_getCursorReferenceNameRange(CXCursor C, uint NameFlags, uint PieceIndex)
-    {
-        return _virtualTable.clang_getCursorReferenceNameRange(C, NameFlags, PieceIndex);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRange clang_getCursorReferenceNameRange(CXCursor C, uint NameFlags, uint PieceIndex);
 
     // Function @ Index.h:4875:25
-    public static CXCursor clang_getSpecializedCursorTemplate(CXCursor C)
-    {
-        return _virtualTable.clang_getSpecializedCursorTemplate(C);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getSpecializedCursorTemplate(CXCursor C);
 
     // Function @ Index.h:4845:34
-    public static CXCursorKind clang_getTemplateCursorKind(CXCursor C)
-    {
-        return _virtualTable.clang_getTemplateCursorKind(C);
-    }
+    [DllImport("clang")]
+    public static extern CXCursorKind clang_getTemplateCursorKind(CXCursor C);
 
     // Function @ Index.h:4826:25
-    public static uint clang_CXXMethod_isConst(CXCursor C)
-    {
-        return _virtualTable.clang_CXXMethod_isConst(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXMethod_isConst(CXCursor C);
 
     // Function @ Index.h:4820:25
-    public static uint clang_EnumDecl_isScoped(CXCursor C)
-    {
-        return _virtualTable.clang_EnumDecl_isScoped(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_EnumDecl_isScoped(CXCursor C);
 
     // Function @ Index.h:4815:25
-    public static uint clang_CXXRecord_isAbstract(CXCursor C)
-    {
-        return _virtualTable.clang_CXXRecord_isAbstract(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXRecord_isAbstract(CXCursor C);
 
     // Function @ Index.h:4809:25
-    public static uint clang_CXXMethod_isVirtual(CXCursor C)
-    {
-        return _virtualTable.clang_CXXMethod_isVirtual(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXMethod_isVirtual(CXCursor C);
 
     // Function @ Index.h:4802:25
-    public static uint clang_CXXMethod_isStatic(CXCursor C)
-    {
-        return _virtualTable.clang_CXXMethod_isStatic(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXMethod_isStatic(CXCursor C);
 
     // Function @ Index.h:4796:25
-    public static uint clang_CXXMethod_isPureVirtual(CXCursor C)
-    {
-        return _virtualTable.clang_CXXMethod_isPureVirtual(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXMethod_isPureVirtual(CXCursor C);
 
     // Function @ Index.h:4790:25
-    public static uint clang_CXXMethod_isDefaulted(CXCursor C)
-    {
-        return _virtualTable.clang_CXXMethod_isDefaulted(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXMethod_isDefaulted(CXCursor C);
 
     // Function @ Index.h:4785:25
-    public static uint clang_CXXField_isMutable(CXCursor C)
-    {
-        return _virtualTable.clang_CXXField_isMutable(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXField_isMutable(CXCursor C);
 
     // Function @ Index.h:4780:25
-    public static uint clang_CXXConstructor_isMoveConstructor(CXCursor C)
-    {
-        return _virtualTable.clang_CXXConstructor_isMoveConstructor(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXConstructor_isMoveConstructor(CXCursor C);
 
     // Function @ Index.h:4775:25
-    public static uint clang_CXXConstructor_isDefaultConstructor(CXCursor C)
-    {
-        return _virtualTable.clang_CXXConstructor_isDefaultConstructor(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXConstructor_isDefaultConstructor(CXCursor C);
 
     // Function @ Index.h:4770:25
-    public static uint clang_CXXConstructor_isCopyConstructor(CXCursor C)
-    {
-        return _virtualTable.clang_CXXConstructor_isCopyConstructor(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXConstructor_isCopyConstructor(CXCursor C);
 
     // Function @ Index.h:4765:1
-    public static uint clang_CXXConstructor_isConvertingConstructor(CXCursor C)
-    {
-        return _virtualTable.clang_CXXConstructor_isConvertingConstructor(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXXConstructor_isConvertingConstructor(CXCursor C);
 
     // Function @ Index.h:4745:8
-    public static CXFile clang_Module_getTopLevelHeader(CXTranslationUnit param, CXModule Module, uint Index)
-    {
-        return _virtualTable.clang_Module_getTopLevelHeader(param, Module, Index);
-    }
+    [DllImport("clang")]
+    public static extern CXFile clang_Module_getTopLevelHeader(CXTranslationUnit param, CXModule Module, uint Index);
 
     // Function @ Index.h:4734:25
-    public static uint clang_Module_getNumTopLevelHeaders(CXTranslationUnit param, CXModule Module)
-    {
-        return _virtualTable.clang_Module_getNumTopLevelHeaders(param, Module);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Module_getNumTopLevelHeaders(CXTranslationUnit param, CXModule Module);
 
     // Function @ Index.h:4727:20
-    public static int clang_Module_isSystem(CXModule Module)
-    {
-        return _virtualTable.clang_Module_isSystem(Module);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Module_isSystem(CXModule Module);
 
     // Function @ Index.h:4720:25
-    public static CXString clang_Module_getFullName(CXModule Module)
-    {
-        return _virtualTable.clang_Module_getFullName(Module);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_Module_getFullName(CXModule Module);
 
     // Function @ Index.h:4713:25
-    public static CXString clang_Module_getName(CXModule Module)
-    {
-        return _virtualTable.clang_Module_getName(Module);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_Module_getName(CXModule Module);
 
     // Function @ Index.h:4705:25
-    public static CXModule clang_Module_getParent(CXModule Module)
-    {
-        return _virtualTable.clang_Module_getParent(Module);
-    }
+    [DllImport("clang")]
+    public static extern CXModule clang_Module_getParent(CXModule Module);
 
     // Function @ Index.h:4697:23
-    public static CXFile clang_Module_getASTFile(CXModule Module)
-    {
-        return _virtualTable.clang_Module_getASTFile(Module);
-    }
+    [DllImport("clang")]
+    public static extern CXFile clang_Module_getASTFile(CXModule Module);
 
     // Function @ Index.h:4690:25
-    public static CXModule clang_getModuleForFile(CXTranslationUnit param, CXFile param2)
-    {
-        return _virtualTable.clang_getModuleForFile(param, param2);
-    }
+    [DllImport("clang")]
+    public static extern CXModule clang_getModuleForFile(CXTranslationUnit param, CXFile param2);
 
     // Function @ Index.h:4684:25
-    public static CXModule clang_Cursor_getModule(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getModule(C);
-    }
+    [DllImport("clang")]
+    public static extern CXModule clang_Cursor_getModule(CXCursor C);
 
     // Function @ Index.h:4665:29
-    public static CXStringSet* clang_Cursor_getObjCManglings(CXCursor param)
-    {
-        return _virtualTable.clang_Cursor_getObjCManglings(param);
-    }
+    [DllImport("clang")]
+    public static extern CXStringSet* clang_Cursor_getObjCManglings(CXCursor param);
 
     // Function @ Index.h:4659:29
-    public static CXStringSet* clang_Cursor_getCXXManglings(CXCursor param)
-    {
-        return _virtualTable.clang_Cursor_getCXXManglings(param);
-    }
+    [DllImport("clang")]
+    public static extern CXStringSet* clang_Cursor_getCXXManglings(CXCursor param);
 
     // Function @ Index.h:4653:25
-    public static CXString clang_Cursor_getMangling(CXCursor param)
-    {
-        return _virtualTable.clang_Cursor_getMangling(param);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_Cursor_getMangling(CXCursor param);
 
     // Function @ Index.h:4639:25
-    public static CXString clang_Cursor_getBriefCommentText(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getBriefCommentText(C);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_Cursor_getBriefCommentText(CXCursor C);
 
     // Function @ Index.h:4632:25
-    public static CXString clang_Cursor_getRawCommentText(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getRawCommentText(C);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_Cursor_getRawCommentText(CXCursor C);
 
     // Function @ Index.h:4626:30
-    public static CXSourceRange clang_Cursor_getCommentRange(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getCommentRange(C);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRange clang_Cursor_getCommentRange(CXCursor C);
 
     // Function @ Index.h:4616:25
-    public static uint clang_Cursor_isExternalSymbol(CXCursor C, CXString* language, CXString* definedIn, ulong* isGenerated)
-    {
-        return _virtualTable.clang_Cursor_isExternalSymbol(C, language, definedIn, isGenerated);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isExternalSymbol(CXCursor C, CXString* language, CXString* definedIn, ulong* isGenerated);
 
     // Function @ Index.h:4601:25
-    public static uint clang_Cursor_isVariadic(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isVariadic(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isVariadic(CXCursor C);
 
     // Function @ Index.h:4596:25
-    public static uint clang_Cursor_isObjCOptional(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isObjCOptional(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isObjCOptional(CXCursor C);
 
     // Function @ Index.h:4589:25
-    public static uint clang_Cursor_getObjCDeclQualifiers(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getObjCDeclQualifiers(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_getObjCDeclQualifiers(CXCursor C);
 
     // Function @ Index.h:4567:25
-    public static CXString clang_Cursor_getObjCPropertySetterName(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getObjCPropertySetterName(C);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_Cursor_getObjCPropertySetterName(CXCursor C);
 
     // Function @ Index.h:4561:25
-    public static CXString clang_Cursor_getObjCPropertyGetterName(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getObjCPropertyGetterName(C);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_Cursor_getObjCPropertyGetterName(CXCursor C);
 
     // Function @ Index.h:4555:1
-    public static uint clang_Cursor_getObjCPropertyAttributes(CXCursor C, uint reserved)
-    {
-        return _virtualTable.clang_Cursor_getObjCPropertyAttributes(C, reserved);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_getObjCPropertyAttributes(CXCursor C, uint reserved);
 
     // Function @ Index.h:4525:23
-    public static CXType clang_Cursor_getReceiverType(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getReceiverType(C);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_Cursor_getReceiverType(CXCursor C);
 
     // Function @ Index.h:4519:20
-    public static int clang_Cursor_isDynamicCall(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isDynamicCall(C);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Cursor_isDynamicCall(CXCursor C);
 
     // Function @ Index.h:4506:20
-    public static int clang_Cursor_getObjCSelectorIndex(CXCursor param)
-    {
-        return _virtualTable.clang_Cursor_getObjCSelectorIndex(param);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Cursor_getObjCSelectorIndex(CXCursor param);
 
     // Function @ Index.h:4493:25
-    public static CXCursor clang_getCanonicalCursor(CXCursor param)
-    {
-        return _virtualTable.clang_getCanonicalCursor(param);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getCanonicalCursor(CXCursor param);
 
     // Function @ Index.h:4467:25
-    public static uint clang_isCursorDefinition(CXCursor param)
-    {
-        return _virtualTable.clang_isCursorDefinition(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isCursorDefinition(CXCursor param);
 
     // Function @ Index.h:4461:25
-    public static CXCursor clang_getCursorDefinition(CXCursor param)
-    {
-        return _virtualTable.clang_getCursorDefinition(param);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getCursorDefinition(CXCursor param);
 
     // Function @ Index.h:4431:25
-    public static CXCursor clang_getCursorReferenced(CXCursor param)
-    {
-        return _virtualTable.clang_getCursorReferenced(param);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getCursorReferenced(CXCursor param);
 
     // Function @ Index.h:4419:25
-    public static CXString clang_getCursorDisplayName(CXCursor param)
-    {
-        return _virtualTable.clang_getCursorDisplayName(param);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCursorDisplayName(CXCursor param);
 
     // Function @ Index.h:4409:25
-    public static CXString clang_getCursorPrettyPrinted(CXCursor Cursor, CXPrintingPolicy Policy)
-    {
-        return _virtualTable.clang_getCursorPrettyPrinted(Cursor, Policy);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCursorPrettyPrinted(CXCursor Cursor, CXPrintingPolicy Policy);
 
     // Function @ Index.h:4396:21
-    public static void clang_PrintingPolicy_dispose(CXPrintingPolicy Policy)
-    {
-        _virtualTable.clang_PrintingPolicy_dispose(Policy);
-    }
+    [DllImport("clang")]
+    public static extern void clang_PrintingPolicy_dispose(CXPrintingPolicy Policy);
 
     // Function @ Index.h:4391:33
-    public static CXPrintingPolicy clang_getCursorPrintingPolicy(CXCursor param)
-    {
-        return _virtualTable.clang_getCursorPrintingPolicy(param);
-    }
+    [DllImport("clang")]
+    public static extern CXPrintingPolicy clang_getCursorPrintingPolicy(CXCursor param);
 
     // Function @ Index.h:4381:1
-    public static void clang_PrintingPolicy_setProperty(CXPrintingPolicy Policy, CXPrintingPolicyProperty Property, uint Value)
-    {
-        _virtualTable.clang_PrintingPolicy_setProperty(Policy, Property, Value);
-    }
+    [DllImport("clang")]
+    public static extern void clang_PrintingPolicy_setProperty(CXPrintingPolicy Policy, CXPrintingPolicyProperty Property, uint Value);
 
     // Function @ Index.h:4374:1
-    public static uint clang_PrintingPolicy_getProperty(CXPrintingPolicy Policy, CXPrintingPolicyProperty Property)
-    {
-        return _virtualTable.clang_PrintingPolicy_getProperty(Policy, Property);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_PrintingPolicy_getProperty(CXPrintingPolicy Policy, CXPrintingPolicyProperty Property);
 
     // Function @ Index.h:4325:30
-    public static CXSourceRange clang_Cursor_getSpellingNameRange(CXCursor param, uint pieceIndex, uint options)
-    {
-        return _virtualTable.clang_Cursor_getSpellingNameRange(param, pieceIndex, options);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRange clang_Cursor_getSpellingNameRange(CXCursor param, uint pieceIndex, uint options);
 
     // Function @ Index.h:4312:25
-    public static CXString clang_getCursorSpelling(CXCursor param)
-    {
-        return _virtualTable.clang_getCursorSpelling(param);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCursorSpelling(CXCursor param);
 
     // Function @ Index.h:4306:25
-    public static CXString clang_constructUSR_ObjCProperty(CString property, CXString classUSR)
-    {
-        return _virtualTable.clang_constructUSR_ObjCProperty(property, classUSR);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_constructUSR_ObjCProperty(CString property, CXString classUSR);
 
     // Function @ Index.h:4298:25
-    public static CXString clang_constructUSR_ObjCMethod(CString name, uint isInstanceMethod, CXString classUSR)
-    {
-        return _virtualTable.clang_constructUSR_ObjCMethod(name, isInstanceMethod, classUSR);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_constructUSR_ObjCMethod(CString name, uint isInstanceMethod, CXString classUSR);
 
     // Function @ Index.h:4291:25
-    public static CXString clang_constructUSR_ObjCIvar(CString name, CXString classUSR)
-    {
-        return _virtualTable.clang_constructUSR_ObjCIvar(name, classUSR);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_constructUSR_ObjCIvar(CString name, CXString classUSR);
 
     // Function @ Index.h:4285:1
-    public static CXString clang_constructUSR_ObjCProtocol(CString protocol_name)
-    {
-        return _virtualTable.clang_constructUSR_ObjCProtocol(protocol_name);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_constructUSR_ObjCProtocol(CString protocol_name);
 
     // Function @ Index.h:4278:25
-    public static CXString clang_constructUSR_ObjCCategory(CString class_name, CString category_name)
-    {
-        return _virtualTable.clang_constructUSR_ObjCCategory(class_name, category_name);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_constructUSR_ObjCCategory(CString class_name, CString category_name);
 
     // Function @ Index.h:4273:25
-    public static CXString clang_constructUSR_ObjCClass(CString class_name)
-    {
-        return _virtualTable.clang_constructUSR_ObjCClass(class_name);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_constructUSR_ObjCClass(CString class_name);
 
     // Function @ Index.h:4268:25
-    public static CXString clang_getCursorUSR(CXCursor param)
-    {
-        return _virtualTable.clang_getCursorUSR(param);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getCursorUSR(CXCursor param);
 
     // Function @ Index.h:4217:25
-    public static uint clang_visitChildren(CXCursor parent, CXCursorVisitor visitor, CXClientData client_data)
-    {
-        return _virtualTable.clang_visitChildren(parent, visitor, client_data);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_visitChildren(CXCursor parent, CXCursorVisitor visitor, CXClientData client_data);
 
     // Function @ Index.h:4140:23
-    public static CXType clang_getIBOutletCollectionType(CXCursor param)
-    {
-        return _virtualTable.clang_getIBOutletCollectionType(param);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getIBOutletCollectionType(CXCursor param);
 
     // Function @ Index.h:4122:25
-    public static CXCursor clang_getOverloadedDecl(CXCursor cursor, uint index)
-    {
-        return _virtualTable.clang_getOverloadedDecl(cursor, index);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getOverloadedDecl(CXCursor cursor, uint index);
 
     // Function @ Index.h:4106:25
-    public static uint clang_getNumOverloadedDecls(CXCursor cursor)
-    {
-        return _virtualTable.clang_getNumOverloadedDecls(cursor);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getNumOverloadedDecls(CXCursor cursor);
 
     // Function @ Index.h:4095:37
-    public static CX_StorageClass clang_Cursor_getStorageClass(CXCursor param)
-    {
-        return _virtualTable.clang_Cursor_getStorageClass(param);
-    }
+    [DllImport("clang")]
+    public static extern CX_StorageClass clang_Cursor_getStorageClass(CXCursor param);
 
     // Function @ Index.h:4072:43
-    public static CX_CXXAccessSpecifier clang_getCXXAccessSpecifier(CXCursor param)
-    {
-        return _virtualTable.clang_getCXXAccessSpecifier(param);
-    }
+    [DllImport("clang")]
+    public static extern CX_CXXAccessSpecifier clang_getCXXAccessSpecifier(CXCursor param);
 
     // Function @ Index.h:4052:25
-    public static uint clang_isVirtualBase(CXCursor param)
-    {
-        return _virtualTable.clang_isVirtualBase(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isVirtualBase(CXCursor param);
 
     // Function @ Index.h:4046:25
-    public static uint clang_Cursor_isBitField(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isBitField(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isBitField(CXCursor C);
 
     // Function @ Index.h:4040:40
-    public static CXRefQualifierKind clang_Type_getCXXRefQualifier(CXType T)
-    {
-        return _virtualTable.clang_Type_getCXXRefQualifier(T);
-    }
+    [DllImport("clang")]
+    public static extern CXRefQualifierKind clang_Type_getCXXRefQualifier(CXType T);
 
     // Function @ Index.h:4031:23
-    public static CXType clang_Type_getTemplateArgumentAsType(CXType T, uint i)
-    {
-        return _virtualTable.clang_Type_getTemplateArgumentAsType(T, i);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_Type_getTemplateArgumentAsType(CXType T, uint i);
 
     // Function @ Index.h:4022:20
-    public static int clang_Type_getNumTemplateArguments(CXType T)
-    {
-        return _virtualTable.clang_Type_getNumTemplateArguments(T);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Type_getNumTemplateArguments(CXType T);
 
     // Function @ Index.h:4007:25
-    public static uint clang_Cursor_isInlineNamespace(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isInlineNamespace(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isInlineNamespace(CXCursor C);
 
     // Function @ Index.h:4001:25
-    public static uint clang_Cursor_isAnonymousRecordDecl(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isAnonymousRecordDecl(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isAnonymousRecordDecl(CXCursor C);
 
     // Function @ Index.h:3995:25
-    public static uint clang_Cursor_isAnonymous(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isAnonymous(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isAnonymous(CXCursor C);
 
     // Function @ Index.h:3989:26
-    public static long clang_Cursor_getOffsetOfField(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getOffsetOfField(C);
-    }
+    [DllImport("clang")]
+    public static extern long clang_Cursor_getOffsetOfField(CXCursor C);
 
     // Function @ Index.h:3974:23
-    public static CXType clang_Type_getValueType(CXType CT)
-    {
-        return _virtualTable.clang_Type_getValueType(CT);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_Type_getValueType(CXType CT);
 
     // Function @ Index.h:3967:23
-    public static CXType clang_Type_getModifiedType(CXType T)
-    {
-        return _virtualTable.clang_Type_getModifiedType(T);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_Type_getModifiedType(CXType T);
 
     // Function @ Index.h:3960:26
-    public static long clang_Type_getOffsetOf(CXType T, CString S)
-    {
-        return _virtualTable.clang_Type_getOffsetOf(T, S);
-    }
+    [DllImport("clang")]
+    public static extern long clang_Type_getOffsetOf(CXType T, CString S);
 
     // Function @ Index.h:3945:26
-    public static long clang_Type_getSizeOf(CXType T)
-    {
-        return _virtualTable.clang_Type_getSizeOf(T);
-    }
+    [DllImport("clang")]
+    public static extern long clang_Type_getSizeOf(CXType T);
 
     // Function @ Index.h:3934:23
-    public static CXType clang_Type_getClassType(CXType T)
-    {
-        return _virtualTable.clang_Type_getClassType(T);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_Type_getClassType(CXType T);
 
     // Function @ Index.h:3927:26
-    public static long clang_Type_getAlignOf(CXType T)
-    {
-        return _virtualTable.clang_Type_getAlignOf(T);
-    }
+    [DllImport("clang")]
+    public static extern long clang_Type_getAlignOf(CXType T);
 
     // Function @ Index.h:3878:43
-    public static CXTypeNullabilityKind clang_Type_getNullability(CXType T)
-    {
-        return _virtualTable.clang_Type_getNullability(T);
-    }
+    [DllImport("clang")]
+    public static extern CXTypeNullabilityKind clang_Type_getNullability(CXType T);
 
     // Function @ Index.h:3843:25
-    public static uint clang_Type_isTransparentTagTypedef(CXType T)
-    {
-        return _virtualTable.clang_Type_isTransparentTagTypedef(T);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Type_isTransparentTagTypedef(CXType T);
 
     // Function @ Index.h:3833:23
-    public static CXType clang_Type_getNamedType(CXType T)
-    {
-        return _virtualTable.clang_Type_getNamedType(T);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_Type_getNamedType(CXType T);
 
     // Function @ Index.h:3826:26
-    public static long clang_getArraySize(CXType T)
-    {
-        return _virtualTable.clang_getArraySize(T);
-    }
+    [DllImport("clang")]
+    public static extern long clang_getArraySize(CXType T);
 
     // Function @ Index.h:3819:23
-    public static CXType clang_getArrayElementType(CXType T)
-    {
-        return _virtualTable.clang_getArrayElementType(T);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getArrayElementType(CXType T);
 
     // Function @ Index.h:3812:26
-    public static long clang_getNumElements(CXType T)
-    {
-        return _virtualTable.clang_getNumElements(T);
-    }
+    [DllImport("clang")]
+    public static extern long clang_getNumElements(CXType T);
 
     // Function @ Index.h:3804:23
-    public static CXType clang_getElementType(CXType T)
-    {
-        return _virtualTable.clang_getElementType(T);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getElementType(CXType T);
 
     // Function @ Index.h:3796:25
-    public static uint clang_isPODType(CXType T)
-    {
-        return _virtualTable.clang_isPODType(T);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isPODType(CXType T);
 
     // Function @ Index.h:3790:20
-    public static int clang_getCursorExceptionSpecificationType(CXCursor C)
-    {
-        return _virtualTable.clang_getCursorExceptionSpecificationType(C);
-    }
+    [DllImport("clang")]
+    public static extern int clang_getCursorExceptionSpecificationType(CXCursor C);
 
     // Function @ Index.h:3781:23
-    public static CXType clang_getCursorResultType(CXCursor C)
-    {
-        return _virtualTable.clang_getCursorResultType(C);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getCursorResultType(CXCursor C);
 
     // Function @ Index.h:3774:25
-    public static uint clang_isFunctionTypeVariadic(CXType T)
-    {
-        return _virtualTable.clang_isFunctionTypeVariadic(T);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isFunctionTypeVariadic(CXType T);
 
     // Function @ Index.h:3769:23
-    public static CXType clang_Type_getObjCTypeArg(CXType T, uint i)
-    {
-        return _virtualTable.clang_Type_getObjCTypeArg(T, i);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_Type_getObjCTypeArg(CXType T, uint i);
 
     // Function @ Index.h:3761:25
-    public static uint clang_Type_getNumObjCTypeArgs(CXType T)
-    {
-        return _virtualTable.clang_Type_getNumObjCTypeArgs(T);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Type_getNumObjCTypeArgs(CXType T);
 
     // Function @ Index.h:3754:25
-    public static CXCursor clang_Type_getObjCProtocolDecl(CXType T, uint i)
-    {
-        return _virtualTable.clang_Type_getObjCProtocolDecl(T, i);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_Type_getObjCProtocolDecl(CXType T, uint i);
 
     // Function @ Index.h:3746:25
-    public static uint clang_Type_getNumObjCProtocolRefs(CXType T)
-    {
-        return _virtualTable.clang_Type_getNumObjCProtocolRefs(T);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Type_getNumObjCProtocolRefs(CXType T);
 
     // Function @ Index.h:3739:23
-    public static CXType clang_Type_getObjCObjectBaseType(CXType T)
-    {
-        return _virtualTable.clang_Type_getObjCObjectBaseType(T);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_Type_getObjCObjectBaseType(CXType T);
 
     // Function @ Index.h:3732:23
-    public static CXType clang_getArgType(CXType T, uint i)
-    {
-        return _virtualTable.clang_getArgType(T, i);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getArgType(CXType T, uint i);
 
     // Function @ Index.h:3724:20
-    public static int clang_getNumArgTypes(CXType T)
-    {
-        return _virtualTable.clang_getNumArgTypes(T);
-    }
+    [DllImport("clang")]
+    public static extern int clang_getNumArgTypes(CXType T);
 
     // Function @ Index.h:3716:20
-    public static int clang_getExceptionSpecificationType(CXType T)
-    {
-        return _virtualTable.clang_getExceptionSpecificationType(T);
-    }
+    [DllImport("clang")]
+    public static extern int clang_getExceptionSpecificationType(CXType T);
 
     // Function @ Index.h:3708:23
-    public static CXType clang_getResultType(CXType T)
-    {
-        return _virtualTable.clang_getResultType(T);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getResultType(CXType T);
 
     // Function @ Index.h:3701:35
-    public static CXCallingConv clang_getFunctionTypeCallingConv(CXType T)
-    {
-        return _virtualTable.clang_getFunctionTypeCallingConv(T);
-    }
+    [DllImport("clang")]
+    public static extern CXCallingConv clang_getFunctionTypeCallingConv(CXType T);
 
     // Function @ Index.h:3694:25
-    public static CXString clang_getTypeKindSpelling(CXTypeKind K)
-    {
-        return _virtualTable.clang_getTypeKindSpelling(K);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getTypeKindSpelling(CXTypeKind K);
 
     // Function @ Index.h:3689:25
-    public static CXString clang_Type_getObjCEncoding(CXType type)
-    {
-        return _virtualTable.clang_Type_getObjCEncoding(type);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_Type_getObjCEncoding(CXType type);
 
     // Function @ Index.h:3684:25
-    public static CXString clang_getDeclObjCTypeEncoding(CXCursor C)
-    {
-        return _virtualTable.clang_getDeclObjCTypeEncoding(C);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getDeclObjCTypeEncoding(CXCursor C);
 
     // Function @ Index.h:3679:25
-    public static CXCursor clang_getTypeDeclaration(CXType T)
-    {
-        return _virtualTable.clang_getTypeDeclaration(T);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getTypeDeclaration(CXType T);
 
     // Function @ Index.h:3674:23
-    public static CXType clang_getPointeeType(CXType T)
-    {
-        return _virtualTable.clang_getPointeeType(T);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getPointeeType(CXType T);
 
     // Function @ Index.h:3669:25
-    public static CXString clang_getTypedefName(CXType CT)
-    {
-        return _virtualTable.clang_getTypedefName(CT);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getTypedefName(CXType CT);
 
     // Function @ Index.h:3664:25
-    public static uint clang_getAddressSpace(CXType T)
-    {
-        return _virtualTable.clang_getAddressSpace(T);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getAddressSpace(CXType T);
 
     // Function @ Index.h:3659:25
-    public static uint clang_isRestrictQualifiedType(CXType T)
-    {
-        return _virtualTable.clang_isRestrictQualifiedType(T);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isRestrictQualifiedType(CXType T);
 
     // Function @ Index.h:3652:25
-    public static uint clang_isVolatileQualifiedType(CXType T)
-    {
-        return _virtualTable.clang_isVolatileQualifiedType(T);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isVolatileQualifiedType(CXType T);
 
     // Function @ Index.h:3645:25
-    public static uint clang_Cursor_isFunctionInlined(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isFunctionInlined(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isFunctionInlined(CXCursor C);
 
     // Function @ Index.h:3639:25
-    public static uint clang_Cursor_isMacroBuiltin(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isMacroBuiltin(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isMacroBuiltin(CXCursor C);
 
     // Function @ Index.h:3633:25
-    public static uint clang_Cursor_isMacroFunctionLike(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_isMacroFunctionLike(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_isMacroFunctionLike(CXCursor C);
 
     // Function @ Index.h:3627:25
-    public static uint clang_isConstQualifiedType(CXType T)
-    {
-        return _virtualTable.clang_isConstQualifiedType(T);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isConstQualifiedType(CXType T);
 
     // Function @ Index.h:3620:23
-    public static CXType clang_getCanonicalType(CXType T)
-    {
-        return _virtualTable.clang_getCanonicalType(T);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getCanonicalType(CXType T);
 
     // Function @ Index.h:3610:25
-    public static uint clang_equalTypes(CXType A, CXType B)
-    {
-        return _virtualTable.clang_equalTypes(A, B);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_equalTypes(CXType A, CXType B);
 
     // Function @ Index.h:3602:1
-    public static ulong clang_Cursor_getTemplateArgumentUnsignedValue(CXCursor C, uint I)
-    {
-        return _virtualTable.clang_Cursor_getTemplateArgumentUnsignedValue(C, I);
-    }
+    [DllImport("clang")]
+    public static extern ulong clang_Cursor_getTemplateArgumentUnsignedValue(CXCursor C, uint I);
 
     // Function @ Index.h:3581:26
-    public static long clang_Cursor_getTemplateArgumentValue(CXCursor C, uint I)
-    {
-        return _virtualTable.clang_Cursor_getTemplateArgumentValue(C, I);
-    }
+    [DllImport("clang")]
+    public static extern long clang_Cursor_getTemplateArgumentValue(CXCursor C, uint I);
 
     // Function @ Index.h:3561:23
-    public static CXType clang_Cursor_getTemplateArgumentType(CXCursor C, uint I)
-    {
-        return _virtualTable.clang_Cursor_getTemplateArgumentType(C, I);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_Cursor_getTemplateArgumentType(CXCursor C, uint I);
 
     // Function @ Index.h:3541:1
-    public static CXTemplateArgumentKind clang_Cursor_getTemplateArgumentKind(CXCursor C, uint I)
-    {
-        return _virtualTable.clang_Cursor_getTemplateArgumentKind(C, I);
-    }
+    [DllImport("clang")]
+    public static extern CXTemplateArgumentKind clang_Cursor_getTemplateArgumentKind(CXCursor C, uint I);
 
     // Function @ Index.h:3522:20
-    public static int clang_Cursor_getNumTemplateArguments(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getNumTemplateArguments(C);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Cursor_getNumTemplateArguments(CXCursor C);
 
     // Function @ Index.h:3484:25
-    public static CXCursor clang_Cursor_getArgument(CXCursor C, uint i)
-    {
-        return _virtualTable.clang_Cursor_getArgument(C, i);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_Cursor_getArgument(CXCursor C, uint i);
 
     // Function @ Index.h:3475:20
-    public static int clang_Cursor_getNumArguments(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_getNumArguments(C);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Cursor_getNumArguments(CXCursor C);
 
     // Function @ Index.h:3466:20
-    public static int clang_getFieldDeclBitWidth(CXCursor C)
-    {
-        return _virtualTable.clang_getFieldDeclBitWidth(C);
-    }
+    [DllImport("clang")]
+    public static extern int clang_getFieldDeclBitWidth(CXCursor C);
 
     // Function @ Index.h:3459:1
-    public static ulong clang_getEnumConstantDeclUnsignedValue(CXCursor C)
-    {
-        return _virtualTable.clang_getEnumConstantDeclUnsignedValue(C);
-    }
+    [DllImport("clang")]
+    public static extern ulong clang_getEnumConstantDeclUnsignedValue(CXCursor C);
 
     // Function @ Index.h:3448:26
-    public static long clang_getEnumConstantDeclValue(CXCursor C)
-    {
-        return _virtualTable.clang_getEnumConstantDeclValue(C);
-    }
+    [DllImport("clang")]
+    public static extern long clang_getEnumConstantDeclValue(CXCursor C);
 
     // Function @ Index.h:3438:23
-    public static CXType clang_getEnumDeclIntegerType(CXCursor C)
-    {
-        return _virtualTable.clang_getEnumDeclIntegerType(C);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getEnumDeclIntegerType(CXCursor C);
 
     // Function @ Index.h:3430:23
-    public static CXType clang_getTypedefDeclUnderlyingType(CXCursor C)
-    {
-        return _virtualTable.clang_getTypedefDeclUnderlyingType(C);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getTypedefDeclUnderlyingType(CXCursor C);
 
     // Function @ Index.h:3422:25
-    public static CXString clang_getTypeSpelling(CXType CT)
-    {
-        return _virtualTable.clang_getTypeSpelling(CT);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getTypeSpelling(CXType CT);
 
     // Function @ Index.h:3414:23
-    public static CXType clang_getCursorType(CXCursor C)
-    {
-        return _virtualTable.clang_getCursorType(C);
-    }
+    [DllImport("clang")]
+    public static extern CXType clang_getCursorType(CXCursor C);
 
     // Function @ Index.h:3211:30
-    public static CXSourceRange clang_getCursorExtent(CXCursor param)
-    {
-        return _virtualTable.clang_getCursorExtent(param);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRange clang_getCursorExtent(CXCursor param);
 
     // Function @ Index.h:3198:33
-    public static CXSourceLocation clang_getCursorLocation(CXCursor param)
-    {
-        return _virtualTable.clang_getCursorLocation(param);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceLocation clang_getCursorLocation(CXCursor param);
 
     // Function @ Index.h:3186:25
-    public static CXCursor clang_getCursor(CXTranslationUnit param, CXSourceLocation param2)
-    {
-        return _virtualTable.clang_getCursor(param, param2);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getCursor(CXTranslationUnit param, CXSourceLocation param2);
 
     // Function @ Index.h:3154:23
-    public static CXFile clang_getIncludedFile(CXCursor cursor)
-    {
-        return _virtualTable.clang_getIncludedFile(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXFile clang_getIncludedFile(CXCursor cursor);
 
     // Function @ Index.h:3148:21
-    public static void clang_disposeOverriddenCursors(CXCursor* overridden)
-    {
-        _virtualTable.clang_disposeOverriddenCursors(overridden);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeOverriddenCursors(CXCursor* overridden);
 
     // Function @ Index.h:3140:21
-    public static void clang_getOverriddenCursors(CXCursor cursor, CXCursor** overridden, ulong* num_overridden)
-    {
-        _virtualTable.clang_getOverriddenCursors(cursor, overridden, num_overridden);
-    }
+    [DllImport("clang")]
+    public static extern void clang_getOverriddenCursors(CXCursor cursor, CXCursor** overridden, ulong* num_overridden);
 
     // Function @ Index.h:3095:25
-    public static CXCursor clang_getCursorLexicalParent(CXCursor cursor)
-    {
-        return _virtualTable.clang_getCursorLexicalParent(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getCursorLexicalParent(CXCursor cursor);
 
     // Function @ Index.h:3059:25
-    public static CXCursor clang_getCursorSemanticParent(CXCursor cursor)
-    {
-        return _virtualTable.clang_getCursorSemanticParent(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getCursorSemanticParent(CXCursor cursor);
 
     // Function @ Index.h:3023:25
-    public static uint clang_CXCursorSet_insert(CXCursorSet cset, CXCursor cursor)
-    {
-        return _virtualTable.clang_CXCursorSet_insert(cset, cursor);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXCursorSet_insert(CXCursorSet cset, CXCursor cursor);
 
     // Function @ Index.h:3015:25
-    public static uint clang_CXCursorSet_contains(CXCursorSet cset, CXCursor cursor)
-    {
-        return _virtualTable.clang_CXCursorSet_contains(cset, cursor);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXCursorSet_contains(CXCursorSet cset, CXCursor cursor);
 
     // Function @ Index.h:3008:21
-    public static void clang_disposeCXCursorSet(CXCursorSet cset)
-    {
-        _virtualTable.clang_disposeCXCursorSet(cset);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeCXCursorSet(CXCursorSet cset);
 
     // Function @ Index.h:3003:28
-    public static CXCursorSet clang_createCXCursorSet()
-    {
-        return _virtualTable.clang_createCXCursorSet();
-    }
+    [DllImport("clang")]
+    public static extern CXCursorSet clang_createCXCursorSet();
 
     // Function @ Index.h:2993:34
-    public static CXTranslationUnit clang_Cursor_getTranslationUnit(CXCursor param)
-    {
-        return _virtualTable.clang_Cursor_getTranslationUnit(param);
-    }
+    [DllImport("clang")]
+    public static extern CXTranslationUnit clang_Cursor_getTranslationUnit(CXCursor param);
 
     // Function @ Index.h:2988:31
-    public static CXTLSKind clang_getCursorTLSKind(CXCursor cursor)
-    {
-        return _virtualTable.clang_getCursorTLSKind(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXTLSKind clang_getCursorTLSKind(CXCursor cursor);
 
     // Function @ Index.h:2976:36
-    public static CXLanguageKind clang_getCursorLanguage(CXCursor cursor)
-    {
-        return _virtualTable.clang_getCursorLanguage(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXLanguageKind clang_getCursorLanguage(CXCursor cursor);
 
     // Function @ Index.h:2961:20
-    public static int clang_Cursor_hasVarDeclExternalStorage(CXCursor cursor)
-    {
-        return _virtualTable.clang_Cursor_hasVarDeclExternalStorage(cursor);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Cursor_hasVarDeclExternalStorage(CXCursor cursor);
 
     // Function @ Index.h:2954:20
-    public static int clang_Cursor_hasVarDeclGlobalStorage(CXCursor cursor)
-    {
-        return _virtualTable.clang_Cursor_hasVarDeclGlobalStorage(cursor);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Cursor_hasVarDeclGlobalStorage(CXCursor cursor);
 
     // Function @ Index.h:2947:25
-    public static CXCursor clang_Cursor_getVarDeclInitializer(CXCursor cursor)
-    {
-        return _virtualTable.clang_Cursor_getVarDeclInitializer(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_Cursor_getVarDeclInitializer(CXCursor cursor);
 
     // Function @ Index.h:2941:1
-    public static void clang_disposeCXPlatformAvailability(CXPlatformAvailability* availability)
-    {
-        _virtualTable.clang_disposeCXPlatformAvailability(availability);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeCXPlatformAvailability(CXPlatformAvailability* availability);
 
     // Function @ Index.h:2932:20
-    public static int clang_getCursorPlatformAvailability(CXCursor cursor, long* always_deprecated, CXString* deprecated_message, long* always_unavailable, CXString* unavailable_message, CXPlatformAvailability* availability, int availability_size)
-    {
-        return _virtualTable.clang_getCursorPlatformAvailability(cursor, always_deprecated, deprecated_message, always_unavailable, unavailable_message, availability, availability_size);
-    }
+    [DllImport("clang")]
+    public static extern int clang_getCursorPlatformAvailability(CXCursor cursor, long* always_deprecated, CXString* deprecated_message, long* always_unavailable, CXString* unavailable_message, CXPlatformAvailability* availability, int availability_size);
 
     // Function @ Index.h:2857:1
-    public static CXAvailabilityKind clang_getCursorAvailability(CXCursor cursor)
-    {
-        return _virtualTable.clang_getCursorAvailability(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXAvailabilityKind clang_getCursorAvailability(CXCursor cursor);
 
     // Function @ Index.h:2846:38
-    public static CXVisibilityKind clang_getCursorVisibility(CXCursor cursor)
-    {
-        return _virtualTable.clang_getCursorVisibility(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXVisibilityKind clang_getCursorVisibility(CXCursor cursor);
 
     // Function @ Index.h:2820:35
-    public static CXLinkageKind clang_getCursorLinkage(CXCursor cursor)
-    {
-        return _virtualTable.clang_getCursorLinkage(cursor);
-    }
+    [DllImport("clang")]
+    public static extern CXLinkageKind clang_getCursorLinkage(CXCursor cursor);
 
     // Function @ Index.h:2794:25
-    public static uint clang_isUnexposed(CXCursorKind param)
-    {
-        return _virtualTable.clang_isUnexposed(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isUnexposed(CXCursorKind param);
 
     // Function @ Index.h:2788:25
-    public static uint clang_isPreprocessing(CXCursorKind param)
-    {
-        return _virtualTable.clang_isPreprocessing(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isPreprocessing(CXCursorKind param);
 
     // Function @ Index.h:2782:25
-    public static uint clang_isTranslationUnit(CXCursorKind param)
-    {
-        return _virtualTable.clang_isTranslationUnit(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isTranslationUnit(CXCursorKind param);
 
     // Function @ Index.h:2776:25
-    public static uint clang_isInvalid(CXCursorKind param)
-    {
-        return _virtualTable.clang_isInvalid(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isInvalid(CXCursorKind param);
 
     // Function @ Index.h:2770:25
-    public static uint clang_Cursor_hasAttrs(CXCursor C)
-    {
-        return _virtualTable.clang_Cursor_hasAttrs(C);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_Cursor_hasAttrs(CXCursor C);
 
     // Function @ Index.h:2765:25
-    public static uint clang_isAttribute(CXCursorKind param)
-    {
-        return _virtualTable.clang_isAttribute(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isAttribute(CXCursorKind param);
 
     // Function @ Index.h:2760:25
-    public static uint clang_isStatement(CXCursorKind param)
-    {
-        return _virtualTable.clang_isStatement(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isStatement(CXCursorKind param);
 
     // Function @ Index.h:2755:25
-    public static uint clang_isExpression(CXCursorKind param)
-    {
-        return _virtualTable.clang_isExpression(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isExpression(CXCursorKind param);
 
     // Function @ Index.h:2750:25
-    public static uint clang_isReference(CXCursorKind param)
-    {
-        return _virtualTable.clang_isReference(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isReference(CXCursorKind param);
 
     // Function @ Index.h:2740:25
-    public static uint clang_isInvalidDeclaration(CXCursor param)
-    {
-        return _virtualTable.clang_isInvalidDeclaration(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isInvalidDeclaration(CXCursor param);
 
     // Function @ Index.h:2730:25
-    public static uint clang_isDeclaration(CXCursorKind param)
-    {
-        return _virtualTable.clang_isDeclaration(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isDeclaration(CXCursorKind param);
 
     // Function @ Index.h:2725:34
-    public static CXCursorKind clang_getCursorKind(CXCursor param)
-    {
-        return _virtualTable.clang_getCursorKind(param);
-    }
+    [DllImport("clang")]
+    public static extern CXCursorKind clang_getCursorKind(CXCursor param);
 
     // Function @ Index.h:2720:25
-    public static uint clang_hashCursor(CXCursor param)
-    {
-        return _virtualTable.clang_hashCursor(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_hashCursor(CXCursor param);
 
     // Function @ Index.h:2715:20
-    public static int clang_Cursor_isNull(CXCursor cursor)
-    {
-        return _virtualTable.clang_Cursor_isNull(cursor);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Cursor_isNull(CXCursor cursor);
 
     // Function @ Index.h:2710:25
-    public static uint clang_equalCursors(CXCursor param, CXCursor param2)
-    {
-        return _virtualTable.clang_equalCursors(param, param2);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_equalCursors(CXCursor param, CXCursor param2);
 
     // Function @ Index.h:2705:25
-    public static CXCursor clang_getTranslationUnitCursor(CXTranslationUnit param)
-    {
-        return _virtualTable.clang_getTranslationUnitCursor(param);
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getTranslationUnitCursor(CXTranslationUnit param);
 
     // Function @ Index.h:2697:25
-    public static CXCursor clang_getNullCursor()
-    {
-        return _virtualTable.clang_getNullCursor();
-    }
+    [DllImport("clang")]
+    public static extern CXCursor clang_getNullCursor();
 
     // Function @ Index.h:1697:20
-    public static int clang_TargetInfo_getPointerWidth(CXTargetInfo Info)
-    {
-        return _virtualTable.clang_TargetInfo_getPointerWidth(Info);
-    }
+    [DllImport("clang")]
+    public static extern int clang_TargetInfo_getPointerWidth(CXTargetInfo Info);
 
     // Function @ Index.h:1690:25
-    public static CXString clang_TargetInfo_getTriple(CXTargetInfo Info)
-    {
-        return _virtualTable.clang_TargetInfo_getTriple(Info);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_TargetInfo_getTriple(CXTargetInfo Info);
 
     // Function @ Index.h:1683:21
-    public static void clang_TargetInfo_dispose(CXTargetInfo Info)
-    {
-        _virtualTable.clang_TargetInfo_dispose(Info);
-    }
+    [DllImport("clang")]
+    public static extern void clang_TargetInfo_dispose(CXTargetInfo Info);
 
     // Function @ Index.h:1678:1
-    public static CXTargetInfo clang_getTranslationUnitTargetInfo(CXTranslationUnit CTUnit)
-    {
-        return _virtualTable.clang_getTranslationUnitTargetInfo(CTUnit);
-    }
+    [DllImport("clang")]
+    public static extern CXTargetInfo clang_getTranslationUnitTargetInfo(CXTranslationUnit CTUnit);
 
     // Function @ Index.h:1670:21
-    public static void clang_disposeCXTUResourceUsage(CXTUResourceUsage usage)
-    {
-        _virtualTable.clang_disposeCXTUResourceUsage(usage);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeCXTUResourceUsage(CXTUResourceUsage usage);
 
     // Function @ Index.h:1668:1
-    public static CXTUResourceUsage clang_getCXTUResourceUsage(CXTranslationUnit TU)
-    {
-        return _virtualTable.clang_getCXTUResourceUsage(TU);
-    }
+    [DllImport("clang")]
+    public static extern CXTUResourceUsage clang_getCXTUResourceUsage(CXTranslationUnit TU);
 
     // Function @ Index.h:1637:13
-    public static CString clang_getTUResourceUsageName(CXTUResourceUsageKind kind)
-    {
-        return _virtualTable.clang_getTUResourceUsageName(kind);
-    }
+    [DllImport("clang")]
+    public static extern CString clang_getTUResourceUsageName(CXTUResourceUsageKind kind);
 
     // Function @ Index.h:1602:1
-    public static int clang_reparseTranslationUnit(CXTranslationUnit TU, uint num_unsaved_files, CXUnsavedFile* unsaved_files, uint options)
-    {
-        return _virtualTable.clang_reparseTranslationUnit(TU, num_unsaved_files, unsaved_files, options);
-    }
+    [DllImport("clang")]
+    public static extern int clang_reparseTranslationUnit(CXTranslationUnit TU, uint num_unsaved_files, CXUnsavedFile* unsaved_files, uint options);
 
     // Function @ Index.h:1560:25
-    public static uint clang_defaultReparseOptions(CXTranslationUnit TU)
-    {
-        return _virtualTable.clang_defaultReparseOptions(TU);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_defaultReparseOptions(CXTranslationUnit TU);
 
     // Function @ Index.h:1534:21
-    public static void clang_disposeTranslationUnit(CXTranslationUnit param)
-    {
-        _virtualTable.clang_disposeTranslationUnit(param);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeTranslationUnit(CXTranslationUnit param);
 
     // Function @ Index.h:1529:25
-    public static uint clang_suspendTranslationUnit(CXTranslationUnit param)
-    {
-        return _virtualTable.clang_suspendTranslationUnit(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_suspendTranslationUnit(CXTranslationUnit param);
 
     // Function @ Index.h:1518:20
-    public static int clang_saveTranslationUnit(CXTranslationUnit TU, CString FileName, uint options)
-    {
-        return _virtualTable.clang_saveTranslationUnit(TU, FileName, options);
-    }
+    [DllImport("clang")]
+    public static extern int clang_saveTranslationUnit(CXTranslationUnit TU, CString FileName, uint options);
 
     // Function @ Index.h:1458:25
-    public static uint clang_defaultSaveOptions(CXTranslationUnit TU)
-    {
-        return _virtualTable.clang_defaultSaveOptions(TU);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_defaultSaveOptions(CXTranslationUnit TU);
 
     // Function @ Index.h:1429:33
-    public static CXErrorCode clang_parseTranslationUnit2FullArgv(CXIndex CIdx, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, uint options, CXTranslationUnit* out_TU)
-    {
-        return _virtualTable.clang_parseTranslationUnit2FullArgv(CIdx, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, options, out_TU);
-    }
+    [DllImport("clang")]
+    public static extern CXErrorCode clang_parseTranslationUnit2FullArgv(CXIndex CIdx, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, uint options, CXTranslationUnit* out_TU);
 
     // Function @ Index.h:1418:33
-    public static CXErrorCode clang_parseTranslationUnit2(CXIndex CIdx, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, uint options, CXTranslationUnit* out_TU)
-    {
-        return _virtualTable.clang_parseTranslationUnit2(CIdx, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, options, out_TU);
-    }
+    [DllImport("clang")]
+    public static extern CXErrorCode clang_parseTranslationUnit2(CXIndex CIdx, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, uint options, CXTranslationUnit* out_TU);
 
     // Function @ Index.h:1368:34
-    public static CXTranslationUnit clang_parseTranslationUnit(CXIndex CIdx, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, uint options)
-    {
-        return _virtualTable.clang_parseTranslationUnit(CIdx, source_filename, command_line_args, num_command_line_args, unsaved_files, num_unsaved_files, options);
-    }
+    [DllImport("clang")]
+    public static extern CXTranslationUnit clang_parseTranslationUnit(CXIndex CIdx, CString source_filename, CString* command_line_args, int num_command_line_args, CXUnsavedFile* unsaved_files, uint num_unsaved_files, uint options);
 
     // Function @ Index.h:1360:25
-    public static uint clang_defaultEditingTranslationUnitOptions()
-    {
-        return _virtualTable.clang_defaultEditingTranslationUnitOptions();
-    }
+    [DllImport("clang")]
+    public static extern uint clang_defaultEditingTranslationUnitOptions();
 
     // Function @ Index.h:1189:1
-    public static CXErrorCode clang_createTranslationUnit2(CXIndex CIdx, CString ast_filename, CXTranslationUnit* out_TU)
-    {
-        return _virtualTable.clang_createTranslationUnit2(CIdx, ast_filename, out_TU);
-    }
+    [DllImport("clang")]
+    public static extern CXErrorCode clang_createTranslationUnit2(CXIndex CIdx, CString ast_filename, CXTranslationUnit* out_TU);
 
     // Function @ Index.h:1178:1
-    public static CXTranslationUnit clang_createTranslationUnit(CXIndex CIdx, CString ast_filename)
-    {
-        return _virtualTable.clang_createTranslationUnit(CIdx, ast_filename);
-    }
+    [DllImport("clang")]
+    public static extern CXTranslationUnit clang_createTranslationUnit(CXIndex CIdx, CString ast_filename);
 
     // Function @ Index.h:1166:34
-    public static CXTranslationUnit clang_createTranslationUnitFromSourceFile(CXIndex CIdx, CString source_filename, int num_clang_command_line_args, CString* clang_command_line_args, uint num_unsaved_files, CXUnsavedFile* unsaved_files)
-    {
-        return _virtualTable.clang_createTranslationUnitFromSourceFile(CIdx, source_filename, num_clang_command_line_args, clang_command_line_args, num_unsaved_files, unsaved_files);
-    }
+    [DllImport("clang")]
+    public static extern CXTranslationUnit clang_createTranslationUnitFromSourceFile(CXIndex CIdx, CString source_filename, int num_clang_command_line_args, CString* clang_command_line_args, uint num_unsaved_files, CXUnsavedFile* unsaved_files);
 
     // Function @ Index.h:1124:1
-    public static CXString clang_getTranslationUnitSpelling(CXTranslationUnit CTUnit)
-    {
-        return _virtualTable.clang_getTranslationUnitSpelling(CTUnit);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getTranslationUnitSpelling(CXTranslationUnit CTUnit);
 
     // Function @ Index.h:1103:25
-    public static CXString clang_getDiagnosticFixIt(CXDiagnostic Diagnostic, uint FixIt, CXSourceRange* ReplacementRange)
-    {
-        return _virtualTable.clang_getDiagnosticFixIt(Diagnostic, FixIt, ReplacementRange);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getDiagnosticFixIt(CXDiagnostic Diagnostic, uint FixIt, CXSourceRange* ReplacementRange);
 
     // Function @ Index.h:1076:25
-    public static uint clang_getDiagnosticNumFixIts(CXDiagnostic Diagnostic)
-    {
-        return _virtualTable.clang_getDiagnosticNumFixIts(Diagnostic);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getDiagnosticNumFixIts(CXDiagnostic Diagnostic);
 
     // Function @ Index.h:1069:30
-    public static CXSourceRange clang_getDiagnosticRange(CXDiagnostic Diagnostic, uint Range)
-    {
-        return _virtualTable.clang_getDiagnosticRange(Diagnostic, Range);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRange clang_getDiagnosticRange(CXDiagnostic Diagnostic, uint Range);
 
     // Function @ Index.h:1054:25
-    public static uint clang_getDiagnosticNumRanges(CXDiagnostic param)
-    {
-        return _virtualTable.clang_getDiagnosticNumRanges(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getDiagnosticNumRanges(CXDiagnostic param);
 
     // Function @ Index.h:1048:25
-    public static CXString clang_getDiagnosticCategoryText(CXDiagnostic param)
-    {
-        return _virtualTable.clang_getDiagnosticCategoryText(param);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getDiagnosticCategoryText(CXDiagnostic param);
 
     // Function @ Index.h:1041:1
-    public static CXString clang_getDiagnosticCategoryName(uint Category)
-    {
-        return _virtualTable.clang_getDiagnosticCategoryName(Category);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getDiagnosticCategoryName(uint Category);
 
     // Function @ Index.h:1028:25
-    public static uint clang_getDiagnosticCategory(CXDiagnostic param)
-    {
-        return _virtualTable.clang_getDiagnosticCategory(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getDiagnosticCategory(CXDiagnostic param);
 
     // Function @ Index.h:1015:25
-    public static CXString clang_getDiagnosticOption(CXDiagnostic Diag, CXString* Disable)
-    {
-        return _virtualTable.clang_getDiagnosticOption(Diag, Disable);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getDiagnosticOption(CXDiagnostic Diag, CXString* Disable);
 
     // Function @ Index.h:1001:25
-    public static CXString clang_getDiagnosticSpelling(CXDiagnostic param)
-    {
-        return _virtualTable.clang_getDiagnosticSpelling(param);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getDiagnosticSpelling(CXDiagnostic param);
 
     // Function @ Index.h:996:33
-    public static CXSourceLocation clang_getDiagnosticLocation(CXDiagnostic param)
-    {
-        return _virtualTable.clang_getDiagnosticLocation(param);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceLocation clang_getDiagnosticLocation(CXDiagnostic param);
 
     // Function @ Index.h:988:5
-    public static CXDiagnosticSeverity clang_getDiagnosticSeverity(CXDiagnostic param)
-    {
-        return _virtualTable.clang_getDiagnosticSeverity(param);
-    }
+    [DllImport("clang")]
+    public static extern CXDiagnosticSeverity clang_getDiagnosticSeverity(CXDiagnostic param);
 
     // Function @ Index.h:982:25
-    public static uint clang_defaultDiagnosticDisplayOptions()
-    {
-        return _virtualTable.clang_defaultDiagnosticDisplayOptions();
-    }
+    [DllImport("clang")]
+    public static extern uint clang_defaultDiagnosticDisplayOptions();
 
     // Function @ Index.h:972:25
-    public static CXString clang_formatDiagnostic(CXDiagnostic Diagnostic, uint Options)
-    {
-        return _virtualTable.clang_formatDiagnostic(Diagnostic, Options);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_formatDiagnostic(CXDiagnostic Diagnostic, uint Options);
 
     // Function @ Index.h:887:21
-    public static void clang_disposeDiagnostic(CXDiagnostic Diagnostic)
-    {
-        _virtualTable.clang_disposeDiagnostic(Diagnostic);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeDiagnostic(CXDiagnostic Diagnostic);
 
     // Function @ Index.h:882:1
-    public static CXDiagnosticSet clang_getDiagnosticSetFromTU(CXTranslationUnit Unit)
-    {
-        return _virtualTable.clang_getDiagnosticSetFromTU(Unit);
-    }
+    [DllImport("clang")]
+    public static extern CXDiagnosticSet clang_getDiagnosticSetFromTU(CXTranslationUnit Unit);
 
     // Function @ Index.h:872:29
-    public static CXDiagnostic clang_getDiagnostic(CXTranslationUnit Unit, uint Index)
-    {
-        return _virtualTable.clang_getDiagnostic(Unit, Index);
-    }
+    [DllImport("clang")]
+    public static extern CXDiagnostic clang_getDiagnostic(CXTranslationUnit Unit, uint Index);
 
     // Function @ Index.h:861:25
-    public static uint clang_getNumDiagnostics(CXTranslationUnit Unit)
-    {
-        return _virtualTable.clang_getNumDiagnostics(Unit);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getNumDiagnostics(CXTranslationUnit Unit);
 
     // Function @ Index.h:855:32
-    public static CXDiagnosticSet clang_getChildDiagnostics(CXDiagnostic D)
-    {
-        return _virtualTable.clang_getChildDiagnostics(D);
-    }
+    [DllImport("clang")]
+    public static extern CXDiagnosticSet clang_getChildDiagnostics(CXDiagnostic D);
 
     // Function @ Index.h:847:21
-    public static void clang_disposeDiagnosticSet(CXDiagnosticSet Diags)
-    {
-        _virtualTable.clang_disposeDiagnosticSet(Diags);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeDiagnosticSet(CXDiagnosticSet Diags);
 
     // Function @ Index.h:841:32
-    public static CXDiagnosticSet clang_loadDiagnostics(CString file, CXLoadDiag_Error* error, CXString* errorString)
-    {
-        return _virtualTable.clang_loadDiagnostics(file, error, errorString);
-    }
+    [DllImport("clang")]
+    public static extern CXDiagnosticSet clang_loadDiagnostics(CString file, CXLoadDiag_Error* error, CXString* errorString);
 
     // Function @ Index.h:796:29
-    public static CXDiagnostic clang_getDiagnosticInSet(CXDiagnosticSet Diags, uint Index)
-    {
-        return _virtualTable.clang_getDiagnosticInSet(Diags, Index);
-    }
+    [DllImport("clang")]
+    public static extern CXDiagnostic clang_getDiagnosticInSet(CXDiagnosticSet Diags, uint Index);
 
     // Function @ Index.h:785:25
-    public static uint clang_getNumDiagnosticsInSet(CXDiagnosticSet Diags)
-    {
-        return _virtualTable.clang_getNumDiagnosticsInSet(Diags);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_getNumDiagnosticsInSet(CXDiagnosticSet Diags);
 
     // Function @ Index.h:724:21
-    public static void clang_disposeSourceRangeList(CXSourceRangeList* ranges)
-    {
-        _virtualTable.clang_disposeSourceRangeList(ranges);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeSourceRangeList(CXSourceRangeList* ranges);
 
     // Function @ Index.h:719:1
-    public static CXSourceRangeList* clang_getAllSkippedRanges(CXTranslationUnit tu)
-    {
-        return _virtualTable.clang_getAllSkippedRanges(tu);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRangeList* clang_getAllSkippedRanges(CXTranslationUnit tu);
 
     // Function @ Index.h:708:35
-    public static CXSourceRangeList* clang_getSkippedRanges(CXTranslationUnit tu, CXFile file)
-    {
-        return _virtualTable.clang_getSkippedRanges(tu, file);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRangeList* clang_getSkippedRanges(CXTranslationUnit tu, CXFile file);
 
     // Function @ Index.h:688:33
-    public static CXSourceLocation clang_getRangeEnd(CXSourceRange range)
-    {
-        return _virtualTable.clang_getRangeEnd(range);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceLocation clang_getRangeEnd(CXSourceRange range);
 
     // Function @ Index.h:682:33
-    public static CXSourceLocation clang_getRangeStart(CXSourceRange range)
-    {
-        return _virtualTable.clang_getRangeStart(range);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceLocation clang_getRangeStart(CXSourceRange range);
 
     // Function @ Index.h:674:21
-    public static void clang_getFileLocation(CXSourceLocation location, CXFile* file, ulong* line, ulong* column, ulong* offset)
-    {
-        _virtualTable.clang_getFileLocation(location, file, line, column, offset);
-    }
+    [DllImport("clang")]
+    public static extern void clang_getFileLocation(CXSourceLocation location, CXFile* file, ulong* line, ulong* column, ulong* offset);
 
     // Function @ Index.h:646:21
-    public static void clang_getSpellingLocation(CXSourceLocation location, CXFile* file, ulong* line, ulong* column, ulong* offset)
-    {
-        _virtualTable.clang_getSpellingLocation(location, file, line, column, offset);
-    }
+    [DllImport("clang")]
+    public static extern void clang_getSpellingLocation(CXSourceLocation location, CXFile* file, ulong* line, ulong* column, ulong* offset);
 
     // Function @ Index.h:619:21
-    public static void clang_getInstantiationLocation(CXSourceLocation location, CXFile* file, ulong* line, ulong* column, ulong* offset)
-    {
-        _virtualTable.clang_getInstantiationLocation(location, file, line, column, offset);
-    }
+    [DllImport("clang")]
+    public static extern void clang_getInstantiationLocation(CXSourceLocation location, CXFile* file, ulong* line, ulong* column, ulong* offset);
 
     // Function @ Index.h:607:21
-    public static void clang_getPresumedLocation(CXSourceLocation location, CXString* filename, ulong* line, ulong* column)
-    {
-        _virtualTable.clang_getPresumedLocation(location, filename, line, column);
-    }
+    [DllImport("clang")]
+    public static extern void clang_getPresumedLocation(CXSourceLocation location, CXString* filename, ulong* line, ulong* column);
 
     // Function @ Index.h:562:21
-    public static void clang_getExpansionLocation(CXSourceLocation location, CXFile* file, ulong* line, ulong* column, ulong* offset)
-    {
-        _virtualTable.clang_getExpansionLocation(location, file, line, column, offset);
-    }
+    [DllImport("clang")]
+    public static extern void clang_getExpansionLocation(CXSourceLocation location, CXFile* file, ulong* line, ulong* column, ulong* offset);
 
     // Function @ Index.h:538:20
-    public static int clang_Range_isNull(CXSourceRange range)
-    {
-        return _virtualTable.clang_Range_isNull(range);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Range_isNull(CXSourceRange range);
 
     // Function @ Index.h:532:25
-    public static uint clang_equalRanges(CXSourceRange range1, CXSourceRange range2)
-    {
-        return _virtualTable.clang_equalRanges(range1, range2);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_equalRanges(CXSourceRange range1, CXSourceRange range2);
 
     // Function @ Index.h:524:30
-    public static CXSourceRange clang_getRange(CXSourceLocation begin, CXSourceLocation end)
-    {
-        return _virtualTable.clang_getRange(begin, end);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRange clang_getRange(CXSourceLocation begin, CXSourceLocation end);
 
     // Function @ Index.h:518:30
-    public static CXSourceRange clang_getNullRange()
-    {
-        return _virtualTable.clang_getNullRange();
-    }
+    [DllImport("clang")]
+    public static extern CXSourceRange clang_getNullRange();
 
     // Function @ Index.h:513:20
-    public static int clang_Location_isFromMainFile(CXSourceLocation location)
-    {
-        return _virtualTable.clang_Location_isFromMainFile(location);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Location_isFromMainFile(CXSourceLocation location);
 
     // Function @ Index.h:507:20
-    public static int clang_Location_isInSystemHeader(CXSourceLocation location)
-    {
-        return _virtualTable.clang_Location_isInSystemHeader(location);
-    }
+    [DllImport("clang")]
+    public static extern int clang_Location_isInSystemHeader(CXSourceLocation location);
 
     // Function @ Index.h:500:33
-    public static CXSourceLocation clang_getLocationForOffset(CXTranslationUnit tu, CXFile file, uint offset)
-    {
-        return _virtualTable.clang_getLocationForOffset(tu, file, offset);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceLocation clang_getLocationForOffset(CXTranslationUnit tu, CXFile file, uint offset);
 
     // Function @ Index.h:493:33
-    public static CXSourceLocation clang_getLocation(CXTranslationUnit tu, CXFile file, uint line, uint column)
-    {
-        return _virtualTable.clang_getLocation(tu, file, line, column);
-    }
+    [DllImport("clang")]
+    public static extern CXSourceLocation clang_getLocation(CXTranslationUnit tu, CXFile file, uint line, uint column);
 
     // Function @ Index.h:486:25
-    public static uint clang_equalLocations(CXSourceLocation loc1, CXSourceLocation loc2)
-    {
-        return _virtualTable.clang_equalLocations(loc1, loc2);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_equalLocations(CXSourceLocation loc1, CXSourceLocation loc2);
 
     // Function @ Index.h:476:33
-    public static CXSourceLocation clang_getNullLocation()
-    {
-        return _virtualTable.clang_getNullLocation();
-    }
+    [DllImport("clang")]
+    public static extern CXSourceLocation clang_getNullLocation();
 
     // Function @ Index.h:430:25
-    public static CXString clang_File_tryGetRealPathName(CXFile file)
-    {
-        return _virtualTable.clang_File_tryGetRealPathName(file);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_File_tryGetRealPathName(CXFile file);
 
     // Function @ Index.h:423:20
-    public static int clang_File_isEqual(CXFile file1, CXFile file2)
-    {
-        return _virtualTable.clang_File_isEqual(file1, file2);
-    }
+    [DllImport("clang")]
+    public static extern int clang_File_isEqual(CXFile file1, CXFile file2);
 
     // Function @ Index.h:416:28
-    public static CString clang_getFileContents(CXTranslationUnit tu, CXFile file, ulong* size)
-    {
-        return _virtualTable.clang_getFileContents(tu, file, size);
-    }
+    [DllImport("clang")]
+    public static extern CString clang_getFileContents(CXTranslationUnit tu, CXFile file, ulong* size);
 
     // Function @ Index.h:401:23
-    public static CXFile clang_getFile(CXTranslationUnit tu, CString file_name)
-    {
-        return _virtualTable.clang_getFile(tu, file_name);
-    }
+    [DllImport("clang")]
+    public static extern CXFile clang_getFile(CXTranslationUnit tu, CString file_name);
 
     // Function @ Index.h:388:25
-    public static uint clang_isFileMultipleIncludeGuarded(CXTranslationUnit tu, CXFile file)
-    {
-        return _virtualTable.clang_isFileMultipleIncludeGuarded(tu, file);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_isFileMultipleIncludeGuarded(CXTranslationUnit tu, CXFile file);
 
     // Function @ Index.h:381:20
-    public static int clang_getFileUniqueID(CXFile file, CXFileUniqueID* outID)
-    {
-        return _virtualTable.clang_getFileUniqueID(file, outID);
-    }
+    [DllImport("clang")]
+    public static extern int clang_getFileUniqueID(CXFile file, CXFileUniqueID* outID);
 
     // Function @ Index.h:363:23
-    public static time_t clang_getFileTime(CXFile SFile)
-    {
-        return _virtualTable.clang_getFileTime(SFile);
-    }
+    [DllImport("clang")]
+    public static extern time_t clang_getFileTime(CXFile SFile);
 
     // Function @ Index.h:358:25
-    public static CXString clang_getFileName(CXFile SFile)
-    {
-        return _virtualTable.clang_getFileName(SFile);
-    }
+    [DllImport("clang")]
+    public static extern CXString clang_getFileName(CXFile SFile);
 
     // Function @ Index.h:342:1
-    public static void clang_CXIndex_setInvocationEmissionPathOption(CXIndex param, CString Path)
-    {
-        _virtualTable.clang_CXIndex_setInvocationEmissionPathOption(param, Path);
-    }
+    [DllImport("clang")]
+    public static extern void clang_CXIndex_setInvocationEmissionPathOption(CXIndex param, CString Path);
 
     // Function @ Index.h:332:25
-    public static uint clang_CXIndex_getGlobalOptions(CXIndex param)
-    {
-        return _virtualTable.clang_CXIndex_getGlobalOptions(param);
-    }
+    [DllImport("clang")]
+    public static extern uint clang_CXIndex_getGlobalOptions(CXIndex param);
 
     // Function @ Index.h:324:21
-    public static void clang_CXIndex_setGlobalOptions(CXIndex param, uint options)
-    {
-        _virtualTable.clang_CXIndex_setGlobalOptions(param, options);
-    }
+    [DllImport("clang")]
+    public static extern void clang_CXIndex_setGlobalOptions(CXIndex param, uint options);
 
     // Function @ Index.h:275:21
-    public static void clang_disposeIndex(CXIndex index)
-    {
-        _virtualTable.clang_disposeIndex(index);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeIndex(CXIndex index);
 
     // Function @ Index.h:266:24
-    public static CXIndex clang_createIndex(int excludeDeclarationsFromPCH, int displayDiagnostics)
-    {
-        return _virtualTable.clang_createIndex(excludeDeclarationsFromPCH, displayDiagnostics);
-    }
+    [DllImport("clang")]
+    public static extern CXIndex clang_createIndex(int excludeDeclarationsFromPCH, int displayDiagnostics);
 
     // Function @ BuildSystem.h:144:21
-    public static void clang_ModuleMapDescriptor_dispose(CXModuleMapDescriptor param)
-    {
-        _virtualTable.clang_ModuleMapDescriptor_dispose(param);
-    }
+    [DllImport("clang")]
+    public static extern void clang_ModuleMapDescriptor_dispose(CXModuleMapDescriptor param);
 
     // Function @ BuildSystem.h:137:1
-    public static CXErrorCode clang_ModuleMapDescriptor_writeToBuffer(CXModuleMapDescriptor param, uint options, CString* out_buffer_ptr, ulong* out_buffer_size)
-    {
-        return _virtualTable.clang_ModuleMapDescriptor_writeToBuffer(param, options, out_buffer_ptr, out_buffer_size);
-    }
+    [DllImport("clang")]
+    public static extern CXErrorCode clang_ModuleMapDescriptor_writeToBuffer(CXModuleMapDescriptor param, uint options, CString* out_buffer_ptr, ulong* out_buffer_size);
 
     // Function @ BuildSystem.h:124:1
-    public static CXErrorCode clang_ModuleMapDescriptor_setUmbrellaHeader(CXModuleMapDescriptor param, CString name)
-    {
-        return _virtualTable.clang_ModuleMapDescriptor_setUmbrellaHeader(param, name);
-    }
+    [DllImport("clang")]
+    public static extern CXErrorCode clang_ModuleMapDescriptor_setUmbrellaHeader(CXModuleMapDescriptor param, CString name);
 
     // Function @ BuildSystem.h:116:1
-    public static CXErrorCode clang_ModuleMapDescriptor_setFrameworkModuleName(CXModuleMapDescriptor param, CString name)
-    {
-        return _virtualTable.clang_ModuleMapDescriptor_setFrameworkModuleName(param, name);
-    }
+    [DllImport("clang")]
+    public static extern CXErrorCode clang_ModuleMapDescriptor_setFrameworkModuleName(CXModuleMapDescriptor param, CString name);
 
     // Function @ BuildSystem.h:109:1
-    public static CXModuleMapDescriptor clang_ModuleMapDescriptor_create(uint options)
-    {
-        return _virtualTable.clang_ModuleMapDescriptor_create(options);
-    }
+    [DllImport("clang")]
+    public static extern CXModuleMapDescriptor clang_ModuleMapDescriptor_create(uint options);
 
     // Function @ BuildSystem.h:95:21
-    public static void clang_VirtualFileOverlay_dispose(CXVirtualFileOverlay param)
-    {
-        _virtualTable.clang_VirtualFileOverlay_dispose(param);
-    }
+    [DllImport("clang")]
+    public static extern void clang_VirtualFileOverlay_dispose(CXVirtualFileOverlay param);
 
     // Function @ BuildSystem.h:90:21
-    public static void clang_free(void* buffer)
-    {
-        _virtualTable.clang_free(buffer);
-    }
+    [DllImport("clang")]
+    public static extern void clang_free(void* buffer);
 
     // Function @ BuildSystem.h:80:1
-    public static CXErrorCode clang_VirtualFileOverlay_writeToBuffer(CXVirtualFileOverlay param, uint options, CString* out_buffer_ptr, ulong* out_buffer_size)
-    {
-        return _virtualTable.clang_VirtualFileOverlay_writeToBuffer(param, options, out_buffer_ptr, out_buffer_size);
-    }
+    [DllImport("clang")]
+    public static extern CXErrorCode clang_VirtualFileOverlay_writeToBuffer(CXVirtualFileOverlay param, uint options, CString* out_buffer_ptr, ulong* out_buffer_size);
 
     // Function @ BuildSystem.h:67:1
-    public static CXErrorCode clang_VirtualFileOverlay_setCaseSensitivity(CXVirtualFileOverlay param, int caseSensitive)
-    {
-        return _virtualTable.clang_VirtualFileOverlay_setCaseSensitivity(param, caseSensitive);
-    }
+    [DllImport("clang")]
+    public static extern CXErrorCode clang_VirtualFileOverlay_setCaseSensitivity(CXVirtualFileOverlay param, int caseSensitive);
 
     // Function @ BuildSystem.h:56:1
-    public static CXErrorCode clang_VirtualFileOverlay_addFileMapping(CXVirtualFileOverlay param, CString virtualPath, CString realPath)
-    {
-        return _virtualTable.clang_VirtualFileOverlay_addFileMapping(param, virtualPath, realPath);
-    }
+    [DllImport("clang")]
+    public static extern CXErrorCode clang_VirtualFileOverlay_addFileMapping(CXVirtualFileOverlay param, CString virtualPath, CString realPath);
 
     // Function @ BuildSystem.h:48:1
-    public static CXVirtualFileOverlay clang_VirtualFileOverlay_create(uint options)
-    {
-        return _virtualTable.clang_VirtualFileOverlay_create(options);
-    }
+    [DllImport("clang")]
+    public static extern CXVirtualFileOverlay clang_VirtualFileOverlay_create(uint options);
 
     // Function @ BuildSystem.h:33:35
-    public static ulong clang_getBuildSessionTimestamp()
-    {
-        return _virtualTable.clang_getBuildSessionTimestamp();
-    }
+    [DllImport("clang")]
+    public static extern ulong clang_getBuildSessionTimestamp();
 
     // Function @ CXString.h:60:21
-    public static void clang_disposeStringSet(CXStringSet* set)
-    {
-        _virtualTable.clang_disposeStringSet(set);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeStringSet(CXStringSet* set);
 
     // Function @ CXString.h:55:21
-    public static void clang_disposeString(CXString @string)
-    {
-        _virtualTable.clang_disposeString(@string);
-    }
+    [DllImport("clang")]
+    public static extern void clang_disposeString(CXString @string);
 
     // Function @ CXString.h:50:28
-    public static CString clang_getCString(CXString @string)
-    {
-        return _virtualTable.clang_getCString(@string);
-    }
+    [DllImport("clang")]
+    public static extern CString clang_getCString(CXString @string);
 
     // FunctionPointer @ Index.h:6746:32
     [StructLayout(LayoutKind.Sequential)]
@@ -2443,8 +1751,8 @@ public static unsafe partial class clang
         [FieldOffset(8)] // size = 8, padding = 0
         public CString Contents;
 
-        [FieldOffset(16)] // size = 4, padding = 4
-        public uint Length;
+        [FieldOffset(16)] // size = 8, padding = 0
+        public ulong Length;
     }
 
     // Struct @ Index.h:6414:3
@@ -2734,14 +2042,14 @@ public static unsafe partial class clang
     }
 
     // Struct @ Index.h:1645:3
-    [StructLayout(LayoutKind.Explicit, Size = 8, Pack = 4)]
+    [StructLayout(LayoutKind.Explicit, Size = 16, Pack = 8)]
     public struct CXTUResourceUsageEntry
     {
-        [FieldOffset(0)] // size = 4, padding = 0
+        [FieldOffset(0)] // size = 4, padding = 4
         public CXTUResourceUsageKind kind;
 
-        [FieldOffset(4)] // size = 4, padding = 0
-        public uint amount;
+        [FieldOffset(8)] // size = 8, padding = 0
+        public ulong amount;
     }
 
     // Struct @ Index.h:700:3
@@ -3027,1819 +2335,767 @@ public static unsafe partial class clang
     }
 
     // Enum @ Index.h:6087:6
-    public enum CXVisitorResult : int
+    public enum CXVisitorResult : uint
     {
-        CXVisit_Break = 0,
-        CXVisit_Continue = 1
+        CXVisit_Break = 0U,
+        CXVisit_Continue = 1U
     }
 
     // Enum @ Index.h:1706:6
-    public enum CXCursorKind : int
+    public enum CXCursorKind : uint
     {
-        CXCursor_UnexposedDecl = 1,
-        CXCursor_StructDecl = 2,
-        CXCursor_UnionDecl = 3,
-        CXCursor_ClassDecl = 4,
-        CXCursor_EnumDecl = 5,
-        CXCursor_FieldDecl = 6,
-        CXCursor_EnumConstantDecl = 7,
-        CXCursor_FunctionDecl = 8,
-        CXCursor_VarDecl = 9,
-        CXCursor_ParmDecl = 10,
-        CXCursor_ObjCInterfaceDecl = 11,
-        CXCursor_ObjCCategoryDecl = 12,
-        CXCursor_ObjCProtocolDecl = 13,
-        CXCursor_ObjCPropertyDecl = 14,
-        CXCursor_ObjCIvarDecl = 15,
-        CXCursor_ObjCInstanceMethodDecl = 16,
-        CXCursor_ObjCClassMethodDecl = 17,
-        CXCursor_ObjCImplementationDecl = 18,
-        CXCursor_ObjCCategoryImplDecl = 19,
-        CXCursor_TypedefDecl = 20,
-        CXCursor_CXXMethod = 21,
-        CXCursor_Namespace = 22,
-        CXCursor_LinkageSpec = 23,
-        CXCursor_Constructor = 24,
-        CXCursor_Destructor = 25,
-        CXCursor_ConversionFunction = 26,
-        CXCursor_TemplateTypeParameter = 27,
-        CXCursor_NonTypeTemplateParameter = 28,
-        CXCursor_TemplateTemplateParameter = 29,
-        CXCursor_FunctionTemplate = 30,
-        CXCursor_ClassTemplate = 31,
-        CXCursor_ClassTemplatePartialSpecialization = 32,
-        CXCursor_NamespaceAlias = 33,
-        CXCursor_UsingDirective = 34,
-        CXCursor_UsingDeclaration = 35,
-        CXCursor_TypeAliasDecl = 36,
-        CXCursor_ObjCSynthesizeDecl = 37,
-        CXCursor_ObjCDynamicDecl = 38,
-        CXCursor_CXXAccessSpecifier = 39,
-        CXCursor_FirstDecl = 1,
-        CXCursor_LastDecl = 39,
-        CXCursor_FirstRef = 40,
-        CXCursor_ObjCSuperClassRef = 40,
-        CXCursor_ObjCProtocolRef = 41,
-        CXCursor_ObjCClassRef = 42,
-        CXCursor_TypeRef = 43,
-        CXCursor_CXXBaseSpecifier = 44,
-        CXCursor_TemplateRef = 45,
-        CXCursor_NamespaceRef = 46,
-        CXCursor_MemberRef = 47,
-        CXCursor_LabelRef = 48,
-        CXCursor_OverloadedDeclRef = 49,
-        CXCursor_VariableRef = 50,
-        CXCursor_LastRef = 50,
-        CXCursor_FirstInvalid = 70,
-        CXCursor_InvalidFile = 70,
-        CXCursor_NoDeclFound = 71,
-        CXCursor_NotImplemented = 72,
-        CXCursor_InvalidCode = 73,
-        CXCursor_LastInvalid = 73,
-        CXCursor_FirstExpr = 100,
-        CXCursor_UnexposedExpr = 100,
-        CXCursor_DeclRefExpr = 101,
-        CXCursor_MemberRefExpr = 102,
-        CXCursor_CallExpr = 103,
-        CXCursor_ObjCMessageExpr = 104,
-        CXCursor_BlockExpr = 105,
-        CXCursor_IntegerLiteral = 106,
-        CXCursor_FloatingLiteral = 107,
-        CXCursor_ImaginaryLiteral = 108,
-        CXCursor_StringLiteral = 109,
-        CXCursor_CharacterLiteral = 110,
-        CXCursor_ParenExpr = 111,
-        CXCursor_UnaryOperator = 112,
-        CXCursor_ArraySubscriptExpr = 113,
-        CXCursor_BinaryOperator = 114,
-        CXCursor_CompoundAssignOperator = 115,
-        CXCursor_ConditionalOperator = 116,
-        CXCursor_CStyleCastExpr = 117,
-        CXCursor_CompoundLiteralExpr = 118,
-        CXCursor_InitListExpr = 119,
-        CXCursor_AddrLabelExpr = 120,
-        CXCursor_StmtExpr = 121,
-        CXCursor_GenericSelectionExpr = 122,
-        CXCursor_GNUNullExpr = 123,
-        CXCursor_CXXStaticCastExpr = 124,
-        CXCursor_CXXDynamicCastExpr = 125,
-        CXCursor_CXXReinterpretCastExpr = 126,
-        CXCursor_CXXConstCastExpr = 127,
-        CXCursor_CXXFunctionalCastExpr = 128,
-        CXCursor_CXXTypeidExpr = 129,
-        CXCursor_CXXBoolLiteralExpr = 130,
-        CXCursor_CXXNullPtrLiteralExpr = 131,
-        CXCursor_CXXThisExpr = 132,
-        CXCursor_CXXThrowExpr = 133,
-        CXCursor_CXXNewExpr = 134,
-        CXCursor_CXXDeleteExpr = 135,
-        CXCursor_UnaryExpr = 136,
-        CXCursor_ObjCStringLiteral = 137,
-        CXCursor_ObjCEncodeExpr = 138,
-        CXCursor_ObjCSelectorExpr = 139,
-        CXCursor_ObjCProtocolExpr = 140,
-        CXCursor_ObjCBridgedCastExpr = 141,
-        CXCursor_PackExpansionExpr = 142,
-        CXCursor_SizeOfPackExpr = 143,
-        CXCursor_LambdaExpr = 144,
-        CXCursor_ObjCBoolLiteralExpr = 145,
-        CXCursor_ObjCSelfExpr = 146,
-        CXCursor_OMPArraySectionExpr = 147,
-        CXCursor_ObjCAvailabilityCheckExpr = 148,
-        CXCursor_FixedPointLiteral = 149,
-        CXCursor_OMPArrayShapingExpr = 150,
-        CXCursor_OMPIteratorExpr = 151,
-        CXCursor_CXXAddrspaceCastExpr = 152,
-        CXCursor_LastExpr = 152,
-        CXCursor_FirstStmt = 200,
-        CXCursor_UnexposedStmt = 200,
-        CXCursor_LabelStmt = 201,
-        CXCursor_CompoundStmt = 202,
-        CXCursor_CaseStmt = 203,
-        CXCursor_DefaultStmt = 204,
-        CXCursor_IfStmt = 205,
-        CXCursor_SwitchStmt = 206,
-        CXCursor_WhileStmt = 207,
-        CXCursor_DoStmt = 208,
-        CXCursor_ForStmt = 209,
-        CXCursor_GotoStmt = 210,
-        CXCursor_IndirectGotoStmt = 211,
-        CXCursor_ContinueStmt = 212,
-        CXCursor_BreakStmt = 213,
-        CXCursor_ReturnStmt = 214,
-        CXCursor_GCCAsmStmt = 215,
-        CXCursor_AsmStmt = 215,
-        CXCursor_ObjCAtTryStmt = 216,
-        CXCursor_ObjCAtCatchStmt = 217,
-        CXCursor_ObjCAtFinallyStmt = 218,
-        CXCursor_ObjCAtThrowStmt = 219,
-        CXCursor_ObjCAtSynchronizedStmt = 220,
-        CXCursor_ObjCAutoreleasePoolStmt = 221,
-        CXCursor_ObjCForCollectionStmt = 222,
-        CXCursor_CXXCatchStmt = 223,
-        CXCursor_CXXTryStmt = 224,
-        CXCursor_CXXForRangeStmt = 225,
-        CXCursor_SEHTryStmt = 226,
-        CXCursor_SEHExceptStmt = 227,
-        CXCursor_SEHFinallyStmt = 228,
-        CXCursor_MSAsmStmt = 229,
-        CXCursor_NullStmt = 230,
-        CXCursor_DeclStmt = 231,
-        CXCursor_OMPParallelDirective = 232,
-        CXCursor_OMPSimdDirective = 233,
-        CXCursor_OMPForDirective = 234,
-        CXCursor_OMPSectionsDirective = 235,
-        CXCursor_OMPSectionDirective = 236,
-        CXCursor_OMPSingleDirective = 237,
-        CXCursor_OMPParallelForDirective = 238,
-        CXCursor_OMPParallelSectionsDirective = 239,
-        CXCursor_OMPTaskDirective = 240,
-        CXCursor_OMPMasterDirective = 241,
-        CXCursor_OMPCriticalDirective = 242,
-        CXCursor_OMPTaskyieldDirective = 243,
-        CXCursor_OMPBarrierDirective = 244,
-        CXCursor_OMPTaskwaitDirective = 245,
-        CXCursor_OMPFlushDirective = 246,
-        CXCursor_SEHLeaveStmt = 247,
-        CXCursor_OMPOrderedDirective = 248,
-        CXCursor_OMPAtomicDirective = 249,
-        CXCursor_OMPForSimdDirective = 250,
-        CXCursor_OMPParallelForSimdDirective = 251,
-        CXCursor_OMPTargetDirective = 252,
-        CXCursor_OMPTeamsDirective = 253,
-        CXCursor_OMPTaskgroupDirective = 254,
-        CXCursor_OMPCancellationPointDirective = 255,
-        CXCursor_OMPCancelDirective = 256,
-        CXCursor_OMPTargetDataDirective = 257,
-        CXCursor_OMPTaskLoopDirective = 258,
-        CXCursor_OMPTaskLoopSimdDirective = 259,
-        CXCursor_OMPDistributeDirective = 260,
-        CXCursor_OMPTargetEnterDataDirective = 261,
-        CXCursor_OMPTargetExitDataDirective = 262,
-        CXCursor_OMPTargetParallelDirective = 263,
-        CXCursor_OMPTargetParallelForDirective = 264,
-        CXCursor_OMPTargetUpdateDirective = 265,
-        CXCursor_OMPDistributeParallelForDirective = 266,
-        CXCursor_OMPDistributeParallelForSimdDirective = 267,
-        CXCursor_OMPDistributeSimdDirective = 268,
-        CXCursor_OMPTargetParallelForSimdDirective = 269,
-        CXCursor_OMPTargetSimdDirective = 270,
-        CXCursor_OMPTeamsDistributeDirective = 271,
-        CXCursor_OMPTeamsDistributeSimdDirective = 272,
-        CXCursor_OMPTeamsDistributeParallelForSimdDirective = 273,
-        CXCursor_OMPTeamsDistributeParallelForDirective = 274,
-        CXCursor_OMPTargetTeamsDirective = 275,
-        CXCursor_OMPTargetTeamsDistributeDirective = 276,
-        CXCursor_OMPTargetTeamsDistributeParallelForDirective = 277,
-        CXCursor_OMPTargetTeamsDistributeParallelForSimdDirective = 278,
-        CXCursor_OMPTargetTeamsDistributeSimdDirective = 279,
-        CXCursor_BuiltinBitCastExpr = 280,
-        CXCursor_OMPMasterTaskLoopDirective = 281,
-        CXCursor_OMPParallelMasterTaskLoopDirective = 282,
-        CXCursor_OMPMasterTaskLoopSimdDirective = 283,
-        CXCursor_OMPParallelMasterTaskLoopSimdDirective = 284,
-        CXCursor_OMPParallelMasterDirective = 285,
-        CXCursor_OMPDepobjDirective = 286,
-        CXCursor_OMPScanDirective = 287,
-        CXCursor_LastStmt = 287,
-        CXCursor_TranslationUnit = 300,
-        CXCursor_FirstAttr = 400,
-        CXCursor_UnexposedAttr = 400,
-        CXCursor_IBActionAttr = 401,
-        CXCursor_IBOutletAttr = 402,
-        CXCursor_IBOutletCollectionAttr = 403,
-        CXCursor_CXXFinalAttr = 404,
-        CXCursor_CXXOverrideAttr = 405,
-        CXCursor_AnnotateAttr = 406,
-        CXCursor_AsmLabelAttr = 407,
-        CXCursor_PackedAttr = 408,
-        CXCursor_PureAttr = 409,
-        CXCursor_ConstAttr = 410,
-        CXCursor_NoDuplicateAttr = 411,
-        CXCursor_CUDAConstantAttr = 412,
-        CXCursor_CUDADeviceAttr = 413,
-        CXCursor_CUDAGlobalAttr = 414,
-        CXCursor_CUDAHostAttr = 415,
-        CXCursor_CUDASharedAttr = 416,
-        CXCursor_VisibilityAttr = 417,
-        CXCursor_DLLExport = 418,
-        CXCursor_DLLImport = 419,
-        CXCursor_NSReturnsRetained = 420,
-        CXCursor_NSReturnsNotRetained = 421,
-        CXCursor_NSReturnsAutoreleased = 422,
-        CXCursor_NSConsumesSelf = 423,
-        CXCursor_NSConsumed = 424,
-        CXCursor_ObjCException = 425,
-        CXCursor_ObjCNSObject = 426,
-        CXCursor_ObjCIndependentClass = 427,
-        CXCursor_ObjCPreciseLifetime = 428,
-        CXCursor_ObjCReturnsInnerPointer = 429,
-        CXCursor_ObjCRequiresSuper = 430,
-        CXCursor_ObjCRootClass = 431,
-        CXCursor_ObjCSubclassingRestricted = 432,
-        CXCursor_ObjCExplicitProtocolImpl = 433,
-        CXCursor_ObjCDesignatedInitializer = 434,
-        CXCursor_ObjCRuntimeVisible = 435,
-        CXCursor_ObjCBoxable = 436,
-        CXCursor_FlagEnum = 437,
-        CXCursor_ConvergentAttr = 438,
-        CXCursor_WarnUnusedAttr = 439,
-        CXCursor_WarnUnusedResultAttr = 440,
-        CXCursor_AlignedAttr = 441,
-        CXCursor_LastAttr = 441,
-        CXCursor_PreprocessingDirective = 500,
-        CXCursor_MacroDefinition = 501,
-        CXCursor_MacroExpansion = 502,
-        CXCursor_MacroInstantiation = 502,
-        CXCursor_InclusionDirective = 503,
-        CXCursor_FirstPreprocessing = 500,
-        CXCursor_LastPreprocessing = 503,
-        CXCursor_ModuleImportDecl = 600,
-        CXCursor_TypeAliasTemplateDecl = 601,
-        CXCursor_StaticAssert = 602,
-        CXCursor_FriendDecl = 603,
-        CXCursor_FirstExtraDecl = 600,
-        CXCursor_LastExtraDecl = 603,
-        CXCursor_OverloadCandidate = 700
+        CXCursor_UnexposedDecl = 1U,
+        CXCursor_StructDecl = 2U,
+        CXCursor_UnionDecl = 3U,
+        CXCursor_ClassDecl = 4U,
+        CXCursor_EnumDecl = 5U,
+        CXCursor_FieldDecl = 6U,
+        CXCursor_EnumConstantDecl = 7U,
+        CXCursor_FunctionDecl = 8U,
+        CXCursor_VarDecl = 9U,
+        CXCursor_ParmDecl = 10U,
+        CXCursor_ObjCInterfaceDecl = 11U,
+        CXCursor_ObjCCategoryDecl = 12U,
+        CXCursor_ObjCProtocolDecl = 13U,
+        CXCursor_ObjCPropertyDecl = 14U,
+        CXCursor_ObjCIvarDecl = 15U,
+        CXCursor_ObjCInstanceMethodDecl = 16U,
+        CXCursor_ObjCClassMethodDecl = 17U,
+        CXCursor_ObjCImplementationDecl = 18U,
+        CXCursor_ObjCCategoryImplDecl = 19U,
+        CXCursor_TypedefDecl = 20U,
+        CXCursor_CXXMethod = 21U,
+        CXCursor_Namespace = 22U,
+        CXCursor_LinkageSpec = 23U,
+        CXCursor_Constructor = 24U,
+        CXCursor_Destructor = 25U,
+        CXCursor_ConversionFunction = 26U,
+        CXCursor_TemplateTypeParameter = 27U,
+        CXCursor_NonTypeTemplateParameter = 28U,
+        CXCursor_TemplateTemplateParameter = 29U,
+        CXCursor_FunctionTemplate = 30U,
+        CXCursor_ClassTemplate = 31U,
+        CXCursor_ClassTemplatePartialSpecialization = 32U,
+        CXCursor_NamespaceAlias = 33U,
+        CXCursor_UsingDirective = 34U,
+        CXCursor_UsingDeclaration = 35U,
+        CXCursor_TypeAliasDecl = 36U,
+        CXCursor_ObjCSynthesizeDecl = 37U,
+        CXCursor_ObjCDynamicDecl = 38U,
+        CXCursor_CXXAccessSpecifier = 39U,
+        CXCursor_FirstDecl = 1U,
+        CXCursor_LastDecl = 39U,
+        CXCursor_FirstRef = 40U,
+        CXCursor_ObjCSuperClassRef = 40U,
+        CXCursor_ObjCProtocolRef = 41U,
+        CXCursor_ObjCClassRef = 42U,
+        CXCursor_TypeRef = 43U,
+        CXCursor_CXXBaseSpecifier = 44U,
+        CXCursor_TemplateRef = 45U,
+        CXCursor_NamespaceRef = 46U,
+        CXCursor_MemberRef = 47U,
+        CXCursor_LabelRef = 48U,
+        CXCursor_OverloadedDeclRef = 49U,
+        CXCursor_VariableRef = 50U,
+        CXCursor_LastRef = 50U,
+        CXCursor_FirstInvalid = 70U,
+        CXCursor_InvalidFile = 70U,
+        CXCursor_NoDeclFound = 71U,
+        CXCursor_NotImplemented = 72U,
+        CXCursor_InvalidCode = 73U,
+        CXCursor_LastInvalid = 73U,
+        CXCursor_FirstExpr = 100U,
+        CXCursor_UnexposedExpr = 100U,
+        CXCursor_DeclRefExpr = 101U,
+        CXCursor_MemberRefExpr = 102U,
+        CXCursor_CallExpr = 103U,
+        CXCursor_ObjCMessageExpr = 104U,
+        CXCursor_BlockExpr = 105U,
+        CXCursor_IntegerLiteral = 106U,
+        CXCursor_FloatingLiteral = 107U,
+        CXCursor_ImaginaryLiteral = 108U,
+        CXCursor_StringLiteral = 109U,
+        CXCursor_CharacterLiteral = 110U,
+        CXCursor_ParenExpr = 111U,
+        CXCursor_UnaryOperator = 112U,
+        CXCursor_ArraySubscriptExpr = 113U,
+        CXCursor_BinaryOperator = 114U,
+        CXCursor_CompoundAssignOperator = 115U,
+        CXCursor_ConditionalOperator = 116U,
+        CXCursor_CStyleCastExpr = 117U,
+        CXCursor_CompoundLiteralExpr = 118U,
+        CXCursor_InitListExpr = 119U,
+        CXCursor_AddrLabelExpr = 120U,
+        CXCursor_StmtExpr = 121U,
+        CXCursor_GenericSelectionExpr = 122U,
+        CXCursor_GNUNullExpr = 123U,
+        CXCursor_CXXStaticCastExpr = 124U,
+        CXCursor_CXXDynamicCastExpr = 125U,
+        CXCursor_CXXReinterpretCastExpr = 126U,
+        CXCursor_CXXConstCastExpr = 127U,
+        CXCursor_CXXFunctionalCastExpr = 128U,
+        CXCursor_CXXTypeidExpr = 129U,
+        CXCursor_CXXBoolLiteralExpr = 130U,
+        CXCursor_CXXNullPtrLiteralExpr = 131U,
+        CXCursor_CXXThisExpr = 132U,
+        CXCursor_CXXThrowExpr = 133U,
+        CXCursor_CXXNewExpr = 134U,
+        CXCursor_CXXDeleteExpr = 135U,
+        CXCursor_UnaryExpr = 136U,
+        CXCursor_ObjCStringLiteral = 137U,
+        CXCursor_ObjCEncodeExpr = 138U,
+        CXCursor_ObjCSelectorExpr = 139U,
+        CXCursor_ObjCProtocolExpr = 140U,
+        CXCursor_ObjCBridgedCastExpr = 141U,
+        CXCursor_PackExpansionExpr = 142U,
+        CXCursor_SizeOfPackExpr = 143U,
+        CXCursor_LambdaExpr = 144U,
+        CXCursor_ObjCBoolLiteralExpr = 145U,
+        CXCursor_ObjCSelfExpr = 146U,
+        CXCursor_OMPArraySectionExpr = 147U,
+        CXCursor_ObjCAvailabilityCheckExpr = 148U,
+        CXCursor_FixedPointLiteral = 149U,
+        CXCursor_OMPArrayShapingExpr = 150U,
+        CXCursor_OMPIteratorExpr = 151U,
+        CXCursor_CXXAddrspaceCastExpr = 152U,
+        CXCursor_LastExpr = 152U,
+        CXCursor_FirstStmt = 200U,
+        CXCursor_UnexposedStmt = 200U,
+        CXCursor_LabelStmt = 201U,
+        CXCursor_CompoundStmt = 202U,
+        CXCursor_CaseStmt = 203U,
+        CXCursor_DefaultStmt = 204U,
+        CXCursor_IfStmt = 205U,
+        CXCursor_SwitchStmt = 206U,
+        CXCursor_WhileStmt = 207U,
+        CXCursor_DoStmt = 208U,
+        CXCursor_ForStmt = 209U,
+        CXCursor_GotoStmt = 210U,
+        CXCursor_IndirectGotoStmt = 211U,
+        CXCursor_ContinueStmt = 212U,
+        CXCursor_BreakStmt = 213U,
+        CXCursor_ReturnStmt = 214U,
+        CXCursor_GCCAsmStmt = 215U,
+        CXCursor_AsmStmt = 215U,
+        CXCursor_ObjCAtTryStmt = 216U,
+        CXCursor_ObjCAtCatchStmt = 217U,
+        CXCursor_ObjCAtFinallyStmt = 218U,
+        CXCursor_ObjCAtThrowStmt = 219U,
+        CXCursor_ObjCAtSynchronizedStmt = 220U,
+        CXCursor_ObjCAutoreleasePoolStmt = 221U,
+        CXCursor_ObjCForCollectionStmt = 222U,
+        CXCursor_CXXCatchStmt = 223U,
+        CXCursor_CXXTryStmt = 224U,
+        CXCursor_CXXForRangeStmt = 225U,
+        CXCursor_SEHTryStmt = 226U,
+        CXCursor_SEHExceptStmt = 227U,
+        CXCursor_SEHFinallyStmt = 228U,
+        CXCursor_MSAsmStmt = 229U,
+        CXCursor_NullStmt = 230U,
+        CXCursor_DeclStmt = 231U,
+        CXCursor_OMPParallelDirective = 232U,
+        CXCursor_OMPSimdDirective = 233U,
+        CXCursor_OMPForDirective = 234U,
+        CXCursor_OMPSectionsDirective = 235U,
+        CXCursor_OMPSectionDirective = 236U,
+        CXCursor_OMPSingleDirective = 237U,
+        CXCursor_OMPParallelForDirective = 238U,
+        CXCursor_OMPParallelSectionsDirective = 239U,
+        CXCursor_OMPTaskDirective = 240U,
+        CXCursor_OMPMasterDirective = 241U,
+        CXCursor_OMPCriticalDirective = 242U,
+        CXCursor_OMPTaskyieldDirective = 243U,
+        CXCursor_OMPBarrierDirective = 244U,
+        CXCursor_OMPTaskwaitDirective = 245U,
+        CXCursor_OMPFlushDirective = 246U,
+        CXCursor_SEHLeaveStmt = 247U,
+        CXCursor_OMPOrderedDirective = 248U,
+        CXCursor_OMPAtomicDirective = 249U,
+        CXCursor_OMPForSimdDirective = 250U,
+        CXCursor_OMPParallelForSimdDirective = 251U,
+        CXCursor_OMPTargetDirective = 252U,
+        CXCursor_OMPTeamsDirective = 253U,
+        CXCursor_OMPTaskgroupDirective = 254U,
+        CXCursor_OMPCancellationPointDirective = 255U,
+        CXCursor_OMPCancelDirective = 256U,
+        CXCursor_OMPTargetDataDirective = 257U,
+        CXCursor_OMPTaskLoopDirective = 258U,
+        CXCursor_OMPTaskLoopSimdDirective = 259U,
+        CXCursor_OMPDistributeDirective = 260U,
+        CXCursor_OMPTargetEnterDataDirective = 261U,
+        CXCursor_OMPTargetExitDataDirective = 262U,
+        CXCursor_OMPTargetParallelDirective = 263U,
+        CXCursor_OMPTargetParallelForDirective = 264U,
+        CXCursor_OMPTargetUpdateDirective = 265U,
+        CXCursor_OMPDistributeParallelForDirective = 266U,
+        CXCursor_OMPDistributeParallelForSimdDirective = 267U,
+        CXCursor_OMPDistributeSimdDirective = 268U,
+        CXCursor_OMPTargetParallelForSimdDirective = 269U,
+        CXCursor_OMPTargetSimdDirective = 270U,
+        CXCursor_OMPTeamsDistributeDirective = 271U,
+        CXCursor_OMPTeamsDistributeSimdDirective = 272U,
+        CXCursor_OMPTeamsDistributeParallelForSimdDirective = 273U,
+        CXCursor_OMPTeamsDistributeParallelForDirective = 274U,
+        CXCursor_OMPTargetTeamsDirective = 275U,
+        CXCursor_OMPTargetTeamsDistributeDirective = 276U,
+        CXCursor_OMPTargetTeamsDistributeParallelForDirective = 277U,
+        CXCursor_OMPTargetTeamsDistributeParallelForSimdDirective = 278U,
+        CXCursor_OMPTargetTeamsDistributeSimdDirective = 279U,
+        CXCursor_BuiltinBitCastExpr = 280U,
+        CXCursor_OMPMasterTaskLoopDirective = 281U,
+        CXCursor_OMPParallelMasterTaskLoopDirective = 282U,
+        CXCursor_OMPMasterTaskLoopSimdDirective = 283U,
+        CXCursor_OMPParallelMasterTaskLoopSimdDirective = 284U,
+        CXCursor_OMPParallelMasterDirective = 285U,
+        CXCursor_OMPDepobjDirective = 286U,
+        CXCursor_OMPScanDirective = 287U,
+        CXCursor_LastStmt = 287U,
+        CXCursor_TranslationUnit = 300U,
+        CXCursor_FirstAttr = 400U,
+        CXCursor_UnexposedAttr = 400U,
+        CXCursor_IBActionAttr = 401U,
+        CXCursor_IBOutletAttr = 402U,
+        CXCursor_IBOutletCollectionAttr = 403U,
+        CXCursor_CXXFinalAttr = 404U,
+        CXCursor_CXXOverrideAttr = 405U,
+        CXCursor_AnnotateAttr = 406U,
+        CXCursor_AsmLabelAttr = 407U,
+        CXCursor_PackedAttr = 408U,
+        CXCursor_PureAttr = 409U,
+        CXCursor_ConstAttr = 410U,
+        CXCursor_NoDuplicateAttr = 411U,
+        CXCursor_CUDAConstantAttr = 412U,
+        CXCursor_CUDADeviceAttr = 413U,
+        CXCursor_CUDAGlobalAttr = 414U,
+        CXCursor_CUDAHostAttr = 415U,
+        CXCursor_CUDASharedAttr = 416U,
+        CXCursor_VisibilityAttr = 417U,
+        CXCursor_DLLExport = 418U,
+        CXCursor_DLLImport = 419U,
+        CXCursor_NSReturnsRetained = 420U,
+        CXCursor_NSReturnsNotRetained = 421U,
+        CXCursor_NSReturnsAutoreleased = 422U,
+        CXCursor_NSConsumesSelf = 423U,
+        CXCursor_NSConsumed = 424U,
+        CXCursor_ObjCException = 425U,
+        CXCursor_ObjCNSObject = 426U,
+        CXCursor_ObjCIndependentClass = 427U,
+        CXCursor_ObjCPreciseLifetime = 428U,
+        CXCursor_ObjCReturnsInnerPointer = 429U,
+        CXCursor_ObjCRequiresSuper = 430U,
+        CXCursor_ObjCRootClass = 431U,
+        CXCursor_ObjCSubclassingRestricted = 432U,
+        CXCursor_ObjCExplicitProtocolImpl = 433U,
+        CXCursor_ObjCDesignatedInitializer = 434U,
+        CXCursor_ObjCRuntimeVisible = 435U,
+        CXCursor_ObjCBoxable = 436U,
+        CXCursor_FlagEnum = 437U,
+        CXCursor_ConvergentAttr = 438U,
+        CXCursor_WarnUnusedAttr = 439U,
+        CXCursor_WarnUnusedResultAttr = 440U,
+        CXCursor_AlignedAttr = 441U,
+        CXCursor_LastAttr = 441U,
+        CXCursor_PreprocessingDirective = 500U,
+        CXCursor_MacroDefinition = 501U,
+        CXCursor_MacroExpansion = 502U,
+        CXCursor_MacroInstantiation = 502U,
+        CXCursor_InclusionDirective = 503U,
+        CXCursor_FirstPreprocessing = 500U,
+        CXCursor_LastPreprocessing = 503U,
+        CXCursor_ModuleImportDecl = 600U,
+        CXCursor_TypeAliasTemplateDecl = 601U,
+        CXCursor_StaticAssert = 602U,
+        CXCursor_FriendDecl = 603U,
+        CXCursor_FirstExtraDecl = 600U,
+        CXCursor_LastExtraDecl = 603U,
+        CXCursor_OverloadCandidate = 700U
     }
 
     // Enum @ Index.h:3226:6
-    public enum CXTypeKind : int
+    public enum CXTypeKind : uint
     {
-        CXType_Invalid = 0,
-        CXType_Unexposed = 1,
-        CXType_Void = 2,
-        CXType_Bool = 3,
-        CXType_Char_U = 4,
-        CXType_UChar = 5,
-        CXType_Char16 = 6,
-        CXType_Char32 = 7,
-        CXType_UShort = 8,
-        CXType_UInt = 9,
-        CXType_ULong = 10,
-        CXType_ULongLong = 11,
-        CXType_UInt128 = 12,
-        CXType_Char_S = 13,
-        CXType_SChar = 14,
-        CXType_WChar = 15,
-        CXType_Short = 16,
-        CXType_Int = 17,
-        CXType_Long = 18,
-        CXType_LongLong = 19,
-        CXType_Int128 = 20,
-        CXType_Float = 21,
-        CXType_Double = 22,
-        CXType_LongDouble = 23,
-        CXType_NullPtr = 24,
-        CXType_Overload = 25,
-        CXType_Dependent = 26,
-        CXType_ObjCId = 27,
-        CXType_ObjCClass = 28,
-        CXType_ObjCSel = 29,
-        CXType_Float128 = 30,
-        CXType_Half = 31,
-        CXType_Float16 = 32,
-        CXType_ShortAccum = 33,
-        CXType_Accum = 34,
-        CXType_LongAccum = 35,
-        CXType_UShortAccum = 36,
-        CXType_UAccum = 37,
-        CXType_ULongAccum = 38,
-        CXType_BFloat16 = 39,
-        CXType_FirstBuiltin = 2,
-        CXType_LastBuiltin = 39,
-        CXType_Complex = 100,
-        CXType_Pointer = 101,
-        CXType_BlockPointer = 102,
-        CXType_LValueReference = 103,
-        CXType_RValueReference = 104,
-        CXType_Record = 105,
-        CXType_Enum = 106,
-        CXType_Typedef = 107,
-        CXType_ObjCInterface = 108,
-        CXType_ObjCObjectPointer = 109,
-        CXType_FunctionNoProto = 110,
-        CXType_FunctionProto = 111,
-        CXType_ConstantArray = 112,
-        CXType_Vector = 113,
-        CXType_IncompleteArray = 114,
-        CXType_VariableArray = 115,
-        CXType_DependentSizedArray = 116,
-        CXType_MemberPointer = 117,
-        CXType_Auto = 118,
-        CXType_Elaborated = 119,
-        CXType_Pipe = 120,
-        CXType_OCLImage1dRO = 121,
-        CXType_OCLImage1dArrayRO = 122,
-        CXType_OCLImage1dBufferRO = 123,
-        CXType_OCLImage2dRO = 124,
-        CXType_OCLImage2dArrayRO = 125,
-        CXType_OCLImage2dDepthRO = 126,
-        CXType_OCLImage2dArrayDepthRO = 127,
-        CXType_OCLImage2dMSAARO = 128,
-        CXType_OCLImage2dArrayMSAARO = 129,
-        CXType_OCLImage2dMSAADepthRO = 130,
-        CXType_OCLImage2dArrayMSAADepthRO = 131,
-        CXType_OCLImage3dRO = 132,
-        CXType_OCLImage1dWO = 133,
-        CXType_OCLImage1dArrayWO = 134,
-        CXType_OCLImage1dBufferWO = 135,
-        CXType_OCLImage2dWO = 136,
-        CXType_OCLImage2dArrayWO = 137,
-        CXType_OCLImage2dDepthWO = 138,
-        CXType_OCLImage2dArrayDepthWO = 139,
-        CXType_OCLImage2dMSAAWO = 140,
-        CXType_OCLImage2dArrayMSAAWO = 141,
-        CXType_OCLImage2dMSAADepthWO = 142,
-        CXType_OCLImage2dArrayMSAADepthWO = 143,
-        CXType_OCLImage3dWO = 144,
-        CXType_OCLImage1dRW = 145,
-        CXType_OCLImage1dArrayRW = 146,
-        CXType_OCLImage1dBufferRW = 147,
-        CXType_OCLImage2dRW = 148,
-        CXType_OCLImage2dArrayRW = 149,
-        CXType_OCLImage2dDepthRW = 150,
-        CXType_OCLImage2dArrayDepthRW = 151,
-        CXType_OCLImage2dMSAARW = 152,
-        CXType_OCLImage2dArrayMSAARW = 153,
-        CXType_OCLImage2dMSAADepthRW = 154,
-        CXType_OCLImage2dArrayMSAADepthRW = 155,
-        CXType_OCLImage3dRW = 156,
-        CXType_OCLSampler = 157,
-        CXType_OCLEvent = 158,
-        CXType_OCLQueue = 159,
-        CXType_OCLReserveID = 160,
-        CXType_ObjCObject = 161,
-        CXType_ObjCTypeParam = 162,
-        CXType_Attributed = 163,
-        CXType_OCLIntelSubgroupAVCMcePayload = 164,
-        CXType_OCLIntelSubgroupAVCImePayload = 165,
-        CXType_OCLIntelSubgroupAVCRefPayload = 166,
-        CXType_OCLIntelSubgroupAVCSicPayload = 167,
-        CXType_OCLIntelSubgroupAVCMceResult = 168,
-        CXType_OCLIntelSubgroupAVCImeResult = 169,
-        CXType_OCLIntelSubgroupAVCRefResult = 170,
-        CXType_OCLIntelSubgroupAVCSicResult = 171,
-        CXType_OCLIntelSubgroupAVCImeResultSingleRefStreamout = 172,
-        CXType_OCLIntelSubgroupAVCImeResultDualRefStreamout = 173,
-        CXType_OCLIntelSubgroupAVCImeSingleRefStreamin = 174,
-        CXType_OCLIntelSubgroupAVCImeDualRefStreamin = 175,
-        CXType_ExtVector = 176,
-        CXType_Atomic = 177
+        CXType_Invalid = 0U,
+        CXType_Unexposed = 1U,
+        CXType_Void = 2U,
+        CXType_Bool = 3U,
+        CXType_Char_U = 4U,
+        CXType_UChar = 5U,
+        CXType_Char16 = 6U,
+        CXType_Char32 = 7U,
+        CXType_UShort = 8U,
+        CXType_UInt = 9U,
+        CXType_ULong = 10U,
+        CXType_ULongLong = 11U,
+        CXType_UInt128 = 12U,
+        CXType_Char_S = 13U,
+        CXType_SChar = 14U,
+        CXType_WChar = 15U,
+        CXType_Short = 16U,
+        CXType_Int = 17U,
+        CXType_Long = 18U,
+        CXType_LongLong = 19U,
+        CXType_Int128 = 20U,
+        CXType_Float = 21U,
+        CXType_Double = 22U,
+        CXType_LongDouble = 23U,
+        CXType_NullPtr = 24U,
+        CXType_Overload = 25U,
+        CXType_Dependent = 26U,
+        CXType_ObjCId = 27U,
+        CXType_ObjCClass = 28U,
+        CXType_ObjCSel = 29U,
+        CXType_Float128 = 30U,
+        CXType_Half = 31U,
+        CXType_Float16 = 32U,
+        CXType_ShortAccum = 33U,
+        CXType_Accum = 34U,
+        CXType_LongAccum = 35U,
+        CXType_UShortAccum = 36U,
+        CXType_UAccum = 37U,
+        CXType_ULongAccum = 38U,
+        CXType_BFloat16 = 39U,
+        CXType_FirstBuiltin = 2U,
+        CXType_LastBuiltin = 39U,
+        CXType_Complex = 100U,
+        CXType_Pointer = 101U,
+        CXType_BlockPointer = 102U,
+        CXType_LValueReference = 103U,
+        CXType_RValueReference = 104U,
+        CXType_Record = 105U,
+        CXType_Enum = 106U,
+        CXType_Typedef = 107U,
+        CXType_ObjCInterface = 108U,
+        CXType_ObjCObjectPointer = 109U,
+        CXType_FunctionNoProto = 110U,
+        CXType_FunctionProto = 111U,
+        CXType_ConstantArray = 112U,
+        CXType_Vector = 113U,
+        CXType_IncompleteArray = 114U,
+        CXType_VariableArray = 115U,
+        CXType_DependentSizedArray = 116U,
+        CXType_MemberPointer = 117U,
+        CXType_Auto = 118U,
+        CXType_Elaborated = 119U,
+        CXType_Pipe = 120U,
+        CXType_OCLImage1dRO = 121U,
+        CXType_OCLImage1dArrayRO = 122U,
+        CXType_OCLImage1dBufferRO = 123U,
+        CXType_OCLImage2dRO = 124U,
+        CXType_OCLImage2dArrayRO = 125U,
+        CXType_OCLImage2dDepthRO = 126U,
+        CXType_OCLImage2dArrayDepthRO = 127U,
+        CXType_OCLImage2dMSAARO = 128U,
+        CXType_OCLImage2dArrayMSAARO = 129U,
+        CXType_OCLImage2dMSAADepthRO = 130U,
+        CXType_OCLImage2dArrayMSAADepthRO = 131U,
+        CXType_OCLImage3dRO = 132U,
+        CXType_OCLImage1dWO = 133U,
+        CXType_OCLImage1dArrayWO = 134U,
+        CXType_OCLImage1dBufferWO = 135U,
+        CXType_OCLImage2dWO = 136U,
+        CXType_OCLImage2dArrayWO = 137U,
+        CXType_OCLImage2dDepthWO = 138U,
+        CXType_OCLImage2dArrayDepthWO = 139U,
+        CXType_OCLImage2dMSAAWO = 140U,
+        CXType_OCLImage2dArrayMSAAWO = 141U,
+        CXType_OCLImage2dMSAADepthWO = 142U,
+        CXType_OCLImage2dArrayMSAADepthWO = 143U,
+        CXType_OCLImage3dWO = 144U,
+        CXType_OCLImage1dRW = 145U,
+        CXType_OCLImage1dArrayRW = 146U,
+        CXType_OCLImage1dBufferRW = 147U,
+        CXType_OCLImage2dRW = 148U,
+        CXType_OCLImage2dArrayRW = 149U,
+        CXType_OCLImage2dDepthRW = 150U,
+        CXType_OCLImage2dArrayDepthRW = 151U,
+        CXType_OCLImage2dMSAARW = 152U,
+        CXType_OCLImage2dArrayMSAARW = 153U,
+        CXType_OCLImage2dMSAADepthRW = 154U,
+        CXType_OCLImage2dArrayMSAADepthRW = 155U,
+        CXType_OCLImage3dRW = 156U,
+        CXType_OCLSampler = 157U,
+        CXType_OCLEvent = 158U,
+        CXType_OCLQueue = 159U,
+        CXType_OCLReserveID = 160U,
+        CXType_ObjCObject = 161U,
+        CXType_ObjCTypeParam = 162U,
+        CXType_Attributed = 163U,
+        CXType_OCLIntelSubgroupAVCMcePayload = 164U,
+        CXType_OCLIntelSubgroupAVCImePayload = 165U,
+        CXType_OCLIntelSubgroupAVCRefPayload = 166U,
+        CXType_OCLIntelSubgroupAVCSicPayload = 167U,
+        CXType_OCLIntelSubgroupAVCMceResult = 168U,
+        CXType_OCLIntelSubgroupAVCImeResult = 169U,
+        CXType_OCLIntelSubgroupAVCRefResult = 170U,
+        CXType_OCLIntelSubgroupAVCSicResult = 171U,
+        CXType_OCLIntelSubgroupAVCImeResultSingleRefStreamout = 172U,
+        CXType_OCLIntelSubgroupAVCImeResultDualRefStreamout = 173U,
+        CXType_OCLIntelSubgroupAVCImeSingleRefStreamin = 174U,
+        CXType_OCLIntelSubgroupAVCImeDualRefStreamin = 175U,
+        CXType_ExtVector = 176U,
+        CXType_Atomic = 177U
     }
 
     // Enum @ Index.h:6451:3
-    public enum CXSymbolRole : int
+    public enum CXSymbolRole : uint
     {
-        CXSymbolRole_None = 0,
-        CXSymbolRole_Declaration = 1,
-        CXSymbolRole_Definition = 2,
-        CXSymbolRole_Reference = 4,
-        CXSymbolRole_Read = 8,
-        CXSymbolRole_Write = 16,
-        CXSymbolRole_Call = 32,
-        CXSymbolRole_Dynamic = 64,
-        CXSymbolRole_AddressOf = 128,
-        CXSymbolRole_Implicit = 256
+        CXSymbolRole_None = 0U,
+        CXSymbolRole_Declaration = 1U,
+        CXSymbolRole_Definition = 2U,
+        CXSymbolRole_Reference = 4U,
+        CXSymbolRole_Read = 8U,
+        CXSymbolRole_Write = 16U,
+        CXSymbolRole_Call = 32U,
+        CXSymbolRole_Dynamic = 64U,
+        CXSymbolRole_AddressOf = 128U,
+        CXSymbolRole_Implicit = 256U
     }
 
     // Enum @ Index.h:6304:3
-    public enum CXIdxAttrKind : int
+    public enum CXIdxAttrKind : uint
     {
-        CXIdxAttr_Unexposed = 0,
-        CXIdxAttr_IBAction = 1,
-        CXIdxAttr_IBOutlet = 2,
-        CXIdxAttr_IBOutletCollection = 3
+        CXIdxAttr_Unexposed = 0U,
+        CXIdxAttr_IBAction = 1U,
+        CXIdxAttr_IBOutlet = 2U,
+        CXIdxAttr_IBOutletCollection = 3U
     }
 
     // Enum @ Index.h:6280:3
-    public enum CXIdxEntityLanguage : int
+    public enum CXIdxEntityLanguage : uint
     {
-        CXIdxEntityLang_None = 0,
-        CXIdxEntityLang_C = 1,
-        CXIdxEntityLang_ObjC = 2,
-        CXIdxEntityLang_CXX = 3,
-        CXIdxEntityLang_Swift = 4
+        CXIdxEntityLang_None = 0U,
+        CXIdxEntityLang_C = 1U,
+        CXIdxEntityLang_ObjC = 2U,
+        CXIdxEntityLang_CXX = 3U,
+        CXIdxEntityLang_Swift = 4U
     }
 
     // Enum @ Index.h:6297:3
-    public enum CXIdxEntityCXXTemplateKind : int
+    public enum CXIdxEntityCXXTemplateKind : uint
     {
-        CXIdxEntity_NonTemplate = 0,
-        CXIdxEntity_Template = 1,
-        CXIdxEntity_TemplatePartialSpecialization = 2,
-        CXIdxEntity_TemplateSpecialization = 3
+        CXIdxEntity_NonTemplate = 0U,
+        CXIdxEntity_Template = 1U,
+        CXIdxEntity_TemplatePartialSpecialization = 2U,
+        CXIdxEntity_TemplateSpecialization = 3U
     }
 
     // Enum @ Index.h:6272:3
-    public enum CXIdxEntityKind : int
+    public enum CXIdxEntityKind : uint
     {
-        CXIdxEntity_Unexposed = 0,
-        CXIdxEntity_Typedef = 1,
-        CXIdxEntity_Function = 2,
-        CXIdxEntity_Variable = 3,
-        CXIdxEntity_Field = 4,
-        CXIdxEntity_EnumConstant = 5,
-        CXIdxEntity_ObjCClass = 6,
-        CXIdxEntity_ObjCProtocol = 7,
-        CXIdxEntity_ObjCCategory = 8,
-        CXIdxEntity_ObjCInstanceMethod = 9,
-        CXIdxEntity_ObjCClassMethod = 10,
-        CXIdxEntity_ObjCProperty = 11,
-        CXIdxEntity_ObjCIvar = 12,
-        CXIdxEntity_Enum = 13,
-        CXIdxEntity_Struct = 14,
-        CXIdxEntity_Union = 15,
-        CXIdxEntity_CXXClass = 16,
-        CXIdxEntity_CXXNamespace = 17,
-        CXIdxEntity_CXXNamespaceAlias = 18,
-        CXIdxEntity_CXXStaticVariable = 19,
-        CXIdxEntity_CXXStaticMethod = 20,
-        CXIdxEntity_CXXInstanceMethod = 21,
-        CXIdxEntity_CXXConstructor = 22,
-        CXIdxEntity_CXXDestructor = 23,
-        CXIdxEntity_CXXConversionFunction = 24,
-        CXIdxEntity_CXXTypeAlias = 25,
-        CXIdxEntity_CXXInterface = 26
+        CXIdxEntity_Unexposed = 0U,
+        CXIdxEntity_Typedef = 1U,
+        CXIdxEntity_Function = 2U,
+        CXIdxEntity_Variable = 3U,
+        CXIdxEntity_Field = 4U,
+        CXIdxEntity_EnumConstant = 5U,
+        CXIdxEntity_ObjCClass = 6U,
+        CXIdxEntity_ObjCProtocol = 7U,
+        CXIdxEntity_ObjCCategory = 8U,
+        CXIdxEntity_ObjCInstanceMethod = 9U,
+        CXIdxEntity_ObjCClassMethod = 10U,
+        CXIdxEntity_ObjCProperty = 11U,
+        CXIdxEntity_ObjCIvar = 12U,
+        CXIdxEntity_Enum = 13U,
+        CXIdxEntity_Struct = 14U,
+        CXIdxEntity_Union = 15U,
+        CXIdxEntity_CXXClass = 16U,
+        CXIdxEntity_CXXNamespace = 17U,
+        CXIdxEntity_CXXNamespaceAlias = 18U,
+        CXIdxEntity_CXXStaticVariable = 19U,
+        CXIdxEntity_CXXStaticMethod = 20U,
+        CXIdxEntity_CXXInstanceMethod = 21U,
+        CXIdxEntity_CXXConstructor = 22U,
+        CXIdxEntity_CXXDestructor = 23U,
+        CXIdxEntity_CXXConversionFunction = 24U,
+        CXIdxEntity_CXXTypeAlias = 25U,
+        CXIdxEntity_CXXInterface = 26U
     }
 
     // Enum @ Index.h:6432:3
-    public enum CXIdxEntityRefKind : int
+    public enum CXIdxEntityRefKind : uint
     {
-        CXIdxEntityRef_Direct = 1,
-        CXIdxEntityRef_Implicit = 2
+        CXIdxEntityRef_Direct = 1U,
+        CXIdxEntityRef_Implicit = 2U
     }
 
     // Enum @ Index.h:6366:3
-    public enum CXIdxObjCContainerKind : int
+    public enum CXIdxObjCContainerKind : uint
     {
-        CXIdxObjCContainer_ForwardRef = 0,
-        CXIdxObjCContainer_Interface = 1,
-        CXIdxObjCContainer_Implementation = 2
+        CXIdxObjCContainer_ForwardRef = 0U,
+        CXIdxObjCContainer_Interface = 1U,
+        CXIdxObjCContainer_Implementation = 2U
     }
 
     // Enum @ Index.h:6109:3
-    public enum CXResult : int
+    public enum CXResult : uint
     {
-        CXResult_Success = 0,
-        CXResult_Invalid = 1,
-        CXResult_VisitBreak = 2
+        CXResult_Success = 0U,
+        CXResult_Invalid = 1U,
+        CXResult_VisitBreak = 2U
     }
 
     // Enum @ Index.h:5954:3
-    public enum CXEvalResultKind : int
+    public enum CXEvalResultKind : uint
     {
-        CXEval_Int = 1,
-        CXEval_Float = 2,
-        CXEval_ObjCStrLiteral = 3,
-        CXEval_StrLiteral = 4,
-        CXEval_CFStr = 5,
-        CXEval_Other = 6,
-        CXEval_UnExposed = 0
+        CXEval_Int = 1U,
+        CXEval_Float = 2U,
+        CXEval_ObjCStrLiteral = 3U,
+        CXEval_StrLiteral = 4U,
+        CXEval_CFStr = 5U,
+        CXEval_Other = 6U,
+        CXEval_UnExposed = 0U
     }
 
     // Enum @ Index.h:125:6
-    public enum CXAvailabilityKind : int
+    public enum CXAvailabilityKind : uint
     {
-        CXAvailability_Available = 0,
-        CXAvailability_Deprecated = 1,
-        CXAvailability_NotAvailable = 2,
-        CXAvailability_NotAccessible = 3
+        CXAvailability_Available = 0U,
+        CXAvailability_Deprecated = 1U,
+        CXAvailability_NotAvailable = 2U,
+        CXAvailability_NotAccessible = 3U
     }
 
     // Enum @ Index.h:5156:6
-    public enum CXCompletionChunkKind : int
+    public enum CXCompletionChunkKind : uint
     {
-        CXCompletionChunk_Optional = 0,
-        CXCompletionChunk_TypedText = 1,
-        CXCompletionChunk_Text = 2,
-        CXCompletionChunk_Placeholder = 3,
-        CXCompletionChunk_Informative = 4,
-        CXCompletionChunk_CurrentParameter = 5,
-        CXCompletionChunk_LeftParen = 6,
-        CXCompletionChunk_RightParen = 7,
-        CXCompletionChunk_LeftBracket = 8,
-        CXCompletionChunk_RightBracket = 9,
-        CXCompletionChunk_LeftBrace = 10,
-        CXCompletionChunk_RightBrace = 11,
-        CXCompletionChunk_LeftAngle = 12,
-        CXCompletionChunk_RightAngle = 13,
-        CXCompletionChunk_Comma = 14,
-        CXCompletionChunk_ResultType = 15,
-        CXCompletionChunk_Colon = 16,
-        CXCompletionChunk_SemiColon = 17,
-        CXCompletionChunk_Equal = 18,
-        CXCompletionChunk_HorizontalSpace = 19,
-        CXCompletionChunk_VerticalSpace = 20
+        CXCompletionChunk_Optional = 0U,
+        CXCompletionChunk_TypedText = 1U,
+        CXCompletionChunk_Text = 2U,
+        CXCompletionChunk_Placeholder = 3U,
+        CXCompletionChunk_Informative = 4U,
+        CXCompletionChunk_CurrentParameter = 5U,
+        CXCompletionChunk_LeftParen = 6U,
+        CXCompletionChunk_RightParen = 7U,
+        CXCompletionChunk_LeftBracket = 8U,
+        CXCompletionChunk_RightBracket = 9U,
+        CXCompletionChunk_LeftBrace = 10U,
+        CXCompletionChunk_RightBrace = 11U,
+        CXCompletionChunk_LeftAngle = 12U,
+        CXCompletionChunk_RightAngle = 13U,
+        CXCompletionChunk_Comma = 14U,
+        CXCompletionChunk_ResultType = 15U,
+        CXCompletionChunk_Colon = 16U,
+        CXCompletionChunk_SemiColon = 17U,
+        CXCompletionChunk_Equal = 18U,
+        CXCompletionChunk_HorizontalSpace = 19U,
+        CXCompletionChunk_VerticalSpace = 20U
     }
 
     // Enum @ Index.h:4966:3
-    public enum CXTokenKind : int
+    public enum CXTokenKind : uint
     {
-        CXToken_Punctuation = 0,
-        CXToken_Keyword = 1,
-        CXToken_Identifier = 2,
-        CXToken_Literal = 3,
-        CXToken_Comment = 4
+        CXToken_Punctuation = 0U,
+        CXToken_Keyword = 1U,
+        CXToken_Identifier = 2U,
+        CXToken_Literal = 3U,
+        CXToken_Comment = 4U
     }
 
     // Enum @ Index.h:4339:6
-    public enum CXPrintingPolicyProperty : int
+    public enum CXPrintingPolicyProperty : uint
     {
-        CXPrintingPolicy_Indentation = 0,
-        CXPrintingPolicy_SuppressSpecifiers = 1,
-        CXPrintingPolicy_SuppressTagKeyword = 2,
-        CXPrintingPolicy_IncludeTagDefinition = 3,
-        CXPrintingPolicy_SuppressScope = 4,
-        CXPrintingPolicy_SuppressUnwrittenScope = 5,
-        CXPrintingPolicy_SuppressInitializers = 6,
-        CXPrintingPolicy_ConstantArraySizeAsWritten = 7,
-        CXPrintingPolicy_AnonymousTagLocations = 8,
-        CXPrintingPolicy_SuppressStrongLifetime = 9,
-        CXPrintingPolicy_SuppressLifetimeQualifiers = 10,
-        CXPrintingPolicy_SuppressTemplateArgsInCXXConstructors = 11,
-        CXPrintingPolicy_Bool = 12,
-        CXPrintingPolicy_Restrict = 13,
-        CXPrintingPolicy_Alignof = 14,
-        CXPrintingPolicy_UnderscoreAlignof = 15,
-        CXPrintingPolicy_UseVoidForZeroParams = 16,
-        CXPrintingPolicy_TerseOutput = 17,
-        CXPrintingPolicy_PolishForDeclaration = 18,
-        CXPrintingPolicy_Half = 19,
-        CXPrintingPolicy_MSWChar = 20,
-        CXPrintingPolicy_IncludeNewlines = 21,
-        CXPrintingPolicy_MSVCFormatting = 22,
-        CXPrintingPolicy_ConstantsAsWritten = 23,
-        CXPrintingPolicy_SuppressImplicitBase = 24,
-        CXPrintingPolicy_FullyQualifiedName = 25,
-        CXPrintingPolicy_LastProperty = 25
+        CXPrintingPolicy_Indentation = 0U,
+        CXPrintingPolicy_SuppressSpecifiers = 1U,
+        CXPrintingPolicy_SuppressTagKeyword = 2U,
+        CXPrintingPolicy_IncludeTagDefinition = 3U,
+        CXPrintingPolicy_SuppressScope = 4U,
+        CXPrintingPolicy_SuppressUnwrittenScope = 5U,
+        CXPrintingPolicy_SuppressInitializers = 6U,
+        CXPrintingPolicy_ConstantArraySizeAsWritten = 7U,
+        CXPrintingPolicy_AnonymousTagLocations = 8U,
+        CXPrintingPolicy_SuppressStrongLifetime = 9U,
+        CXPrintingPolicy_SuppressLifetimeQualifiers = 10U,
+        CXPrintingPolicy_SuppressTemplateArgsInCXXConstructors = 11U,
+        CXPrintingPolicy_Bool = 12U,
+        CXPrintingPolicy_Restrict = 13U,
+        CXPrintingPolicy_Alignof = 14U,
+        CXPrintingPolicy_UnderscoreAlignof = 15U,
+        CXPrintingPolicy_UseVoidForZeroParams = 16U,
+        CXPrintingPolicy_TerseOutput = 17U,
+        CXPrintingPolicy_PolishForDeclaration = 18U,
+        CXPrintingPolicy_Half = 19U,
+        CXPrintingPolicy_MSWChar = 20U,
+        CXPrintingPolicy_IncludeNewlines = 21U,
+        CXPrintingPolicy_MSVCFormatting = 22U,
+        CXPrintingPolicy_ConstantsAsWritten = 23U,
+        CXPrintingPolicy_SuppressImplicitBase = 24U,
+        CXPrintingPolicy_FullyQualifiedName = 25U,
+        CXPrintingPolicy_LastProperty = 25U
     }
 
     // Enum @ Index.h:4162:6
-    public enum CXChildVisitResult : int
+    public enum CXChildVisitResult : uint
     {
-        CXChildVisit_Break = 0,
-        CXChildVisit_Continue = 1,
-        CXChildVisit_Recurse = 2
+        CXChildVisit_Break = 0U,
+        CXChildVisit_Continue = 1U,
+        CXChildVisit_Recurse = 2U
     }
 
     // Enum @ Index.h:4078:6
-    public enum CX_StorageClass : int
+    public enum CX_StorageClass : uint
     {
-        CX_SC_Invalid = 0,
-        CX_SC_None = 1,
-        CX_SC_Extern = 2,
-        CX_SC_Static = 3,
-        CX_SC_PrivateExtern = 4,
-        CX_SC_OpenCLWorkGroupLocal = 5,
-        CX_SC_Auto = 6,
-        CX_SC_Register = 7
+        CX_SC_Invalid = 0U,
+        CX_SC_None = 1U,
+        CX_SC_Extern = 2U,
+        CX_SC_Static = 3U,
+        CX_SC_PrivateExtern = 4U,
+        CX_SC_OpenCLWorkGroupLocal = 5U,
+        CX_SC_Auto = 6U,
+        CX_SC_Register = 7U
     }
 
     // Enum @ Index.h:4058:6
-    public enum CX_CXXAccessSpecifier : int
+    public enum CX_CXXAccessSpecifier : uint
     {
-        CX_CXXInvalidAccessSpecifier = 0,
-        CX_CXXPublic = 1,
-        CX_CXXProtected = 2,
-        CX_CXXPrivate = 3
+        CX_CXXInvalidAccessSpecifier = 0U,
+        CX_CXXPublic = 1U,
+        CX_CXXProtected = 2U,
+        CX_CXXPrivate = 3U
     }
 
     // Enum @ Index.h:4009:6
-    public enum CXRefQualifierKind : int
+    public enum CXRefQualifierKind : uint
     {
-        CXRefQualifier_None = 0,
-        CXRefQualifier_LValue = 1,
-        CXRefQualifier_RValue = 2
+        CXRefQualifier_None = 0U,
+        CXRefQualifier_LValue = 1U,
+        CXRefQualifier_RValue = 2U
     }
 
     // Enum @ Index.h:3845:6
-    public enum CXTypeNullabilityKind : int
+    public enum CXTypeNullabilityKind : uint
     {
-        CXTypeNullability_NonNull = 0,
-        CXTypeNullability_Nullable = 1,
-        CXTypeNullability_Unspecified = 2,
-        CXTypeNullability_Invalid = 3,
-        CXTypeNullability_NullableResult = 4
+        CXTypeNullability_NonNull = 0U,
+        CXTypeNullability_Nullable = 1U,
+        CXTypeNullability_Unspecified = 2U,
+        CXTypeNullability_Invalid = 3U,
+        CXTypeNullability_NullableResult = 4U
     }
 
     // Enum @ Index.h:3377:6
-    public enum CXCallingConv : int
+    public enum CXCallingConv : uint
     {
-        CXCallingConv_Default = 0,
-        CXCallingConv_C = 1,
-        CXCallingConv_X86StdCall = 2,
-        CXCallingConv_X86FastCall = 3,
-        CXCallingConv_X86ThisCall = 4,
-        CXCallingConv_X86Pascal = 5,
-        CXCallingConv_AAPCS = 6,
-        CXCallingConv_AAPCS_VFP = 7,
-        CXCallingConv_X86RegCall = 8,
-        CXCallingConv_IntelOclBicc = 9,
-        CXCallingConv_Win64 = 10,
-        CXCallingConv_X86_64Win64 = 10,
-        CXCallingConv_X86_64SysV = 11,
-        CXCallingConv_X86VectorCall = 12,
-        CXCallingConv_Swift = 13,
-        CXCallingConv_PreserveMost = 14,
-        CXCallingConv_PreserveAll = 15,
-        CXCallingConv_AArch64VectorCall = 16,
-        CXCallingConv_Invalid = 100,
-        CXCallingConv_Unexposed = 200
+        CXCallingConv_Default = 0U,
+        CXCallingConv_C = 1U,
+        CXCallingConv_X86StdCall = 2U,
+        CXCallingConv_X86FastCall = 3U,
+        CXCallingConv_X86ThisCall = 4U,
+        CXCallingConv_X86Pascal = 5U,
+        CXCallingConv_AAPCS = 6U,
+        CXCallingConv_AAPCS_VFP = 7U,
+        CXCallingConv_X86RegCall = 8U,
+        CXCallingConv_IntelOclBicc = 9U,
+        CXCallingConv_Win64 = 10U,
+        CXCallingConv_X86_64Win64 = 10U,
+        CXCallingConv_X86_64SysV = 11U,
+        CXCallingConv_X86VectorCall = 12U,
+        CXCallingConv_Swift = 13U,
+        CXCallingConv_PreserveMost = 14U,
+        CXCallingConv_PreserveAll = 15U,
+        CXCallingConv_AArch64VectorCall = 16U,
+        CXCallingConv_Invalid = 100U,
+        CXCallingConv_Unexposed = 200U
     }
 
     // Enum @ Index.h:3492:6
-    public enum CXTemplateArgumentKind : int
+    public enum CXTemplateArgumentKind : uint
     {
-        CXTemplateArgumentKind_Null = 0,
-        CXTemplateArgumentKind_Type = 1,
-        CXTemplateArgumentKind_Declaration = 2,
-        CXTemplateArgumentKind_NullPtr = 3,
-        CXTemplateArgumentKind_Integral = 4,
-        CXTemplateArgumentKind_Template = 5,
-        CXTemplateArgumentKind_TemplateExpansion = 6,
-        CXTemplateArgumentKind_Expression = 7,
-        CXTemplateArgumentKind_Pack = 8,
-        CXTemplateArgumentKind_Invalid = 9
+        CXTemplateArgumentKind_Null = 0U,
+        CXTemplateArgumentKind_Type = 1U,
+        CXTemplateArgumentKind_Declaration = 2U,
+        CXTemplateArgumentKind_NullPtr = 3U,
+        CXTemplateArgumentKind_Integral = 4U,
+        CXTemplateArgumentKind_Template = 5U,
+        CXTemplateArgumentKind_TemplateExpansion = 6U,
+        CXTemplateArgumentKind_Expression = 7U,
+        CXTemplateArgumentKind_Pack = 8U,
+        CXTemplateArgumentKind_Invalid = 9U
     }
 
     // Enum @ Index.h:2982:6
-    public enum CXTLSKind : int
+    public enum CXTLSKind : uint
     {
-        CXTLS_None = 0,
-        CXTLS_Dynamic = 1,
-        CXTLS_Static = 2
+        CXTLS_None = 0U,
+        CXTLS_Dynamic = 1U,
+        CXTLS_Static = 2U
     }
 
     // Enum @ Index.h:2966:6
-    public enum CXLanguageKind : int
+    public enum CXLanguageKind : uint
     {
-        CXLanguage_Invalid = 0,
-        CXLanguage_C = 1,
-        CXLanguage_ObjC = 2,
-        CXLanguage_CPlusPlus = 3
+        CXLanguage_Invalid = 0U,
+        CXLanguage_C = 1U,
+        CXLanguage_ObjC = 2U,
+        CXLanguage_CPlusPlus = 3U
     }
 
     // Enum @ Index.h:2822:6
-    public enum CXVisibilityKind : int
+    public enum CXVisibilityKind : uint
     {
-        CXVisibility_Invalid = 0,
-        CXVisibility_Hidden = 1,
-        CXVisibility_Protected = 2,
-        CXVisibility_Default = 3
+        CXVisibility_Invalid = 0U,
+        CXVisibility_Hidden = 1U,
+        CXVisibility_Protected = 2U,
+        CXVisibility_Default = 3U
     }
 
     // Enum @ Index.h:2799:6
-    public enum CXLinkageKind : int
+    public enum CXLinkageKind : uint
     {
-        CXLinkage_Invalid = 0,
-        CXLinkage_NoLinkage = 1,
-        CXLinkage_Internal = 2,
-        CXLinkage_UniqueExternal = 3,
-        CXLinkage_External = 4
+        CXLinkage_Invalid = 0U,
+        CXLinkage_NoLinkage = 1U,
+        CXLinkage_Internal = 2U,
+        CXLinkage_UniqueExternal = 3U,
+        CXLinkage_External = 4U
     }
 
     // Enum @ Index.h:1609:6
-    public enum CXTUResourceUsageKind : int
+    public enum CXTUResourceUsageKind : uint
     {
-        CXTUResourceUsage_AST = 1,
-        CXTUResourceUsage_Identifiers = 2,
-        CXTUResourceUsage_Selectors = 3,
-        CXTUResourceUsage_GlobalCompletionResults = 4,
-        CXTUResourceUsage_SourceManagerContentCache = 5,
-        CXTUResourceUsage_AST_SideTables = 6,
-        CXTUResourceUsage_SourceManager_Membuffer_Malloc = 7,
-        CXTUResourceUsage_SourceManager_Membuffer_MMap = 8,
-        CXTUResourceUsage_ExternalASTSource_Membuffer_Malloc = 9,
-        CXTUResourceUsage_ExternalASTSource_Membuffer_MMap = 10,
-        CXTUResourceUsage_Preprocessor = 11,
-        CXTUResourceUsage_PreprocessingRecord = 12,
-        CXTUResourceUsage_SourceManager_DataStructures = 13,
-        CXTUResourceUsage_Preprocessor_HeaderSearch = 14,
-        CXTUResourceUsage_MEMORY_IN_BYTES_BEGIN = 1,
-        CXTUResourceUsage_MEMORY_IN_BYTES_END = 14,
-        CXTUResourceUsage_First = 1,
-        CXTUResourceUsage_Last = 14
+        CXTUResourceUsage_AST = 1U,
+        CXTUResourceUsage_Identifiers = 2U,
+        CXTUResourceUsage_Selectors = 3U,
+        CXTUResourceUsage_GlobalCompletionResults = 4U,
+        CXTUResourceUsage_SourceManagerContentCache = 5U,
+        CXTUResourceUsage_AST_SideTables = 6U,
+        CXTUResourceUsage_SourceManager_Membuffer_Malloc = 7U,
+        CXTUResourceUsage_SourceManager_Membuffer_MMap = 8U,
+        CXTUResourceUsage_ExternalASTSource_Membuffer_Malloc = 9U,
+        CXTUResourceUsage_ExternalASTSource_Membuffer_MMap = 10U,
+        CXTUResourceUsage_Preprocessor = 11U,
+        CXTUResourceUsage_PreprocessingRecord = 12U,
+        CXTUResourceUsage_SourceManager_DataStructures = 13U,
+        CXTUResourceUsage_Preprocessor_HeaderSearch = 14U,
+        CXTUResourceUsage_MEMORY_IN_BYTES_BEGIN = 1U,
+        CXTUResourceUsage_MEMORY_IN_BYTES_END = 14U,
+        CXTUResourceUsage_First = 1U,
+        CXTUResourceUsage_Last = 14U
     }
 
     // Enum @ CXErrorCode.h:28:6
-    public enum CXErrorCode : int
+    public enum CXErrorCode : uint
     {
-        CXError_Success = 0,
-        CXError_Failure = 1,
-        CXError_Crashed = 2,
-        CXError_InvalidArguments = 3,
-        CXError_ASTReadError = 4
+        CXError_Success = 0U,
+        CXError_Failure = 1U,
+        CXError_Crashed = 2U,
+        CXError_InvalidArguments = 3U,
+        CXError_ASTReadError = 4U
     }
 
     // Enum @ Index.h:739:6
-    public enum CXDiagnosticSeverity : int
+    public enum CXDiagnosticSeverity : uint
     {
-        CXDiagnostic_Ignored = 0,
-        CXDiagnostic_Note = 1,
-        CXDiagnostic_Warning = 2,
-        CXDiagnostic_Error = 3,
-        CXDiagnostic_Fatal = 4
+        CXDiagnostic_Ignored = 0U,
+        CXDiagnostic_Note = 1U,
+        CXDiagnostic_Warning = 2U,
+        CXDiagnostic_Error = 3U,
+        CXDiagnostic_Fatal = 4U
     }
 
     // Enum @ Index.h:803:6
-    public enum CXLoadDiag_Error : int
+    public enum CXLoadDiag_Error : uint
     {
-        CXLoadDiag_None = 0,
-        CXLoadDiag_Unknown = 1,
-        CXLoadDiag_CannotLoad = 2,
-        CXLoadDiag_InvalidFile = 3
+        CXLoadDiag_None = 0U,
+        CXLoadDiag_Unknown = 1U,
+        CXLoadDiag_CannotLoad = 2U,
+        CXLoadDiag_InvalidFile = 3U
     }
-
-    private static void _LoadVirtualTable()
-    {
-        #region "Functions"
-        _virtualTable.clang_Type_visitFields = (delegate* unmanaged[Cdecl]<CXType, CXFieldVisitor, CXClientData, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_visitFields");
-        _virtualTable.clang_indexLoc_getCXSourceLocation = (delegate* unmanaged[Cdecl]<CXIdxLoc, CXSourceLocation>)Runtime.LibraryGetExport(_libraryHandle, "clang_indexLoc_getCXSourceLocation");
-        _virtualTable.clang_indexLoc_getFileLocation = (delegate* unmanaged[Cdecl]<CXIdxLoc, CXIdxClientFile*, CXFile*, ulong*, ulong*, ulong*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_indexLoc_getFileLocation");
-        _virtualTable.clang_indexTranslationUnit = (delegate* unmanaged[Cdecl]<CXIndexAction, CXClientData, IndexerCallbacks*, uint, uint, CXTranslationUnit, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_indexTranslationUnit");
-        _virtualTable.clang_indexSourceFileFullArgv = (delegate* unmanaged[Cdecl]<CXIndexAction, CXClientData, IndexerCallbacks*, uint, uint, CString, CString*, int, CXUnsavedFile*, uint, CXTranslationUnit*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_indexSourceFileFullArgv");
-        _virtualTable.clang_indexSourceFile = (delegate* unmanaged[Cdecl]<CXIndexAction, CXClientData, IndexerCallbacks*, uint, uint, CString, CString*, int, CXUnsavedFile*, uint, CXTranslationUnit*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_indexSourceFile");
-        _virtualTable.clang_IndexAction_dispose = (delegate* unmanaged[Cdecl]<CXIndexAction, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_IndexAction_dispose");
-        _virtualTable.clang_IndexAction_create = (delegate* unmanaged[Cdecl]<CXIndex, CXIndexAction>)Runtime.LibraryGetExport(_libraryHandle, "clang_IndexAction_create");
-        _virtualTable.clang_index_setClientEntity = (delegate* unmanaged[Cdecl]<CXIdxEntityInfo*, CXIdxClientEntity, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_setClientEntity");
-        _virtualTable.clang_index_getClientEntity = (delegate* unmanaged[Cdecl]<CXIdxEntityInfo*, CXIdxClientEntity>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_getClientEntity");
-        _virtualTable.clang_index_setClientContainer = (delegate* unmanaged[Cdecl]<CXIdxContainerInfo*, CXIdxClientContainer, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_setClientContainer");
-        _virtualTable.clang_index_getClientContainer = (delegate* unmanaged[Cdecl]<CXIdxContainerInfo*, CXIdxClientContainer>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_getClientContainer");
-        _virtualTable.clang_index_getCXXClassDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxCXXClassDeclInfo*>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_getCXXClassDeclInfo");
-        _virtualTable.clang_index_getIBOutletCollectionAttrInfo = (delegate* unmanaged[Cdecl]<CXIdxAttrInfo*, CXIdxIBOutletCollectionAttrInfo*>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_getIBOutletCollectionAttrInfo");
-        _virtualTable.clang_index_getObjCPropertyDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCPropertyDeclInfo*>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_getObjCPropertyDeclInfo");
-        _virtualTable.clang_index_getObjCProtocolRefListInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCProtocolRefListInfo*>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_getObjCProtocolRefListInfo");
-        _virtualTable.clang_index_getObjCCategoryDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCCategoryDeclInfo*>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_getObjCCategoryDeclInfo");
-        _virtualTable.clang_index_getObjCInterfaceDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCInterfaceDeclInfo*>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_getObjCInterfaceDeclInfo");
-        _virtualTable.clang_index_getObjCContainerDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCContainerDeclInfo*>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_getObjCContainerDeclInfo");
-        _virtualTable.clang_index_isEntityObjCContainerKind = (delegate* unmanaged[Cdecl]<CXIdxEntityKind, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_index_isEntityObjCContainerKind");
-        _virtualTable.clang_findIncludesInFile = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, CXCursorAndRangeVisitor, CXResult>)Runtime.LibraryGetExport(_libraryHandle, "clang_findIncludesInFile");
-        _virtualTable.clang_findReferencesInFile = (delegate* unmanaged[Cdecl]<CXCursor, CXFile, CXCursorAndRangeVisitor, CXResult>)Runtime.LibraryGetExport(_libraryHandle, "clang_findReferencesInFile");
-        _virtualTable.clang_remap_dispose = (delegate* unmanaged[Cdecl]<CXRemapping, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_remap_dispose");
-        _virtualTable.clang_remap_getFilenames = (delegate* unmanaged[Cdecl]<CXRemapping, uint, CXString*, CXString*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_remap_getFilenames");
-        _virtualTable.clang_remap_getNumFiles = (delegate* unmanaged[Cdecl]<CXRemapping, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_remap_getNumFiles");
-        _virtualTable.clang_getRemappingsFromFileList = (delegate* unmanaged[Cdecl]<CString*, uint, CXRemapping>)Runtime.LibraryGetExport(_libraryHandle, "clang_getRemappingsFromFileList");
-        _virtualTable.clang_getRemappings = (delegate* unmanaged[Cdecl]<CString, CXRemapping>)Runtime.LibraryGetExport(_libraryHandle, "clang_getRemappings");
-        _virtualTable.clang_EvalResult_dispose = (delegate* unmanaged[Cdecl]<CXEvalResult, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_EvalResult_dispose");
-        _virtualTable.clang_EvalResult_getAsStr = (delegate* unmanaged[Cdecl]<CXEvalResult, CString>)Runtime.LibraryGetExport(_libraryHandle, "clang_EvalResult_getAsStr");
-        _virtualTable.clang_EvalResult_getAsDouble = (delegate* unmanaged[Cdecl]<CXEvalResult, double>)Runtime.LibraryGetExport(_libraryHandle, "clang_EvalResult_getAsDouble");
-        _virtualTable.clang_EvalResult_getAsUnsigned = (delegate* unmanaged[Cdecl]<CXEvalResult, ulong>)Runtime.LibraryGetExport(_libraryHandle, "clang_EvalResult_getAsUnsigned");
-        _virtualTable.clang_EvalResult_isUnsignedInt = (delegate* unmanaged[Cdecl]<CXEvalResult, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_EvalResult_isUnsignedInt");
-        _virtualTable.clang_EvalResult_getAsLongLong = (delegate* unmanaged[Cdecl]<CXEvalResult, long>)Runtime.LibraryGetExport(_libraryHandle, "clang_EvalResult_getAsLongLong");
-        _virtualTable.clang_EvalResult_getAsInt = (delegate* unmanaged[Cdecl]<CXEvalResult, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_EvalResult_getAsInt");
-        _virtualTable.clang_EvalResult_getKind = (delegate* unmanaged[Cdecl]<CXEvalResult, CXEvalResultKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_EvalResult_getKind");
-        _virtualTable.clang_Cursor_Evaluate = (delegate* unmanaged[Cdecl]<CXCursor, CXEvalResult>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_Evaluate");
-        _virtualTable.clang_getInclusions = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXInclusionVisitor, CXClientData, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_getInclusions");
-        _virtualTable.clang_toggleCrashRecovery = (delegate* unmanaged[Cdecl]<uint, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_toggleCrashRecovery");
-        _virtualTable.clang_getClangVersion = (delegate* unmanaged[Cdecl]<CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getClangVersion");
-        _virtualTable.clang_codeCompleteGetObjCSelector = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_codeCompleteGetObjCSelector");
-        _virtualTable.clang_codeCompleteGetContainerUSR = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_codeCompleteGetContainerUSR");
-        _virtualTable.clang_codeCompleteGetContainerKind = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, ulong*, CXCursorKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_codeCompleteGetContainerKind");
-        _virtualTable.clang_codeCompleteGetContexts = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, ulong>)Runtime.LibraryGetExport(_libraryHandle, "clang_codeCompleteGetContexts");
-        _virtualTable.clang_codeCompleteGetDiagnostic = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint, CXDiagnostic>)Runtime.LibraryGetExport(_libraryHandle, "clang_codeCompleteGetDiagnostic");
-        _virtualTable.clang_codeCompleteGetNumDiagnostics = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_codeCompleteGetNumDiagnostics");
-        _virtualTable.clang_disposeCodeCompleteResults = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeCodeCompleteResults");
-        _virtualTable.clang_sortCodeCompletionResults = (delegate* unmanaged[Cdecl]<CXCompletionResult*, uint, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_sortCodeCompletionResults");
-        _virtualTable.clang_codeCompleteAt = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CString, uint, uint, CXUnsavedFile*, uint, uint, CXCodeCompleteResults*>)Runtime.LibraryGetExport(_libraryHandle, "clang_codeCompleteAt");
-        _virtualTable.clang_defaultCodeCompleteOptions = (delegate* unmanaged[Cdecl]<uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_defaultCodeCompleteOptions");
-        _virtualTable.clang_getCompletionFixIt = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint, uint, CXSourceRange*, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionFixIt");
-        _virtualTable.clang_getCompletionNumFixIts = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionNumFixIts");
-        _virtualTable.clang_getCursorCompletionString = (delegate* unmanaged[Cdecl]<CXCursor, CXCompletionString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorCompletionString");
-        _virtualTable.clang_getCompletionBriefComment = (delegate* unmanaged[Cdecl]<CXCompletionString, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionBriefComment");
-        _virtualTable.clang_getCompletionParent = (delegate* unmanaged[Cdecl]<CXCompletionString, CXCursorKind*, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionParent");
-        _virtualTable.clang_getCompletionAnnotation = (delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionAnnotation");
-        _virtualTable.clang_getCompletionNumAnnotations = (delegate* unmanaged[Cdecl]<CXCompletionString, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionNumAnnotations");
-        _virtualTable.clang_getCompletionAvailability = (delegate* unmanaged[Cdecl]<CXCompletionString, CXAvailabilityKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionAvailability");
-        _virtualTable.clang_getCompletionPriority = (delegate* unmanaged[Cdecl]<CXCompletionString, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionPriority");
-        _virtualTable.clang_getNumCompletionChunks = (delegate* unmanaged[Cdecl]<CXCompletionString, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getNumCompletionChunks");
-        _virtualTable.clang_getCompletionChunkCompletionString = (delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXCompletionString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionChunkCompletionString");
-        _virtualTable.clang_getCompletionChunkText = (delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionChunkText");
-        _virtualTable.clang_getCompletionChunkKind = (delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXCompletionChunkKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCompletionChunkKind");
-        _virtualTable.clang_executeOnThread = (delegate* unmanaged[Cdecl]<FnPtr_CLANG_VoidPtr_Void, void*, uint, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_executeOnThread");
-        _virtualTable.clang_enableStackTraces = (delegate* unmanaged[Cdecl]<void>)Runtime.LibraryGetExport(_libraryHandle, "clang_enableStackTraces");
-        _virtualTable.clang_getDefinitionSpellingAndExtent = (delegate* unmanaged[Cdecl]<CXCursor, CString*, CString*, ulong*, ulong*, ulong*, ulong*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDefinitionSpellingAndExtent");
-        _virtualTable.clang_getCursorKindSpelling = (delegate* unmanaged[Cdecl]<CXCursorKind, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorKindSpelling");
-        _virtualTable.clang_disposeTokens = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken*, uint, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeTokens");
-        _virtualTable.clang_annotateTokens = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken*, uint, CXCursor*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_annotateTokens");
-        _virtualTable.clang_tokenize = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceRange, CXToken**, ulong*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_tokenize");
-        _virtualTable.clang_getTokenExtent = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken, CXSourceRange>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTokenExtent");
-        _virtualTable.clang_getTokenLocation = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken, CXSourceLocation>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTokenLocation");
-        _virtualTable.clang_getTokenSpelling = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTokenSpelling");
-        _virtualTable.clang_getTokenKind = (delegate* unmanaged[Cdecl]<CXToken, CXTokenKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTokenKind");
-        _virtualTable.clang_getToken = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceLocation, CXToken*>)Runtime.LibraryGetExport(_libraryHandle, "clang_getToken");
-        _virtualTable.clang_getCursorReferenceNameRange = (delegate* unmanaged[Cdecl]<CXCursor, uint, uint, CXSourceRange>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorReferenceNameRange");
-        _virtualTable.clang_getSpecializedCursorTemplate = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getSpecializedCursorTemplate");
-        _virtualTable.clang_getTemplateCursorKind = (delegate* unmanaged[Cdecl]<CXCursor, CXCursorKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTemplateCursorKind");
-        _virtualTable.clang_CXXMethod_isConst = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXMethod_isConst");
-        _virtualTable.clang_EnumDecl_isScoped = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_EnumDecl_isScoped");
-        _virtualTable.clang_CXXRecord_isAbstract = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXRecord_isAbstract");
-        _virtualTable.clang_CXXMethod_isVirtual = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXMethod_isVirtual");
-        _virtualTable.clang_CXXMethod_isStatic = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXMethod_isStatic");
-        _virtualTable.clang_CXXMethod_isPureVirtual = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXMethod_isPureVirtual");
-        _virtualTable.clang_CXXMethod_isDefaulted = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXMethod_isDefaulted");
-        _virtualTable.clang_CXXField_isMutable = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXField_isMutable");
-        _virtualTable.clang_CXXConstructor_isMoveConstructor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXConstructor_isMoveConstructor");
-        _virtualTable.clang_CXXConstructor_isDefaultConstructor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXConstructor_isDefaultConstructor");
-        _virtualTable.clang_CXXConstructor_isCopyConstructor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXConstructor_isCopyConstructor");
-        _virtualTable.clang_CXXConstructor_isConvertingConstructor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXXConstructor_isConvertingConstructor");
-        _virtualTable.clang_Module_getTopLevelHeader = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXModule, uint, CXFile>)Runtime.LibraryGetExport(_libraryHandle, "clang_Module_getTopLevelHeader");
-        _virtualTable.clang_Module_getNumTopLevelHeaders = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXModule, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Module_getNumTopLevelHeaders");
-        _virtualTable.clang_Module_isSystem = (delegate* unmanaged[Cdecl]<CXModule, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Module_isSystem");
-        _virtualTable.clang_Module_getFullName = (delegate* unmanaged[Cdecl]<CXModule, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_Module_getFullName");
-        _virtualTable.clang_Module_getName = (delegate* unmanaged[Cdecl]<CXModule, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_Module_getName");
-        _virtualTable.clang_Module_getParent = (delegate* unmanaged[Cdecl]<CXModule, CXModule>)Runtime.LibraryGetExport(_libraryHandle, "clang_Module_getParent");
-        _virtualTable.clang_Module_getASTFile = (delegate* unmanaged[Cdecl]<CXModule, CXFile>)Runtime.LibraryGetExport(_libraryHandle, "clang_Module_getASTFile");
-        _virtualTable.clang_getModuleForFile = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, CXModule>)Runtime.LibraryGetExport(_libraryHandle, "clang_getModuleForFile");
-        _virtualTable.clang_Cursor_getModule = (delegate* unmanaged[Cdecl]<CXCursor, CXModule>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getModule");
-        _virtualTable.clang_Cursor_getObjCManglings = (delegate* unmanaged[Cdecl]<CXCursor, CXStringSet*>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getObjCManglings");
-        _virtualTable.clang_Cursor_getCXXManglings = (delegate* unmanaged[Cdecl]<CXCursor, CXStringSet*>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getCXXManglings");
-        _virtualTable.clang_Cursor_getMangling = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getMangling");
-        _virtualTable.clang_Cursor_getBriefCommentText = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getBriefCommentText");
-        _virtualTable.clang_Cursor_getRawCommentText = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getRawCommentText");
-        _virtualTable.clang_Cursor_getCommentRange = (delegate* unmanaged[Cdecl]<CXCursor, CXSourceRange>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getCommentRange");
-        _virtualTable.clang_Cursor_isExternalSymbol = (delegate* unmanaged[Cdecl]<CXCursor, CXString*, CXString*, ulong*, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isExternalSymbol");
-        _virtualTable.clang_Cursor_isVariadic = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isVariadic");
-        _virtualTable.clang_Cursor_isObjCOptional = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isObjCOptional");
-        _virtualTable.clang_Cursor_getObjCDeclQualifiers = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getObjCDeclQualifiers");
-        _virtualTable.clang_Cursor_getObjCPropertySetterName = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getObjCPropertySetterName");
-        _virtualTable.clang_Cursor_getObjCPropertyGetterName = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getObjCPropertyGetterName");
-        _virtualTable.clang_Cursor_getObjCPropertyAttributes = (delegate* unmanaged[Cdecl]<CXCursor, uint, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getObjCPropertyAttributes");
-        _virtualTable.clang_Cursor_getReceiverType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getReceiverType");
-        _virtualTable.clang_Cursor_isDynamicCall = (delegate* unmanaged[Cdecl]<CXCursor, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isDynamicCall");
-        _virtualTable.clang_Cursor_getObjCSelectorIndex = (delegate* unmanaged[Cdecl]<CXCursor, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getObjCSelectorIndex");
-        _virtualTable.clang_getCanonicalCursor = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCanonicalCursor");
-        _virtualTable.clang_isCursorDefinition = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isCursorDefinition");
-        _virtualTable.clang_getCursorDefinition = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorDefinition");
-        _virtualTable.clang_getCursorReferenced = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorReferenced");
-        _virtualTable.clang_getCursorDisplayName = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorDisplayName");
-        _virtualTable.clang_getCursorPrettyPrinted = (delegate* unmanaged[Cdecl]<CXCursor, CXPrintingPolicy, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorPrettyPrinted");
-        _virtualTable.clang_PrintingPolicy_dispose = (delegate* unmanaged[Cdecl]<CXPrintingPolicy, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_PrintingPolicy_dispose");
-        _virtualTable.clang_getCursorPrintingPolicy = (delegate* unmanaged[Cdecl]<CXCursor, CXPrintingPolicy>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorPrintingPolicy");
-        _virtualTable.clang_PrintingPolicy_setProperty = (delegate* unmanaged[Cdecl]<CXPrintingPolicy, CXPrintingPolicyProperty, uint, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_PrintingPolicy_setProperty");
-        _virtualTable.clang_PrintingPolicy_getProperty = (delegate* unmanaged[Cdecl]<CXPrintingPolicy, CXPrintingPolicyProperty, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_PrintingPolicy_getProperty");
-        _virtualTable.clang_Cursor_getSpellingNameRange = (delegate* unmanaged[Cdecl]<CXCursor, uint, uint, CXSourceRange>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getSpellingNameRange");
-        _virtualTable.clang_getCursorSpelling = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorSpelling");
-        _virtualTable.clang_constructUSR_ObjCProperty = (delegate* unmanaged[Cdecl]<CString, CXString, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_constructUSR_ObjCProperty");
-        _virtualTable.clang_constructUSR_ObjCMethod = (delegate* unmanaged[Cdecl]<CString, uint, CXString, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_constructUSR_ObjCMethod");
-        _virtualTable.clang_constructUSR_ObjCIvar = (delegate* unmanaged[Cdecl]<CString, CXString, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_constructUSR_ObjCIvar");
-        _virtualTable.clang_constructUSR_ObjCProtocol = (delegate* unmanaged[Cdecl]<CString, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_constructUSR_ObjCProtocol");
-        _virtualTable.clang_constructUSR_ObjCCategory = (delegate* unmanaged[Cdecl]<CString, CString, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_constructUSR_ObjCCategory");
-        _virtualTable.clang_constructUSR_ObjCClass = (delegate* unmanaged[Cdecl]<CString, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_constructUSR_ObjCClass");
-        _virtualTable.clang_getCursorUSR = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorUSR");
-        _virtualTable.clang_visitChildren = (delegate* unmanaged[Cdecl]<CXCursor, CXCursorVisitor, CXClientData, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_visitChildren");
-        _virtualTable.clang_getIBOutletCollectionType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getIBOutletCollectionType");
-        _virtualTable.clang_getOverloadedDecl = (delegate* unmanaged[Cdecl]<CXCursor, uint, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getOverloadedDecl");
-        _virtualTable.clang_getNumOverloadedDecls = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getNumOverloadedDecls");
-        _virtualTable.clang_Cursor_getStorageClass = (delegate* unmanaged[Cdecl]<CXCursor, CX_StorageClass>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getStorageClass");
-        _virtualTable.clang_getCXXAccessSpecifier = (delegate* unmanaged[Cdecl]<CXCursor, CX_CXXAccessSpecifier>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCXXAccessSpecifier");
-        _virtualTable.clang_isVirtualBase = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isVirtualBase");
-        _virtualTable.clang_Cursor_isBitField = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isBitField");
-        _virtualTable.clang_Type_getCXXRefQualifier = (delegate* unmanaged[Cdecl]<CXType, CXRefQualifierKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getCXXRefQualifier");
-        _virtualTable.clang_Type_getTemplateArgumentAsType = (delegate* unmanaged[Cdecl]<CXType, uint, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getTemplateArgumentAsType");
-        _virtualTable.clang_Type_getNumTemplateArguments = (delegate* unmanaged[Cdecl]<CXType, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getNumTemplateArguments");
-        _virtualTable.clang_Cursor_isInlineNamespace = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isInlineNamespace");
-        _virtualTable.clang_Cursor_isAnonymousRecordDecl = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isAnonymousRecordDecl");
-        _virtualTable.clang_Cursor_isAnonymous = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isAnonymous");
-        _virtualTable.clang_Cursor_getOffsetOfField = (delegate* unmanaged[Cdecl]<CXCursor, long>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getOffsetOfField");
-        _virtualTable.clang_Type_getValueType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getValueType");
-        _virtualTable.clang_Type_getModifiedType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getModifiedType");
-        _virtualTable.clang_Type_getOffsetOf = (delegate* unmanaged[Cdecl]<CXType, CString, long>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getOffsetOf");
-        _virtualTable.clang_Type_getSizeOf = (delegate* unmanaged[Cdecl]<CXType, long>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getSizeOf");
-        _virtualTable.clang_Type_getClassType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getClassType");
-        _virtualTable.clang_Type_getAlignOf = (delegate* unmanaged[Cdecl]<CXType, long>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getAlignOf");
-        _virtualTable.clang_Type_getNullability = (delegate* unmanaged[Cdecl]<CXType, CXTypeNullabilityKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getNullability");
-        _virtualTable.clang_Type_isTransparentTagTypedef = (delegate* unmanaged[Cdecl]<CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_isTransparentTagTypedef");
-        _virtualTable.clang_Type_getNamedType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getNamedType");
-        _virtualTable.clang_getArraySize = (delegate* unmanaged[Cdecl]<CXType, long>)Runtime.LibraryGetExport(_libraryHandle, "clang_getArraySize");
-        _virtualTable.clang_getArrayElementType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getArrayElementType");
-        _virtualTable.clang_getNumElements = (delegate* unmanaged[Cdecl]<CXType, long>)Runtime.LibraryGetExport(_libraryHandle, "clang_getNumElements");
-        _virtualTable.clang_getElementType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getElementType");
-        _virtualTable.clang_isPODType = (delegate* unmanaged[Cdecl]<CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isPODType");
-        _virtualTable.clang_getCursorExceptionSpecificationType = (delegate* unmanaged[Cdecl]<CXCursor, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorExceptionSpecificationType");
-        _virtualTable.clang_getCursorResultType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorResultType");
-        _virtualTable.clang_isFunctionTypeVariadic = (delegate* unmanaged[Cdecl]<CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isFunctionTypeVariadic");
-        _virtualTable.clang_Type_getObjCTypeArg = (delegate* unmanaged[Cdecl]<CXType, uint, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getObjCTypeArg");
-        _virtualTable.clang_Type_getNumObjCTypeArgs = (delegate* unmanaged[Cdecl]<CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getNumObjCTypeArgs");
-        _virtualTable.clang_Type_getObjCProtocolDecl = (delegate* unmanaged[Cdecl]<CXType, uint, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getObjCProtocolDecl");
-        _virtualTable.clang_Type_getNumObjCProtocolRefs = (delegate* unmanaged[Cdecl]<CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getNumObjCProtocolRefs");
-        _virtualTable.clang_Type_getObjCObjectBaseType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getObjCObjectBaseType");
-        _virtualTable.clang_getArgType = (delegate* unmanaged[Cdecl]<CXType, uint, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getArgType");
-        _virtualTable.clang_getNumArgTypes = (delegate* unmanaged[Cdecl]<CXType, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_getNumArgTypes");
-        _virtualTable.clang_getExceptionSpecificationType = (delegate* unmanaged[Cdecl]<CXType, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_getExceptionSpecificationType");
-        _virtualTable.clang_getResultType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getResultType");
-        _virtualTable.clang_getFunctionTypeCallingConv = (delegate* unmanaged[Cdecl]<CXType, CXCallingConv>)Runtime.LibraryGetExport(_libraryHandle, "clang_getFunctionTypeCallingConv");
-        _virtualTable.clang_getTypeKindSpelling = (delegate* unmanaged[Cdecl]<CXTypeKind, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTypeKindSpelling");
-        _virtualTable.clang_Type_getObjCEncoding = (delegate* unmanaged[Cdecl]<CXType, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_Type_getObjCEncoding");
-        _virtualTable.clang_getDeclObjCTypeEncoding = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDeclObjCTypeEncoding");
-        _virtualTable.clang_getTypeDeclaration = (delegate* unmanaged[Cdecl]<CXType, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTypeDeclaration");
-        _virtualTable.clang_getPointeeType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getPointeeType");
-        _virtualTable.clang_getTypedefName = (delegate* unmanaged[Cdecl]<CXType, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTypedefName");
-        _virtualTable.clang_getAddressSpace = (delegate* unmanaged[Cdecl]<CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getAddressSpace");
-        _virtualTable.clang_isRestrictQualifiedType = (delegate* unmanaged[Cdecl]<CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isRestrictQualifiedType");
-        _virtualTable.clang_isVolatileQualifiedType = (delegate* unmanaged[Cdecl]<CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isVolatileQualifiedType");
-        _virtualTable.clang_Cursor_isFunctionInlined = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isFunctionInlined");
-        _virtualTable.clang_Cursor_isMacroBuiltin = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isMacroBuiltin");
-        _virtualTable.clang_Cursor_isMacroFunctionLike = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isMacroFunctionLike");
-        _virtualTable.clang_isConstQualifiedType = (delegate* unmanaged[Cdecl]<CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isConstQualifiedType");
-        _virtualTable.clang_getCanonicalType = (delegate* unmanaged[Cdecl]<CXType, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCanonicalType");
-        _virtualTable.clang_equalTypes = (delegate* unmanaged[Cdecl]<CXType, CXType, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_equalTypes");
-        _virtualTable.clang_Cursor_getTemplateArgumentUnsignedValue = (delegate* unmanaged[Cdecl]<CXCursor, uint, ulong>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getTemplateArgumentUnsignedValue");
-        _virtualTable.clang_Cursor_getTemplateArgumentValue = (delegate* unmanaged[Cdecl]<CXCursor, uint, long>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getTemplateArgumentValue");
-        _virtualTable.clang_Cursor_getTemplateArgumentType = (delegate* unmanaged[Cdecl]<CXCursor, uint, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getTemplateArgumentType");
-        _virtualTable.clang_Cursor_getTemplateArgumentKind = (delegate* unmanaged[Cdecl]<CXCursor, uint, CXTemplateArgumentKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getTemplateArgumentKind");
-        _virtualTable.clang_Cursor_getNumTemplateArguments = (delegate* unmanaged[Cdecl]<CXCursor, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getNumTemplateArguments");
-        _virtualTable.clang_Cursor_getArgument = (delegate* unmanaged[Cdecl]<CXCursor, uint, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getArgument");
-        _virtualTable.clang_Cursor_getNumArguments = (delegate* unmanaged[Cdecl]<CXCursor, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getNumArguments");
-        _virtualTable.clang_getFieldDeclBitWidth = (delegate* unmanaged[Cdecl]<CXCursor, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_getFieldDeclBitWidth");
-        _virtualTable.clang_getEnumConstantDeclUnsignedValue = (delegate* unmanaged[Cdecl]<CXCursor, ulong>)Runtime.LibraryGetExport(_libraryHandle, "clang_getEnumConstantDeclUnsignedValue");
-        _virtualTable.clang_getEnumConstantDeclValue = (delegate* unmanaged[Cdecl]<CXCursor, long>)Runtime.LibraryGetExport(_libraryHandle, "clang_getEnumConstantDeclValue");
-        _virtualTable.clang_getEnumDeclIntegerType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getEnumDeclIntegerType");
-        _virtualTable.clang_getTypedefDeclUnderlyingType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTypedefDeclUnderlyingType");
-        _virtualTable.clang_getTypeSpelling = (delegate* unmanaged[Cdecl]<CXType, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTypeSpelling");
-        _virtualTable.clang_getCursorType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorType");
-        _virtualTable.clang_getCursorExtent = (delegate* unmanaged[Cdecl]<CXCursor, CXSourceRange>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorExtent");
-        _virtualTable.clang_getCursorLocation = (delegate* unmanaged[Cdecl]<CXCursor, CXSourceLocation>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorLocation");
-        _virtualTable.clang_getCursor = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceLocation, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursor");
-        _virtualTable.clang_getIncludedFile = (delegate* unmanaged[Cdecl]<CXCursor, CXFile>)Runtime.LibraryGetExport(_libraryHandle, "clang_getIncludedFile");
-        _virtualTable.clang_disposeOverriddenCursors = (delegate* unmanaged[Cdecl]<CXCursor*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeOverriddenCursors");
-        _virtualTable.clang_getOverriddenCursors = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor**, ulong*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_getOverriddenCursors");
-        _virtualTable.clang_getCursorLexicalParent = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorLexicalParent");
-        _virtualTable.clang_getCursorSemanticParent = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorSemanticParent");
-        _virtualTable.clang_CXCursorSet_insert = (delegate* unmanaged[Cdecl]<CXCursorSet, CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXCursorSet_insert");
-        _virtualTable.clang_CXCursorSet_contains = (delegate* unmanaged[Cdecl]<CXCursorSet, CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXCursorSet_contains");
-        _virtualTable.clang_disposeCXCursorSet = (delegate* unmanaged[Cdecl]<CXCursorSet, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeCXCursorSet");
-        _virtualTable.clang_createCXCursorSet = (delegate* unmanaged[Cdecl]<CXCursorSet>)Runtime.LibraryGetExport(_libraryHandle, "clang_createCXCursorSet");
-        _virtualTable.clang_Cursor_getTranslationUnit = (delegate* unmanaged[Cdecl]<CXCursor, CXTranslationUnit>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getTranslationUnit");
-        _virtualTable.clang_getCursorTLSKind = (delegate* unmanaged[Cdecl]<CXCursor, CXTLSKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorTLSKind");
-        _virtualTable.clang_getCursorLanguage = (delegate* unmanaged[Cdecl]<CXCursor, CXLanguageKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorLanguage");
-        _virtualTable.clang_Cursor_hasVarDeclExternalStorage = (delegate* unmanaged[Cdecl]<CXCursor, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_hasVarDeclExternalStorage");
-        _virtualTable.clang_Cursor_hasVarDeclGlobalStorage = (delegate* unmanaged[Cdecl]<CXCursor, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_hasVarDeclGlobalStorage");
-        _virtualTable.clang_Cursor_getVarDeclInitializer = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_getVarDeclInitializer");
-        _virtualTable.clang_disposeCXPlatformAvailability = (delegate* unmanaged[Cdecl]<CXPlatformAvailability*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeCXPlatformAvailability");
-        _virtualTable.clang_getCursorPlatformAvailability = (delegate* unmanaged[Cdecl]<CXCursor, long*, CXString*, long*, CXString*, CXPlatformAvailability*, int, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorPlatformAvailability");
-        _virtualTable.clang_getCursorAvailability = (delegate* unmanaged[Cdecl]<CXCursor, CXAvailabilityKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorAvailability");
-        _virtualTable.clang_getCursorVisibility = (delegate* unmanaged[Cdecl]<CXCursor, CXVisibilityKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorVisibility");
-        _virtualTable.clang_getCursorLinkage = (delegate* unmanaged[Cdecl]<CXCursor, CXLinkageKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorLinkage");
-        _virtualTable.clang_isUnexposed = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isUnexposed");
-        _virtualTable.clang_isPreprocessing = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isPreprocessing");
-        _virtualTable.clang_isTranslationUnit = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isTranslationUnit");
-        _virtualTable.clang_isInvalid = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isInvalid");
-        _virtualTable.clang_Cursor_hasAttrs = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_hasAttrs");
-        _virtualTable.clang_isAttribute = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isAttribute");
-        _virtualTable.clang_isStatement = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isStatement");
-        _virtualTable.clang_isExpression = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isExpression");
-        _virtualTable.clang_isReference = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isReference");
-        _virtualTable.clang_isInvalidDeclaration = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isInvalidDeclaration");
-        _virtualTable.clang_isDeclaration = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isDeclaration");
-        _virtualTable.clang_getCursorKind = (delegate* unmanaged[Cdecl]<CXCursor, CXCursorKind>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCursorKind");
-        _virtualTable.clang_hashCursor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_hashCursor");
-        _virtualTable.clang_Cursor_isNull = (delegate* unmanaged[Cdecl]<CXCursor, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Cursor_isNull");
-        _virtualTable.clang_equalCursors = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_equalCursors");
-        _virtualTable.clang_getTranslationUnitCursor = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTranslationUnitCursor");
-        _virtualTable.clang_getNullCursor = (delegate* unmanaged[Cdecl]<CXCursor>)Runtime.LibraryGetExport(_libraryHandle, "clang_getNullCursor");
-        _virtualTable.clang_TargetInfo_getPointerWidth = (delegate* unmanaged[Cdecl]<CXTargetInfo, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_TargetInfo_getPointerWidth");
-        _virtualTable.clang_TargetInfo_getTriple = (delegate* unmanaged[Cdecl]<CXTargetInfo, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_TargetInfo_getTriple");
-        _virtualTable.clang_TargetInfo_dispose = (delegate* unmanaged[Cdecl]<CXTargetInfo, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_TargetInfo_dispose");
-        _virtualTable.clang_getTranslationUnitTargetInfo = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXTargetInfo>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTranslationUnitTargetInfo");
-        _virtualTable.clang_disposeCXTUResourceUsage = (delegate* unmanaged[Cdecl]<CXTUResourceUsage, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeCXTUResourceUsage");
-        _virtualTable.clang_getCXTUResourceUsage = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXTUResourceUsage>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCXTUResourceUsage");
-        _virtualTable.clang_getTUResourceUsageName = (delegate* unmanaged[Cdecl]<CXTUResourceUsageKind, CString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTUResourceUsageName");
-        _virtualTable.clang_reparseTranslationUnit = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint, CXUnsavedFile*, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_reparseTranslationUnit");
-        _virtualTable.clang_defaultReparseOptions = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_defaultReparseOptions");
-        _virtualTable.clang_disposeTranslationUnit = (delegate* unmanaged[Cdecl]<CXTranslationUnit, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeTranslationUnit");
-        _virtualTable.clang_suspendTranslationUnit = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_suspendTranslationUnit");
-        _virtualTable.clang_saveTranslationUnit = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CString, uint, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_saveTranslationUnit");
-        _virtualTable.clang_defaultSaveOptions = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_defaultSaveOptions");
-        _virtualTable.clang_parseTranslationUnit2FullArgv = (delegate* unmanaged[Cdecl]<CXIndex, CString, CString*, int, CXUnsavedFile*, uint, uint, CXTranslationUnit*, CXErrorCode>)Runtime.LibraryGetExport(_libraryHandle, "clang_parseTranslationUnit2FullArgv");
-        _virtualTable.clang_parseTranslationUnit2 = (delegate* unmanaged[Cdecl]<CXIndex, CString, CString*, int, CXUnsavedFile*, uint, uint, CXTranslationUnit*, CXErrorCode>)Runtime.LibraryGetExport(_libraryHandle, "clang_parseTranslationUnit2");
-        _virtualTable.clang_parseTranslationUnit = (delegate* unmanaged[Cdecl]<CXIndex, CString, CString*, int, CXUnsavedFile*, uint, uint, CXTranslationUnit>)Runtime.LibraryGetExport(_libraryHandle, "clang_parseTranslationUnit");
-        _virtualTable.clang_defaultEditingTranslationUnitOptions = (delegate* unmanaged[Cdecl]<uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_defaultEditingTranslationUnitOptions");
-        _virtualTable.clang_createTranslationUnit2 = (delegate* unmanaged[Cdecl]<CXIndex, CString, CXTranslationUnit*, CXErrorCode>)Runtime.LibraryGetExport(_libraryHandle, "clang_createTranslationUnit2");
-        _virtualTable.clang_createTranslationUnit = (delegate* unmanaged[Cdecl]<CXIndex, CString, CXTranslationUnit>)Runtime.LibraryGetExport(_libraryHandle, "clang_createTranslationUnit");
-        _virtualTable.clang_createTranslationUnitFromSourceFile = (delegate* unmanaged[Cdecl]<CXIndex, CString, int, CString*, uint, CXUnsavedFile*, CXTranslationUnit>)Runtime.LibraryGetExport(_libraryHandle, "clang_createTranslationUnitFromSourceFile");
-        _virtualTable.clang_getTranslationUnitSpelling = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getTranslationUnitSpelling");
-        _virtualTable.clang_getDiagnosticFixIt = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint, CXSourceRange*, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticFixIt");
-        _virtualTable.clang_getDiagnosticNumFixIts = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticNumFixIts");
-        _virtualTable.clang_getDiagnosticRange = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint, CXSourceRange>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticRange");
-        _virtualTable.clang_getDiagnosticNumRanges = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticNumRanges");
-        _virtualTable.clang_getDiagnosticCategoryText = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticCategoryText");
-        _virtualTable.clang_getDiagnosticCategoryName = (delegate* unmanaged[Cdecl]<uint, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticCategoryName");
-        _virtualTable.clang_getDiagnosticCategory = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticCategory");
-        _virtualTable.clang_getDiagnosticOption = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXString*, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticOption");
-        _virtualTable.clang_getDiagnosticSpelling = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticSpelling");
-        _virtualTable.clang_getDiagnosticLocation = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXSourceLocation>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticLocation");
-        _virtualTable.clang_getDiagnosticSeverity = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXDiagnosticSeverity>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticSeverity");
-        _virtualTable.clang_defaultDiagnosticDisplayOptions = (delegate* unmanaged[Cdecl]<uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_defaultDiagnosticDisplayOptions");
-        _virtualTable.clang_formatDiagnostic = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_formatDiagnostic");
-        _virtualTable.clang_disposeDiagnostic = (delegate* unmanaged[Cdecl]<CXDiagnostic, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeDiagnostic");
-        _virtualTable.clang_getDiagnosticSetFromTU = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXDiagnosticSet>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticSetFromTU");
-        _virtualTable.clang_getDiagnostic = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint, CXDiagnostic>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnostic");
-        _virtualTable.clang_getNumDiagnostics = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getNumDiagnostics");
-        _virtualTable.clang_getChildDiagnostics = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXDiagnosticSet>)Runtime.LibraryGetExport(_libraryHandle, "clang_getChildDiagnostics");
-        _virtualTable.clang_disposeDiagnosticSet = (delegate* unmanaged[Cdecl]<CXDiagnosticSet, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeDiagnosticSet");
-        _virtualTable.clang_loadDiagnostics = (delegate* unmanaged[Cdecl]<CString, CXLoadDiag_Error*, CXString*, CXDiagnosticSet>)Runtime.LibraryGetExport(_libraryHandle, "clang_loadDiagnostics");
-        _virtualTable.clang_getDiagnosticInSet = (delegate* unmanaged[Cdecl]<CXDiagnosticSet, uint, CXDiagnostic>)Runtime.LibraryGetExport(_libraryHandle, "clang_getDiagnosticInSet");
-        _virtualTable.clang_getNumDiagnosticsInSet = (delegate* unmanaged[Cdecl]<CXDiagnosticSet, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_getNumDiagnosticsInSet");
-        _virtualTable.clang_disposeSourceRangeList = (delegate* unmanaged[Cdecl]<CXSourceRangeList*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeSourceRangeList");
-        _virtualTable.clang_getAllSkippedRanges = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceRangeList*>)Runtime.LibraryGetExport(_libraryHandle, "clang_getAllSkippedRanges");
-        _virtualTable.clang_getSkippedRanges = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, CXSourceRangeList*>)Runtime.LibraryGetExport(_libraryHandle, "clang_getSkippedRanges");
-        _virtualTable.clang_getRangeEnd = (delegate* unmanaged[Cdecl]<CXSourceRange, CXSourceLocation>)Runtime.LibraryGetExport(_libraryHandle, "clang_getRangeEnd");
-        _virtualTable.clang_getRangeStart = (delegate* unmanaged[Cdecl]<CXSourceRange, CXSourceLocation>)Runtime.LibraryGetExport(_libraryHandle, "clang_getRangeStart");
-        _virtualTable.clang_getFileLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_getFileLocation");
-        _virtualTable.clang_getSpellingLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_getSpellingLocation");
-        _virtualTable.clang_getInstantiationLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_getInstantiationLocation");
-        _virtualTable.clang_getPresumedLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXString*, ulong*, ulong*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_getPresumedLocation");
-        _virtualTable.clang_getExpansionLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_getExpansionLocation");
-        _virtualTable.clang_Range_isNull = (delegate* unmanaged[Cdecl]<CXSourceRange, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Range_isNull");
-        _virtualTable.clang_equalRanges = (delegate* unmanaged[Cdecl]<CXSourceRange, CXSourceRange, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_equalRanges");
-        _virtualTable.clang_getRange = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXSourceLocation, CXSourceRange>)Runtime.LibraryGetExport(_libraryHandle, "clang_getRange");
-        _virtualTable.clang_getNullRange = (delegate* unmanaged[Cdecl]<CXSourceRange>)Runtime.LibraryGetExport(_libraryHandle, "clang_getNullRange");
-        _virtualTable.clang_Location_isFromMainFile = (delegate* unmanaged[Cdecl]<CXSourceLocation, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Location_isFromMainFile");
-        _virtualTable.clang_Location_isInSystemHeader = (delegate* unmanaged[Cdecl]<CXSourceLocation, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_Location_isInSystemHeader");
-        _virtualTable.clang_getLocationForOffset = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, uint, CXSourceLocation>)Runtime.LibraryGetExport(_libraryHandle, "clang_getLocationForOffset");
-        _virtualTable.clang_getLocation = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, uint, uint, CXSourceLocation>)Runtime.LibraryGetExport(_libraryHandle, "clang_getLocation");
-        _virtualTable.clang_equalLocations = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXSourceLocation, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_equalLocations");
-        _virtualTable.clang_getNullLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation>)Runtime.LibraryGetExport(_libraryHandle, "clang_getNullLocation");
-        _virtualTable.clang_File_tryGetRealPathName = (delegate* unmanaged[Cdecl]<CXFile, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_File_tryGetRealPathName");
-        _virtualTable.clang_File_isEqual = (delegate* unmanaged[Cdecl]<CXFile, CXFile, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_File_isEqual");
-        _virtualTable.clang_getFileContents = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, ulong*, CString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getFileContents");
-        _virtualTable.clang_getFile = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CString, CXFile>)Runtime.LibraryGetExport(_libraryHandle, "clang_getFile");
-        _virtualTable.clang_isFileMultipleIncludeGuarded = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_isFileMultipleIncludeGuarded");
-        _virtualTable.clang_getFileUniqueID = (delegate* unmanaged[Cdecl]<CXFile, CXFileUniqueID*, int>)Runtime.LibraryGetExport(_libraryHandle, "clang_getFileUniqueID");
-        _virtualTable.clang_getFileTime = (delegate* unmanaged[Cdecl]<CXFile, time_t>)Runtime.LibraryGetExport(_libraryHandle, "clang_getFileTime");
-        _virtualTable.clang_getFileName = (delegate* unmanaged[Cdecl]<CXFile, CXString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getFileName");
-        _virtualTable.clang_CXIndex_setInvocationEmissionPathOption = (delegate* unmanaged[Cdecl]<CXIndex, CString, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXIndex_setInvocationEmissionPathOption");
-        _virtualTable.clang_CXIndex_getGlobalOptions = (delegate* unmanaged[Cdecl]<CXIndex, uint>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXIndex_getGlobalOptions");
-        _virtualTable.clang_CXIndex_setGlobalOptions = (delegate* unmanaged[Cdecl]<CXIndex, uint, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_CXIndex_setGlobalOptions");
-        _virtualTable.clang_disposeIndex = (delegate* unmanaged[Cdecl]<CXIndex, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeIndex");
-        _virtualTable.clang_createIndex = (delegate* unmanaged[Cdecl]<int, int, CXIndex>)Runtime.LibraryGetExport(_libraryHandle, "clang_createIndex");
-        _virtualTable.clang_ModuleMapDescriptor_dispose = (delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_ModuleMapDescriptor_dispose");
-        _virtualTable.clang_ModuleMapDescriptor_writeToBuffer = (delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, uint, CString*, ulong*, CXErrorCode>)Runtime.LibraryGetExport(_libraryHandle, "clang_ModuleMapDescriptor_writeToBuffer");
-        _virtualTable.clang_ModuleMapDescriptor_setUmbrellaHeader = (delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, CString, CXErrorCode>)Runtime.LibraryGetExport(_libraryHandle, "clang_ModuleMapDescriptor_setUmbrellaHeader");
-        _virtualTable.clang_ModuleMapDescriptor_setFrameworkModuleName = (delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, CString, CXErrorCode>)Runtime.LibraryGetExport(_libraryHandle, "clang_ModuleMapDescriptor_setFrameworkModuleName");
-        _virtualTable.clang_ModuleMapDescriptor_create = (delegate* unmanaged[Cdecl]<uint, CXModuleMapDescriptor>)Runtime.LibraryGetExport(_libraryHandle, "clang_ModuleMapDescriptor_create");
-        _virtualTable.clang_VirtualFileOverlay_dispose = (delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_VirtualFileOverlay_dispose");
-        _virtualTable.clang_free = (delegate* unmanaged[Cdecl]<void*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_free");
-        _virtualTable.clang_VirtualFileOverlay_writeToBuffer = (delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, uint, CString*, ulong*, CXErrorCode>)Runtime.LibraryGetExport(_libraryHandle, "clang_VirtualFileOverlay_writeToBuffer");
-        _virtualTable.clang_VirtualFileOverlay_setCaseSensitivity = (delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, int, CXErrorCode>)Runtime.LibraryGetExport(_libraryHandle, "clang_VirtualFileOverlay_setCaseSensitivity");
-        _virtualTable.clang_VirtualFileOverlay_addFileMapping = (delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, CString, CString, CXErrorCode>)Runtime.LibraryGetExport(_libraryHandle, "clang_VirtualFileOverlay_addFileMapping");
-        _virtualTable.clang_VirtualFileOverlay_create = (delegate* unmanaged[Cdecl]<uint, CXVirtualFileOverlay>)Runtime.LibraryGetExport(_libraryHandle, "clang_VirtualFileOverlay_create");
-        _virtualTable.clang_getBuildSessionTimestamp = (delegate* unmanaged[Cdecl]<ulong>)Runtime.LibraryGetExport(_libraryHandle, "clang_getBuildSessionTimestamp");
-        _virtualTable.clang_disposeStringSet = (delegate* unmanaged[Cdecl]<CXStringSet*, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeStringSet");
-        _virtualTable.clang_disposeString = (delegate* unmanaged[Cdecl]<CXString, void>)Runtime.LibraryGetExport(_libraryHandle, "clang_disposeString");
-        _virtualTable.clang_getCString = (delegate* unmanaged[Cdecl]<CXString, CString>)Runtime.LibraryGetExport(_libraryHandle, "clang_getCString");
-        #endregion
-
-        #region "Variables"
-
-        #endregion
-    }
-
-    private static void _UnloadVirtualTable()
-    {
-        #region "Functions"
-
-        _virtualTable.clang_Type_visitFields = (delegate* unmanaged[Cdecl]<CXType, CXFieldVisitor, CXClientData, uint>)IntPtr.Zero;
-        _virtualTable.clang_indexLoc_getCXSourceLocation = (delegate* unmanaged[Cdecl]<CXIdxLoc, CXSourceLocation>)IntPtr.Zero;
-        _virtualTable.clang_indexLoc_getFileLocation = (delegate* unmanaged[Cdecl]<CXIdxLoc, CXIdxClientFile*, CXFile*, ulong*, ulong*, ulong*, void>)IntPtr.Zero;
-        _virtualTable.clang_indexTranslationUnit = (delegate* unmanaged[Cdecl]<CXIndexAction, CXClientData, IndexerCallbacks*, uint, uint, CXTranslationUnit, int>)IntPtr.Zero;
-        _virtualTable.clang_indexSourceFileFullArgv = (delegate* unmanaged[Cdecl]<CXIndexAction, CXClientData, IndexerCallbacks*, uint, uint, CString, CString*, int, CXUnsavedFile*, uint, CXTranslationUnit*, uint, int>)IntPtr.Zero;
-        _virtualTable.clang_indexSourceFile = (delegate* unmanaged[Cdecl]<CXIndexAction, CXClientData, IndexerCallbacks*, uint, uint, CString, CString*, int, CXUnsavedFile*, uint, CXTranslationUnit*, uint, int>)IntPtr.Zero;
-        _virtualTable.clang_IndexAction_dispose = (delegate* unmanaged[Cdecl]<CXIndexAction, void>)IntPtr.Zero;
-        _virtualTable.clang_IndexAction_create = (delegate* unmanaged[Cdecl]<CXIndex, CXIndexAction>)IntPtr.Zero;
-        _virtualTable.clang_index_setClientEntity = (delegate* unmanaged[Cdecl]<CXIdxEntityInfo*, CXIdxClientEntity, void>)IntPtr.Zero;
-        _virtualTable.clang_index_getClientEntity = (delegate* unmanaged[Cdecl]<CXIdxEntityInfo*, CXIdxClientEntity>)IntPtr.Zero;
-        _virtualTable.clang_index_setClientContainer = (delegate* unmanaged[Cdecl]<CXIdxContainerInfo*, CXIdxClientContainer, void>)IntPtr.Zero;
-        _virtualTable.clang_index_getClientContainer = (delegate* unmanaged[Cdecl]<CXIdxContainerInfo*, CXIdxClientContainer>)IntPtr.Zero;
-        _virtualTable.clang_index_getCXXClassDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxCXXClassDeclInfo*>)IntPtr.Zero;
-        _virtualTable.clang_index_getIBOutletCollectionAttrInfo = (delegate* unmanaged[Cdecl]<CXIdxAttrInfo*, CXIdxIBOutletCollectionAttrInfo*>)IntPtr.Zero;
-        _virtualTable.clang_index_getObjCPropertyDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCPropertyDeclInfo*>)IntPtr.Zero;
-        _virtualTable.clang_index_getObjCProtocolRefListInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCProtocolRefListInfo*>)IntPtr.Zero;
-        _virtualTable.clang_index_getObjCCategoryDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCCategoryDeclInfo*>)IntPtr.Zero;
-        _virtualTable.clang_index_getObjCInterfaceDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCInterfaceDeclInfo*>)IntPtr.Zero;
-        _virtualTable.clang_index_getObjCContainerDeclInfo = (delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCContainerDeclInfo*>)IntPtr.Zero;
-        _virtualTable.clang_index_isEntityObjCContainerKind = (delegate* unmanaged[Cdecl]<CXIdxEntityKind, int>)IntPtr.Zero;
-        _virtualTable.clang_findIncludesInFile = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, CXCursorAndRangeVisitor, CXResult>)IntPtr.Zero;
-        _virtualTable.clang_findReferencesInFile = (delegate* unmanaged[Cdecl]<CXCursor, CXFile, CXCursorAndRangeVisitor, CXResult>)IntPtr.Zero;
-        _virtualTable.clang_remap_dispose = (delegate* unmanaged[Cdecl]<CXRemapping, void>)IntPtr.Zero;
-        _virtualTable.clang_remap_getFilenames = (delegate* unmanaged[Cdecl]<CXRemapping, uint, CXString*, CXString*, void>)IntPtr.Zero;
-        _virtualTable.clang_remap_getNumFiles = (delegate* unmanaged[Cdecl]<CXRemapping, uint>)IntPtr.Zero;
-        _virtualTable.clang_getRemappingsFromFileList = (delegate* unmanaged[Cdecl]<CString*, uint, CXRemapping>)IntPtr.Zero;
-        _virtualTable.clang_getRemappings = (delegate* unmanaged[Cdecl]<CString, CXRemapping>)IntPtr.Zero;
-        _virtualTable.clang_EvalResult_dispose = (delegate* unmanaged[Cdecl]<CXEvalResult, void>)IntPtr.Zero;
-        _virtualTable.clang_EvalResult_getAsStr = (delegate* unmanaged[Cdecl]<CXEvalResult, CString>)IntPtr.Zero;
-        _virtualTable.clang_EvalResult_getAsDouble = (delegate* unmanaged[Cdecl]<CXEvalResult, double>)IntPtr.Zero;
-        _virtualTable.clang_EvalResult_getAsUnsigned = (delegate* unmanaged[Cdecl]<CXEvalResult, ulong>)IntPtr.Zero;
-        _virtualTable.clang_EvalResult_isUnsignedInt = (delegate* unmanaged[Cdecl]<CXEvalResult, uint>)IntPtr.Zero;
-        _virtualTable.clang_EvalResult_getAsLongLong = (delegate* unmanaged[Cdecl]<CXEvalResult, long>)IntPtr.Zero;
-        _virtualTable.clang_EvalResult_getAsInt = (delegate* unmanaged[Cdecl]<CXEvalResult, int>)IntPtr.Zero;
-        _virtualTable.clang_EvalResult_getKind = (delegate* unmanaged[Cdecl]<CXEvalResult, CXEvalResultKind>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_Evaluate = (delegate* unmanaged[Cdecl]<CXCursor, CXEvalResult>)IntPtr.Zero;
-        _virtualTable.clang_getInclusions = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXInclusionVisitor, CXClientData, void>)IntPtr.Zero;
-        _virtualTable.clang_toggleCrashRecovery = (delegate* unmanaged[Cdecl]<uint, void>)IntPtr.Zero;
-        _virtualTable.clang_getClangVersion = (delegate* unmanaged[Cdecl]<CXString>)IntPtr.Zero;
-        _virtualTable.clang_codeCompleteGetObjCSelector = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, CXString>)IntPtr.Zero;
-        _virtualTable.clang_codeCompleteGetContainerUSR = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, CXString>)IntPtr.Zero;
-        _virtualTable.clang_codeCompleteGetContainerKind = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, ulong*, CXCursorKind>)IntPtr.Zero;
-        _virtualTable.clang_codeCompleteGetContexts = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, ulong>)IntPtr.Zero;
-        _virtualTable.clang_codeCompleteGetDiagnostic = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint, CXDiagnostic>)IntPtr.Zero;
-        _virtualTable.clang_codeCompleteGetNumDiagnostics = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint>)IntPtr.Zero;
-        _virtualTable.clang_disposeCodeCompleteResults = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, void>)IntPtr.Zero;
-        _virtualTable.clang_sortCodeCompletionResults = (delegate* unmanaged[Cdecl]<CXCompletionResult*, uint, void>)IntPtr.Zero;
-        _virtualTable.clang_codeCompleteAt = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CString, uint, uint, CXUnsavedFile*, uint, uint, CXCodeCompleteResults*>)IntPtr.Zero;
-        _virtualTable.clang_defaultCodeCompleteOptions = (delegate* unmanaged[Cdecl]<uint>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionFixIt = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint, uint, CXSourceRange*, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionNumFixIts = (delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint, uint>)IntPtr.Zero;
-        _virtualTable.clang_getCursorCompletionString = (delegate* unmanaged[Cdecl]<CXCursor, CXCompletionString>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionBriefComment = (delegate* unmanaged[Cdecl]<CXCompletionString, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionParent = (delegate* unmanaged[Cdecl]<CXCompletionString, CXCursorKind*, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionAnnotation = (delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionNumAnnotations = (delegate* unmanaged[Cdecl]<CXCompletionString, uint>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionAvailability = (delegate* unmanaged[Cdecl]<CXCompletionString, CXAvailabilityKind>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionPriority = (delegate* unmanaged[Cdecl]<CXCompletionString, uint>)IntPtr.Zero;
-        _virtualTable.clang_getNumCompletionChunks = (delegate* unmanaged[Cdecl]<CXCompletionString, uint>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionChunkCompletionString = (delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXCompletionString>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionChunkText = (delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getCompletionChunkKind = (delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXCompletionChunkKind>)IntPtr.Zero;
-        _virtualTable.clang_executeOnThread = (delegate* unmanaged[Cdecl]<FnPtr_CLANG_VoidPtr_Void, void*, uint, void>)IntPtr.Zero;
-        _virtualTable.clang_enableStackTraces = (delegate* unmanaged[Cdecl]<void>)IntPtr.Zero;
-        _virtualTable.clang_getDefinitionSpellingAndExtent = (delegate* unmanaged[Cdecl]<CXCursor, CString*, CString*, ulong*, ulong*, ulong*, ulong*, void>)IntPtr.Zero;
-        _virtualTable.clang_getCursorKindSpelling = (delegate* unmanaged[Cdecl]<CXCursorKind, CXString>)IntPtr.Zero;
-        _virtualTable.clang_disposeTokens = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken*, uint, void>)IntPtr.Zero;
-        _virtualTable.clang_annotateTokens = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken*, uint, CXCursor*, void>)IntPtr.Zero;
-        _virtualTable.clang_tokenize = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceRange, CXToken**, ulong*, void>)IntPtr.Zero;
-        _virtualTable.clang_getTokenExtent = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken, CXSourceRange>)IntPtr.Zero;
-        _virtualTable.clang_getTokenLocation = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken, CXSourceLocation>)IntPtr.Zero;
-        _virtualTable.clang_getTokenSpelling = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getTokenKind = (delegate* unmanaged[Cdecl]<CXToken, CXTokenKind>)IntPtr.Zero;
-        _virtualTable.clang_getToken = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceLocation, CXToken*>)IntPtr.Zero;
-        _virtualTable.clang_getCursorReferenceNameRange = (delegate* unmanaged[Cdecl]<CXCursor, uint, uint, CXSourceRange>)IntPtr.Zero;
-        _virtualTable.clang_getSpecializedCursorTemplate = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_getTemplateCursorKind = (delegate* unmanaged[Cdecl]<CXCursor, CXCursorKind>)IntPtr.Zero;
-        _virtualTable.clang_CXXMethod_isConst = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_EnumDecl_isScoped = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXRecord_isAbstract = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXMethod_isVirtual = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXMethod_isStatic = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXMethod_isPureVirtual = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXMethod_isDefaulted = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXField_isMutable = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXConstructor_isMoveConstructor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXConstructor_isDefaultConstructor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXConstructor_isCopyConstructor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXXConstructor_isConvertingConstructor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Module_getTopLevelHeader = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXModule, uint, CXFile>)IntPtr.Zero;
-        _virtualTable.clang_Module_getNumTopLevelHeaders = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXModule, uint>)IntPtr.Zero;
-        _virtualTable.clang_Module_isSystem = (delegate* unmanaged[Cdecl]<CXModule, int>)IntPtr.Zero;
-        _virtualTable.clang_Module_getFullName = (delegate* unmanaged[Cdecl]<CXModule, CXString>)IntPtr.Zero;
-        _virtualTable.clang_Module_getName = (delegate* unmanaged[Cdecl]<CXModule, CXString>)IntPtr.Zero;
-        _virtualTable.clang_Module_getParent = (delegate* unmanaged[Cdecl]<CXModule, CXModule>)IntPtr.Zero;
-        _virtualTable.clang_Module_getASTFile = (delegate* unmanaged[Cdecl]<CXModule, CXFile>)IntPtr.Zero;
-        _virtualTable.clang_getModuleForFile = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, CXModule>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getModule = (delegate* unmanaged[Cdecl]<CXCursor, CXModule>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getObjCManglings = (delegate* unmanaged[Cdecl]<CXCursor, CXStringSet*>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getCXXManglings = (delegate* unmanaged[Cdecl]<CXCursor, CXStringSet*>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getMangling = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getBriefCommentText = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getRawCommentText = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getCommentRange = (delegate* unmanaged[Cdecl]<CXCursor, CXSourceRange>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isExternalSymbol = (delegate* unmanaged[Cdecl]<CXCursor, CXString*, CXString*, ulong*, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isVariadic = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isObjCOptional = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getObjCDeclQualifiers = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getObjCPropertySetterName = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getObjCPropertyGetterName = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getObjCPropertyAttributes = (delegate* unmanaged[Cdecl]<CXCursor, uint, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getReceiverType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isDynamicCall = (delegate* unmanaged[Cdecl]<CXCursor, int>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getObjCSelectorIndex = (delegate* unmanaged[Cdecl]<CXCursor, int>)IntPtr.Zero;
-        _virtualTable.clang_getCanonicalCursor = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_isCursorDefinition = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_getCursorDefinition = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_getCursorReferenced = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_getCursorDisplayName = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getCursorPrettyPrinted = (delegate* unmanaged[Cdecl]<CXCursor, CXPrintingPolicy, CXString>)IntPtr.Zero;
-        _virtualTable.clang_PrintingPolicy_dispose = (delegate* unmanaged[Cdecl]<CXPrintingPolicy, void>)IntPtr.Zero;
-        _virtualTable.clang_getCursorPrintingPolicy = (delegate* unmanaged[Cdecl]<CXCursor, CXPrintingPolicy>)IntPtr.Zero;
-        _virtualTable.clang_PrintingPolicy_setProperty = (delegate* unmanaged[Cdecl]<CXPrintingPolicy, CXPrintingPolicyProperty, uint, void>)IntPtr.Zero;
-        _virtualTable.clang_PrintingPolicy_getProperty = (delegate* unmanaged[Cdecl]<CXPrintingPolicy, CXPrintingPolicyProperty, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getSpellingNameRange = (delegate* unmanaged[Cdecl]<CXCursor, uint, uint, CXSourceRange>)IntPtr.Zero;
-        _virtualTable.clang_getCursorSpelling = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)IntPtr.Zero;
-        _virtualTable.clang_constructUSR_ObjCProperty = (delegate* unmanaged[Cdecl]<CString, CXString, CXString>)IntPtr.Zero;
-        _virtualTable.clang_constructUSR_ObjCMethod = (delegate* unmanaged[Cdecl]<CString, uint, CXString, CXString>)IntPtr.Zero;
-        _virtualTable.clang_constructUSR_ObjCIvar = (delegate* unmanaged[Cdecl]<CString, CXString, CXString>)IntPtr.Zero;
-        _virtualTable.clang_constructUSR_ObjCProtocol = (delegate* unmanaged[Cdecl]<CString, CXString>)IntPtr.Zero;
-        _virtualTable.clang_constructUSR_ObjCCategory = (delegate* unmanaged[Cdecl]<CString, CString, CXString>)IntPtr.Zero;
-        _virtualTable.clang_constructUSR_ObjCClass = (delegate* unmanaged[Cdecl]<CString, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getCursorUSR = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)IntPtr.Zero;
-        _virtualTable.clang_visitChildren = (delegate* unmanaged[Cdecl]<CXCursor, CXCursorVisitor, CXClientData, uint>)IntPtr.Zero;
-        _virtualTable.clang_getIBOutletCollectionType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getOverloadedDecl = (delegate* unmanaged[Cdecl]<CXCursor, uint, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_getNumOverloadedDecls = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getStorageClass = (delegate* unmanaged[Cdecl]<CXCursor, CX_StorageClass>)IntPtr.Zero;
-        _virtualTable.clang_getCXXAccessSpecifier = (delegate* unmanaged[Cdecl]<CXCursor, CX_CXXAccessSpecifier>)IntPtr.Zero;
-        _virtualTable.clang_isVirtualBase = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isBitField = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Type_getCXXRefQualifier = (delegate* unmanaged[Cdecl]<CXType, CXRefQualifierKind>)IntPtr.Zero;
-        _virtualTable.clang_Type_getTemplateArgumentAsType = (delegate* unmanaged[Cdecl]<CXType, uint, CXType>)IntPtr.Zero;
-        _virtualTable.clang_Type_getNumTemplateArguments = (delegate* unmanaged[Cdecl]<CXType, int>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isInlineNamespace = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isAnonymousRecordDecl = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isAnonymous = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getOffsetOfField = (delegate* unmanaged[Cdecl]<CXCursor, long>)IntPtr.Zero;
-        _virtualTable.clang_Type_getValueType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_Type_getModifiedType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_Type_getOffsetOf = (delegate* unmanaged[Cdecl]<CXType, CString, long>)IntPtr.Zero;
-        _virtualTable.clang_Type_getSizeOf = (delegate* unmanaged[Cdecl]<CXType, long>)IntPtr.Zero;
-        _virtualTable.clang_Type_getClassType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_Type_getAlignOf = (delegate* unmanaged[Cdecl]<CXType, long>)IntPtr.Zero;
-        _virtualTable.clang_Type_getNullability = (delegate* unmanaged[Cdecl]<CXType, CXTypeNullabilityKind>)IntPtr.Zero;
-        _virtualTable.clang_Type_isTransparentTagTypedef = (delegate* unmanaged[Cdecl]<CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_Type_getNamedType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getArraySize = (delegate* unmanaged[Cdecl]<CXType, long>)IntPtr.Zero;
-        _virtualTable.clang_getArrayElementType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getNumElements = (delegate* unmanaged[Cdecl]<CXType, long>)IntPtr.Zero;
-        _virtualTable.clang_getElementType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_isPODType = (delegate* unmanaged[Cdecl]<CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_getCursorExceptionSpecificationType = (delegate* unmanaged[Cdecl]<CXCursor, int>)IntPtr.Zero;
-        _virtualTable.clang_getCursorResultType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)IntPtr.Zero;
-        _virtualTable.clang_isFunctionTypeVariadic = (delegate* unmanaged[Cdecl]<CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_Type_getObjCTypeArg = (delegate* unmanaged[Cdecl]<CXType, uint, CXType>)IntPtr.Zero;
-        _virtualTable.clang_Type_getNumObjCTypeArgs = (delegate* unmanaged[Cdecl]<CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_Type_getObjCProtocolDecl = (delegate* unmanaged[Cdecl]<CXType, uint, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_Type_getNumObjCProtocolRefs = (delegate* unmanaged[Cdecl]<CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_Type_getObjCObjectBaseType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getArgType = (delegate* unmanaged[Cdecl]<CXType, uint, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getNumArgTypes = (delegate* unmanaged[Cdecl]<CXType, int>)IntPtr.Zero;
-        _virtualTable.clang_getExceptionSpecificationType = (delegate* unmanaged[Cdecl]<CXType, int>)IntPtr.Zero;
-        _virtualTable.clang_getResultType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getFunctionTypeCallingConv = (delegate* unmanaged[Cdecl]<CXType, CXCallingConv>)IntPtr.Zero;
-        _virtualTable.clang_getTypeKindSpelling = (delegate* unmanaged[Cdecl]<CXTypeKind, CXString>)IntPtr.Zero;
-        _virtualTable.clang_Type_getObjCEncoding = (delegate* unmanaged[Cdecl]<CXType, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getDeclObjCTypeEncoding = (delegate* unmanaged[Cdecl]<CXCursor, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getTypeDeclaration = (delegate* unmanaged[Cdecl]<CXType, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_getPointeeType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getTypedefName = (delegate* unmanaged[Cdecl]<CXType, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getAddressSpace = (delegate* unmanaged[Cdecl]<CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_isRestrictQualifiedType = (delegate* unmanaged[Cdecl]<CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_isVolatileQualifiedType = (delegate* unmanaged[Cdecl]<CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isFunctionInlined = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isMacroBuiltin = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isMacroFunctionLike = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_isConstQualifiedType = (delegate* unmanaged[Cdecl]<CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_getCanonicalType = (delegate* unmanaged[Cdecl]<CXType, CXType>)IntPtr.Zero;
-        _virtualTable.clang_equalTypes = (delegate* unmanaged[Cdecl]<CXType, CXType, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getTemplateArgumentUnsignedValue = (delegate* unmanaged[Cdecl]<CXCursor, uint, ulong>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getTemplateArgumentValue = (delegate* unmanaged[Cdecl]<CXCursor, uint, long>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getTemplateArgumentType = (delegate* unmanaged[Cdecl]<CXCursor, uint, CXType>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getTemplateArgumentKind = (delegate* unmanaged[Cdecl]<CXCursor, uint, CXTemplateArgumentKind>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getNumTemplateArguments = (delegate* unmanaged[Cdecl]<CXCursor, int>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getArgument = (delegate* unmanaged[Cdecl]<CXCursor, uint, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getNumArguments = (delegate* unmanaged[Cdecl]<CXCursor, int>)IntPtr.Zero;
-        _virtualTable.clang_getFieldDeclBitWidth = (delegate* unmanaged[Cdecl]<CXCursor, int>)IntPtr.Zero;
-        _virtualTable.clang_getEnumConstantDeclUnsignedValue = (delegate* unmanaged[Cdecl]<CXCursor, ulong>)IntPtr.Zero;
-        _virtualTable.clang_getEnumConstantDeclValue = (delegate* unmanaged[Cdecl]<CXCursor, long>)IntPtr.Zero;
-        _virtualTable.clang_getEnumDeclIntegerType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getTypedefDeclUnderlyingType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getTypeSpelling = (delegate* unmanaged[Cdecl]<CXType, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getCursorType = (delegate* unmanaged[Cdecl]<CXCursor, CXType>)IntPtr.Zero;
-        _virtualTable.clang_getCursorExtent = (delegate* unmanaged[Cdecl]<CXCursor, CXSourceRange>)IntPtr.Zero;
-        _virtualTable.clang_getCursorLocation = (delegate* unmanaged[Cdecl]<CXCursor, CXSourceLocation>)IntPtr.Zero;
-        _virtualTable.clang_getCursor = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceLocation, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_getIncludedFile = (delegate* unmanaged[Cdecl]<CXCursor, CXFile>)IntPtr.Zero;
-        _virtualTable.clang_disposeOverriddenCursors = (delegate* unmanaged[Cdecl]<CXCursor*, void>)IntPtr.Zero;
-        _virtualTable.clang_getOverriddenCursors = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor**, ulong*, void>)IntPtr.Zero;
-        _virtualTable.clang_getCursorLexicalParent = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_getCursorSemanticParent = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_CXCursorSet_insert = (delegate* unmanaged[Cdecl]<CXCursorSet, CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXCursorSet_contains = (delegate* unmanaged[Cdecl]<CXCursorSet, CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_disposeCXCursorSet = (delegate* unmanaged[Cdecl]<CXCursorSet, void>)IntPtr.Zero;
-        _virtualTable.clang_createCXCursorSet = (delegate* unmanaged[Cdecl]<CXCursorSet>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getTranslationUnit = (delegate* unmanaged[Cdecl]<CXCursor, CXTranslationUnit>)IntPtr.Zero;
-        _virtualTable.clang_getCursorTLSKind = (delegate* unmanaged[Cdecl]<CXCursor, CXTLSKind>)IntPtr.Zero;
-        _virtualTable.clang_getCursorLanguage = (delegate* unmanaged[Cdecl]<CXCursor, CXLanguageKind>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_hasVarDeclExternalStorage = (delegate* unmanaged[Cdecl]<CXCursor, int>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_hasVarDeclGlobalStorage = (delegate* unmanaged[Cdecl]<CXCursor, int>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_getVarDeclInitializer = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_disposeCXPlatformAvailability = (delegate* unmanaged[Cdecl]<CXPlatformAvailability*, void>)IntPtr.Zero;
-        _virtualTable.clang_getCursorPlatformAvailability = (delegate* unmanaged[Cdecl]<CXCursor, long*, CXString*, long*, CXString*, CXPlatformAvailability*, int, int>)IntPtr.Zero;
-        _virtualTable.clang_getCursorAvailability = (delegate* unmanaged[Cdecl]<CXCursor, CXAvailabilityKind>)IntPtr.Zero;
-        _virtualTable.clang_getCursorVisibility = (delegate* unmanaged[Cdecl]<CXCursor, CXVisibilityKind>)IntPtr.Zero;
-        _virtualTable.clang_getCursorLinkage = (delegate* unmanaged[Cdecl]<CXCursor, CXLinkageKind>)IntPtr.Zero;
-        _virtualTable.clang_isUnexposed = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)IntPtr.Zero;
-        _virtualTable.clang_isPreprocessing = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)IntPtr.Zero;
-        _virtualTable.clang_isTranslationUnit = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)IntPtr.Zero;
-        _virtualTable.clang_isInvalid = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_hasAttrs = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_isAttribute = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)IntPtr.Zero;
-        _virtualTable.clang_isStatement = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)IntPtr.Zero;
-        _virtualTable.clang_isExpression = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)IntPtr.Zero;
-        _virtualTable.clang_isReference = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)IntPtr.Zero;
-        _virtualTable.clang_isInvalidDeclaration = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_isDeclaration = (delegate* unmanaged[Cdecl]<CXCursorKind, uint>)IntPtr.Zero;
-        _virtualTable.clang_getCursorKind = (delegate* unmanaged[Cdecl]<CXCursor, CXCursorKind>)IntPtr.Zero;
-        _virtualTable.clang_hashCursor = (delegate* unmanaged[Cdecl]<CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_Cursor_isNull = (delegate* unmanaged[Cdecl]<CXCursor, int>)IntPtr.Zero;
-        _virtualTable.clang_equalCursors = (delegate* unmanaged[Cdecl]<CXCursor, CXCursor, uint>)IntPtr.Zero;
-        _virtualTable.clang_getTranslationUnitCursor = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_getNullCursor = (delegate* unmanaged[Cdecl]<CXCursor>)IntPtr.Zero;
-        _virtualTable.clang_TargetInfo_getPointerWidth = (delegate* unmanaged[Cdecl]<CXTargetInfo, int>)IntPtr.Zero;
-        _virtualTable.clang_TargetInfo_getTriple = (delegate* unmanaged[Cdecl]<CXTargetInfo, CXString>)IntPtr.Zero;
-        _virtualTable.clang_TargetInfo_dispose = (delegate* unmanaged[Cdecl]<CXTargetInfo, void>)IntPtr.Zero;
-        _virtualTable.clang_getTranslationUnitTargetInfo = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXTargetInfo>)IntPtr.Zero;
-        _virtualTable.clang_disposeCXTUResourceUsage = (delegate* unmanaged[Cdecl]<CXTUResourceUsage, void>)IntPtr.Zero;
-        _virtualTable.clang_getCXTUResourceUsage = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXTUResourceUsage>)IntPtr.Zero;
-        _virtualTable.clang_getTUResourceUsageName = (delegate* unmanaged[Cdecl]<CXTUResourceUsageKind, CString>)IntPtr.Zero;
-        _virtualTable.clang_reparseTranslationUnit = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint, CXUnsavedFile*, uint, int>)IntPtr.Zero;
-        _virtualTable.clang_defaultReparseOptions = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint>)IntPtr.Zero;
-        _virtualTable.clang_disposeTranslationUnit = (delegate* unmanaged[Cdecl]<CXTranslationUnit, void>)IntPtr.Zero;
-        _virtualTable.clang_suspendTranslationUnit = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint>)IntPtr.Zero;
-        _virtualTable.clang_saveTranslationUnit = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CString, uint, int>)IntPtr.Zero;
-        _virtualTable.clang_defaultSaveOptions = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint>)IntPtr.Zero;
-        _virtualTable.clang_parseTranslationUnit2FullArgv = (delegate* unmanaged[Cdecl]<CXIndex, CString, CString*, int, CXUnsavedFile*, uint, uint, CXTranslationUnit*, CXErrorCode>)IntPtr.Zero;
-        _virtualTable.clang_parseTranslationUnit2 = (delegate* unmanaged[Cdecl]<CXIndex, CString, CString*, int, CXUnsavedFile*, uint, uint, CXTranslationUnit*, CXErrorCode>)IntPtr.Zero;
-        _virtualTable.clang_parseTranslationUnit = (delegate* unmanaged[Cdecl]<CXIndex, CString, CString*, int, CXUnsavedFile*, uint, uint, CXTranslationUnit>)IntPtr.Zero;
-        _virtualTable.clang_defaultEditingTranslationUnitOptions = (delegate* unmanaged[Cdecl]<uint>)IntPtr.Zero;
-        _virtualTable.clang_createTranslationUnit2 = (delegate* unmanaged[Cdecl]<CXIndex, CString, CXTranslationUnit*, CXErrorCode>)IntPtr.Zero;
-        _virtualTable.clang_createTranslationUnit = (delegate* unmanaged[Cdecl]<CXIndex, CString, CXTranslationUnit>)IntPtr.Zero;
-        _virtualTable.clang_createTranslationUnitFromSourceFile = (delegate* unmanaged[Cdecl]<CXIndex, CString, int, CString*, uint, CXUnsavedFile*, CXTranslationUnit>)IntPtr.Zero;
-        _virtualTable.clang_getTranslationUnitSpelling = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticFixIt = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint, CXSourceRange*, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticNumFixIts = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticRange = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint, CXSourceRange>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticNumRanges = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticCategoryText = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticCategoryName = (delegate* unmanaged[Cdecl]<uint, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticCategory = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticOption = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXString*, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticSpelling = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXString>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticLocation = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXSourceLocation>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticSeverity = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXDiagnosticSeverity>)IntPtr.Zero;
-        _virtualTable.clang_defaultDiagnosticDisplayOptions = (delegate* unmanaged[Cdecl]<uint>)IntPtr.Zero;
-        _virtualTable.clang_formatDiagnostic = (delegate* unmanaged[Cdecl]<CXDiagnostic, uint, CXString>)IntPtr.Zero;
-        _virtualTable.clang_disposeDiagnostic = (delegate* unmanaged[Cdecl]<CXDiagnostic, void>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticSetFromTU = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXDiagnosticSet>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnostic = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint, CXDiagnostic>)IntPtr.Zero;
-        _virtualTable.clang_getNumDiagnostics = (delegate* unmanaged[Cdecl]<CXTranslationUnit, uint>)IntPtr.Zero;
-        _virtualTable.clang_getChildDiagnostics = (delegate* unmanaged[Cdecl]<CXDiagnostic, CXDiagnosticSet>)IntPtr.Zero;
-        _virtualTable.clang_disposeDiagnosticSet = (delegate* unmanaged[Cdecl]<CXDiagnosticSet, void>)IntPtr.Zero;
-        _virtualTable.clang_loadDiagnostics = (delegate* unmanaged[Cdecl]<CString, CXLoadDiag_Error*, CXString*, CXDiagnosticSet>)IntPtr.Zero;
-        _virtualTable.clang_getDiagnosticInSet = (delegate* unmanaged[Cdecl]<CXDiagnosticSet, uint, CXDiagnostic>)IntPtr.Zero;
-        _virtualTable.clang_getNumDiagnosticsInSet = (delegate* unmanaged[Cdecl]<CXDiagnosticSet, uint>)IntPtr.Zero;
-        _virtualTable.clang_disposeSourceRangeList = (delegate* unmanaged[Cdecl]<CXSourceRangeList*, void>)IntPtr.Zero;
-        _virtualTable.clang_getAllSkippedRanges = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceRangeList*>)IntPtr.Zero;
-        _virtualTable.clang_getSkippedRanges = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, CXSourceRangeList*>)IntPtr.Zero;
-        _virtualTable.clang_getRangeEnd = (delegate* unmanaged[Cdecl]<CXSourceRange, CXSourceLocation>)IntPtr.Zero;
-        _virtualTable.clang_getRangeStart = (delegate* unmanaged[Cdecl]<CXSourceRange, CXSourceLocation>)IntPtr.Zero;
-        _virtualTable.clang_getFileLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void>)IntPtr.Zero;
-        _virtualTable.clang_getSpellingLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void>)IntPtr.Zero;
-        _virtualTable.clang_getInstantiationLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void>)IntPtr.Zero;
-        _virtualTable.clang_getPresumedLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXString*, ulong*, ulong*, void>)IntPtr.Zero;
-        _virtualTable.clang_getExpansionLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void>)IntPtr.Zero;
-        _virtualTable.clang_Range_isNull = (delegate* unmanaged[Cdecl]<CXSourceRange, int>)IntPtr.Zero;
-        _virtualTable.clang_equalRanges = (delegate* unmanaged[Cdecl]<CXSourceRange, CXSourceRange, uint>)IntPtr.Zero;
-        _virtualTable.clang_getRange = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXSourceLocation, CXSourceRange>)IntPtr.Zero;
-        _virtualTable.clang_getNullRange = (delegate* unmanaged[Cdecl]<CXSourceRange>)IntPtr.Zero;
-        _virtualTable.clang_Location_isFromMainFile = (delegate* unmanaged[Cdecl]<CXSourceLocation, int>)IntPtr.Zero;
-        _virtualTable.clang_Location_isInSystemHeader = (delegate* unmanaged[Cdecl]<CXSourceLocation, int>)IntPtr.Zero;
-        _virtualTable.clang_getLocationForOffset = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, uint, CXSourceLocation>)IntPtr.Zero;
-        _virtualTable.clang_getLocation = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, uint, uint, CXSourceLocation>)IntPtr.Zero;
-        _virtualTable.clang_equalLocations = (delegate* unmanaged[Cdecl]<CXSourceLocation, CXSourceLocation, uint>)IntPtr.Zero;
-        _virtualTable.clang_getNullLocation = (delegate* unmanaged[Cdecl]<CXSourceLocation>)IntPtr.Zero;
-        _virtualTable.clang_File_tryGetRealPathName = (delegate* unmanaged[Cdecl]<CXFile, CXString>)IntPtr.Zero;
-        _virtualTable.clang_File_isEqual = (delegate* unmanaged[Cdecl]<CXFile, CXFile, int>)IntPtr.Zero;
-        _virtualTable.clang_getFileContents = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, ulong*, CString>)IntPtr.Zero;
-        _virtualTable.clang_getFile = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CString, CXFile>)IntPtr.Zero;
-        _virtualTable.clang_isFileMultipleIncludeGuarded = (delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, uint>)IntPtr.Zero;
-        _virtualTable.clang_getFileUniqueID = (delegate* unmanaged[Cdecl]<CXFile, CXFileUniqueID*, int>)IntPtr.Zero;
-        _virtualTable.clang_getFileTime = (delegate* unmanaged[Cdecl]<CXFile, time_t>)IntPtr.Zero;
-        _virtualTable.clang_getFileName = (delegate* unmanaged[Cdecl]<CXFile, CXString>)IntPtr.Zero;
-        _virtualTable.clang_CXIndex_setInvocationEmissionPathOption = (delegate* unmanaged[Cdecl]<CXIndex, CString, void>)IntPtr.Zero;
-        _virtualTable.clang_CXIndex_getGlobalOptions = (delegate* unmanaged[Cdecl]<CXIndex, uint>)IntPtr.Zero;
-        _virtualTable.clang_CXIndex_setGlobalOptions = (delegate* unmanaged[Cdecl]<CXIndex, uint, void>)IntPtr.Zero;
-        _virtualTable.clang_disposeIndex = (delegate* unmanaged[Cdecl]<CXIndex, void>)IntPtr.Zero;
-        _virtualTable.clang_createIndex = (delegate* unmanaged[Cdecl]<int, int, CXIndex>)IntPtr.Zero;
-        _virtualTable.clang_ModuleMapDescriptor_dispose = (delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, void>)IntPtr.Zero;
-        _virtualTable.clang_ModuleMapDescriptor_writeToBuffer = (delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, uint, CString*, ulong*, CXErrorCode>)IntPtr.Zero;
-        _virtualTable.clang_ModuleMapDescriptor_setUmbrellaHeader = (delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, CString, CXErrorCode>)IntPtr.Zero;
-        _virtualTable.clang_ModuleMapDescriptor_setFrameworkModuleName = (delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, CString, CXErrorCode>)IntPtr.Zero;
-        _virtualTable.clang_ModuleMapDescriptor_create = (delegate* unmanaged[Cdecl]<uint, CXModuleMapDescriptor>)IntPtr.Zero;
-        _virtualTable.clang_VirtualFileOverlay_dispose = (delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, void>)IntPtr.Zero;
-        _virtualTable.clang_free = (delegate* unmanaged[Cdecl]<void*, void>)IntPtr.Zero;
-        _virtualTable.clang_VirtualFileOverlay_writeToBuffer = (delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, uint, CString*, ulong*, CXErrorCode>)IntPtr.Zero;
-        _virtualTable.clang_VirtualFileOverlay_setCaseSensitivity = (delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, int, CXErrorCode>)IntPtr.Zero;
-        _virtualTable.clang_VirtualFileOverlay_addFileMapping = (delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, CString, CString, CXErrorCode>)IntPtr.Zero;
-        _virtualTable.clang_VirtualFileOverlay_create = (delegate* unmanaged[Cdecl]<uint, CXVirtualFileOverlay>)IntPtr.Zero;
-        _virtualTable.clang_getBuildSessionTimestamp = (delegate* unmanaged[Cdecl]<ulong>)IntPtr.Zero;
-        _virtualTable.clang_disposeStringSet = (delegate* unmanaged[Cdecl]<CXStringSet*, void>)IntPtr.Zero;
-        _virtualTable.clang_disposeString = (delegate* unmanaged[Cdecl]<CXString, void>)IntPtr.Zero;
-        _virtualTable.clang_getCString = (delegate* unmanaged[Cdecl]<CXString, CString>)IntPtr.Zero;
-
-        #endregion
-
-        #region "Variables"
-
-
-
-        #endregion
-    }
-
-    // The virtual table represents a list of pointers to functions or variables which are resolved in a late manner.
-    //	This allows for flexibility in swapping implementations at runtime.
-    //	You can think of it in traditional OOP terms in C# as the locations of the virtual methods and/or properties of an object.
-    public struct _VirtualTable
-    {
-        #region "Function Pointers"
-        // These pointers hold the locations in the native library where functions are located at runtime.
-        // See: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers
-
-        public delegate* unmanaged[Cdecl]<CXType, CXFieldVisitor, CXClientData, uint> clang_Type_visitFields;
-        public delegate* unmanaged[Cdecl]<CXIdxLoc, CXSourceLocation> clang_indexLoc_getCXSourceLocation;
-        public delegate* unmanaged[Cdecl]<CXIdxLoc, CXIdxClientFile*, CXFile*, ulong*, ulong*, ulong*, void> clang_indexLoc_getFileLocation;
-        public delegate* unmanaged[Cdecl]<CXIndexAction, CXClientData, IndexerCallbacks*, uint, uint, CXTranslationUnit, int> clang_indexTranslationUnit;
-        public delegate* unmanaged[Cdecl]<CXIndexAction, CXClientData, IndexerCallbacks*, uint, uint, CString, CString*, int, CXUnsavedFile*, uint, CXTranslationUnit*, uint, int> clang_indexSourceFileFullArgv;
-        public delegate* unmanaged[Cdecl]<CXIndexAction, CXClientData, IndexerCallbacks*, uint, uint, CString, CString*, int, CXUnsavedFile*, uint, CXTranslationUnit*, uint, int> clang_indexSourceFile;
-        public delegate* unmanaged[Cdecl]<CXIndexAction, void> clang_IndexAction_dispose;
-        public delegate* unmanaged[Cdecl]<CXIndex, CXIndexAction> clang_IndexAction_create;
-        public delegate* unmanaged[Cdecl]<CXIdxEntityInfo*, CXIdxClientEntity, void> clang_index_setClientEntity;
-        public delegate* unmanaged[Cdecl]<CXIdxEntityInfo*, CXIdxClientEntity> clang_index_getClientEntity;
-        public delegate* unmanaged[Cdecl]<CXIdxContainerInfo*, CXIdxClientContainer, void> clang_index_setClientContainer;
-        public delegate* unmanaged[Cdecl]<CXIdxContainerInfo*, CXIdxClientContainer> clang_index_getClientContainer;
-        public delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxCXXClassDeclInfo*> clang_index_getCXXClassDeclInfo;
-        public delegate* unmanaged[Cdecl]<CXIdxAttrInfo*, CXIdxIBOutletCollectionAttrInfo*> clang_index_getIBOutletCollectionAttrInfo;
-        public delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCPropertyDeclInfo*> clang_index_getObjCPropertyDeclInfo;
-        public delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCProtocolRefListInfo*> clang_index_getObjCProtocolRefListInfo;
-        public delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCCategoryDeclInfo*> clang_index_getObjCCategoryDeclInfo;
-        public delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCInterfaceDeclInfo*> clang_index_getObjCInterfaceDeclInfo;
-        public delegate* unmanaged[Cdecl]<CXIdxDeclInfo*, CXIdxObjCContainerDeclInfo*> clang_index_getObjCContainerDeclInfo;
-        public delegate* unmanaged[Cdecl]<CXIdxEntityKind, int> clang_index_isEntityObjCContainerKind;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, CXCursorAndRangeVisitor, CXResult> clang_findIncludesInFile;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXFile, CXCursorAndRangeVisitor, CXResult> clang_findReferencesInFile;
-        public delegate* unmanaged[Cdecl]<CXRemapping, void> clang_remap_dispose;
-        public delegate* unmanaged[Cdecl]<CXRemapping, uint, CXString*, CXString*, void> clang_remap_getFilenames;
-        public delegate* unmanaged[Cdecl]<CXRemapping, uint> clang_remap_getNumFiles;
-        public delegate* unmanaged[Cdecl]<CString*, uint, CXRemapping> clang_getRemappingsFromFileList;
-        public delegate* unmanaged[Cdecl]<CString, CXRemapping> clang_getRemappings;
-        public delegate* unmanaged[Cdecl]<CXEvalResult, void> clang_EvalResult_dispose;
-        public delegate* unmanaged[Cdecl]<CXEvalResult, CString> clang_EvalResult_getAsStr;
-        public delegate* unmanaged[Cdecl]<CXEvalResult, double> clang_EvalResult_getAsDouble;
-        public delegate* unmanaged[Cdecl]<CXEvalResult, ulong> clang_EvalResult_getAsUnsigned;
-        public delegate* unmanaged[Cdecl]<CXEvalResult, uint> clang_EvalResult_isUnsignedInt;
-        public delegate* unmanaged[Cdecl]<CXEvalResult, long> clang_EvalResult_getAsLongLong;
-        public delegate* unmanaged[Cdecl]<CXEvalResult, int> clang_EvalResult_getAsInt;
-        public delegate* unmanaged[Cdecl]<CXEvalResult, CXEvalResultKind> clang_EvalResult_getKind;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXEvalResult> clang_Cursor_Evaluate;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXInclusionVisitor, CXClientData, void> clang_getInclusions;
-        public delegate* unmanaged[Cdecl]<uint, void> clang_toggleCrashRecovery;
-        public delegate* unmanaged[Cdecl]<CXString> clang_getClangVersion;
-        public delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, CXString> clang_codeCompleteGetObjCSelector;
-        public delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, CXString> clang_codeCompleteGetContainerUSR;
-        public delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, ulong*, CXCursorKind> clang_codeCompleteGetContainerKind;
-        public delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, ulong> clang_codeCompleteGetContexts;
-        public delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint, CXDiagnostic> clang_codeCompleteGetDiagnostic;
-        public delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint> clang_codeCompleteGetNumDiagnostics;
-        public delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, void> clang_disposeCodeCompleteResults;
-        public delegate* unmanaged[Cdecl]<CXCompletionResult*, uint, void> clang_sortCodeCompletionResults;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CString, uint, uint, CXUnsavedFile*, uint, uint, CXCodeCompleteResults*> clang_codeCompleteAt;
-        public delegate* unmanaged[Cdecl]<uint> clang_defaultCodeCompleteOptions;
-        public delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint, uint, CXSourceRange*, CXString> clang_getCompletionFixIt;
-        public delegate* unmanaged[Cdecl]<CXCodeCompleteResults*, uint, uint> clang_getCompletionNumFixIts;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCompletionString> clang_getCursorCompletionString;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, CXString> clang_getCompletionBriefComment;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, CXCursorKind*, CXString> clang_getCompletionParent;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXString> clang_getCompletionAnnotation;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, uint> clang_getCompletionNumAnnotations;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, CXAvailabilityKind> clang_getCompletionAvailability;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, uint> clang_getCompletionPriority;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, uint> clang_getNumCompletionChunks;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXCompletionString> clang_getCompletionChunkCompletionString;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXString> clang_getCompletionChunkText;
-        public delegate* unmanaged[Cdecl]<CXCompletionString, uint, CXCompletionChunkKind> clang_getCompletionChunkKind;
-        public delegate* unmanaged[Cdecl]<FnPtr_CLANG_VoidPtr_Void, void*, uint, void> clang_executeOnThread;
-        public delegate* unmanaged[Cdecl]<void> clang_enableStackTraces;
-        public delegate* unmanaged[Cdecl]<CXCursor, CString*, CString*, ulong*, ulong*, ulong*, ulong*, void> clang_getDefinitionSpellingAndExtent;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, CXString> clang_getCursorKindSpelling;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken*, uint, void> clang_disposeTokens;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken*, uint, CXCursor*, void> clang_annotateTokens;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceRange, CXToken**, ulong*, void> clang_tokenize;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken, CXSourceRange> clang_getTokenExtent;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken, CXSourceLocation> clang_getTokenLocation;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXToken, CXString> clang_getTokenSpelling;
-        public delegate* unmanaged[Cdecl]<CXToken, CXTokenKind> clang_getTokenKind;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceLocation, CXToken*> clang_getToken;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint, uint, CXSourceRange> clang_getCursorReferenceNameRange;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursor> clang_getSpecializedCursorTemplate;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursorKind> clang_getTemplateCursorKind;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXMethod_isConst;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_EnumDecl_isScoped;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXRecord_isAbstract;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXMethod_isVirtual;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXMethod_isStatic;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXMethod_isPureVirtual;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXMethod_isDefaulted;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXField_isMutable;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXConstructor_isMoveConstructor;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXConstructor_isDefaultConstructor;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXConstructor_isCopyConstructor;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_CXXConstructor_isConvertingConstructor;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXModule, uint, CXFile> clang_Module_getTopLevelHeader;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXModule, uint> clang_Module_getNumTopLevelHeaders;
-        public delegate* unmanaged[Cdecl]<CXModule, int> clang_Module_isSystem;
-        public delegate* unmanaged[Cdecl]<CXModule, CXString> clang_Module_getFullName;
-        public delegate* unmanaged[Cdecl]<CXModule, CXString> clang_Module_getName;
-        public delegate* unmanaged[Cdecl]<CXModule, CXModule> clang_Module_getParent;
-        public delegate* unmanaged[Cdecl]<CXModule, CXFile> clang_Module_getASTFile;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, CXModule> clang_getModuleForFile;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXModule> clang_Cursor_getModule;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXStringSet*> clang_Cursor_getObjCManglings;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXStringSet*> clang_Cursor_getCXXManglings;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString> clang_Cursor_getMangling;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString> clang_Cursor_getBriefCommentText;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString> clang_Cursor_getRawCommentText;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXSourceRange> clang_Cursor_getCommentRange;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString*, CXString*, ulong*, uint> clang_Cursor_isExternalSymbol;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_isVariadic;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_isObjCOptional;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_getObjCDeclQualifiers;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString> clang_Cursor_getObjCPropertySetterName;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString> clang_Cursor_getObjCPropertyGetterName;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint, uint> clang_Cursor_getObjCPropertyAttributes;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXType> clang_Cursor_getReceiverType;
-        public delegate* unmanaged[Cdecl]<CXCursor, int> clang_Cursor_isDynamicCall;
-        public delegate* unmanaged[Cdecl]<CXCursor, int> clang_Cursor_getObjCSelectorIndex;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursor> clang_getCanonicalCursor;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_isCursorDefinition;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursor> clang_getCursorDefinition;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursor> clang_getCursorReferenced;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString> clang_getCursorDisplayName;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXPrintingPolicy, CXString> clang_getCursorPrettyPrinted;
-        public delegate* unmanaged[Cdecl]<CXPrintingPolicy, void> clang_PrintingPolicy_dispose;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXPrintingPolicy> clang_getCursorPrintingPolicy;
-        public delegate* unmanaged[Cdecl]<CXPrintingPolicy, CXPrintingPolicyProperty, uint, void> clang_PrintingPolicy_setProperty;
-        public delegate* unmanaged[Cdecl]<CXPrintingPolicy, CXPrintingPolicyProperty, uint> clang_PrintingPolicy_getProperty;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint, uint, CXSourceRange> clang_Cursor_getSpellingNameRange;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString> clang_getCursorSpelling;
-        public delegate* unmanaged[Cdecl]<CString, CXString, CXString> clang_constructUSR_ObjCProperty;
-        public delegate* unmanaged[Cdecl]<CString, uint, CXString, CXString> clang_constructUSR_ObjCMethod;
-        public delegate* unmanaged[Cdecl]<CString, CXString, CXString> clang_constructUSR_ObjCIvar;
-        public delegate* unmanaged[Cdecl]<CString, CXString> clang_constructUSR_ObjCProtocol;
-        public delegate* unmanaged[Cdecl]<CString, CString, CXString> clang_constructUSR_ObjCCategory;
-        public delegate* unmanaged[Cdecl]<CString, CXString> clang_constructUSR_ObjCClass;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString> clang_getCursorUSR;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursorVisitor, CXClientData, uint> clang_visitChildren;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXType> clang_getIBOutletCollectionType;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint, CXCursor> clang_getOverloadedDecl;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_getNumOverloadedDecls;
-        public delegate* unmanaged[Cdecl]<CXCursor, CX_StorageClass> clang_Cursor_getStorageClass;
-        public delegate* unmanaged[Cdecl]<CXCursor, CX_CXXAccessSpecifier> clang_getCXXAccessSpecifier;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_isVirtualBase;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_isBitField;
-        public delegate* unmanaged[Cdecl]<CXType, CXRefQualifierKind> clang_Type_getCXXRefQualifier;
-        public delegate* unmanaged[Cdecl]<CXType, uint, CXType> clang_Type_getTemplateArgumentAsType;
-        public delegate* unmanaged[Cdecl]<CXType, int> clang_Type_getNumTemplateArguments;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_isInlineNamespace;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_isAnonymousRecordDecl;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_isAnonymous;
-        public delegate* unmanaged[Cdecl]<CXCursor, long> clang_Cursor_getOffsetOfField;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_Type_getValueType;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_Type_getModifiedType;
-        public delegate* unmanaged[Cdecl]<CXType, CString, long> clang_Type_getOffsetOf;
-        public delegate* unmanaged[Cdecl]<CXType, long> clang_Type_getSizeOf;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_Type_getClassType;
-        public delegate* unmanaged[Cdecl]<CXType, long> clang_Type_getAlignOf;
-        public delegate* unmanaged[Cdecl]<CXType, CXTypeNullabilityKind> clang_Type_getNullability;
-        public delegate* unmanaged[Cdecl]<CXType, uint> clang_Type_isTransparentTagTypedef;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_Type_getNamedType;
-        public delegate* unmanaged[Cdecl]<CXType, long> clang_getArraySize;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_getArrayElementType;
-        public delegate* unmanaged[Cdecl]<CXType, long> clang_getNumElements;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_getElementType;
-        public delegate* unmanaged[Cdecl]<CXType, uint> clang_isPODType;
-        public delegate* unmanaged[Cdecl]<CXCursor, int> clang_getCursorExceptionSpecificationType;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXType> clang_getCursorResultType;
-        public delegate* unmanaged[Cdecl]<CXType, uint> clang_isFunctionTypeVariadic;
-        public delegate* unmanaged[Cdecl]<CXType, uint, CXType> clang_Type_getObjCTypeArg;
-        public delegate* unmanaged[Cdecl]<CXType, uint> clang_Type_getNumObjCTypeArgs;
-        public delegate* unmanaged[Cdecl]<CXType, uint, CXCursor> clang_Type_getObjCProtocolDecl;
-        public delegate* unmanaged[Cdecl]<CXType, uint> clang_Type_getNumObjCProtocolRefs;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_Type_getObjCObjectBaseType;
-        public delegate* unmanaged[Cdecl]<CXType, uint, CXType> clang_getArgType;
-        public delegate* unmanaged[Cdecl]<CXType, int> clang_getNumArgTypes;
-        public delegate* unmanaged[Cdecl]<CXType, int> clang_getExceptionSpecificationType;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_getResultType;
-        public delegate* unmanaged[Cdecl]<CXType, CXCallingConv> clang_getFunctionTypeCallingConv;
-        public delegate* unmanaged[Cdecl]<CXTypeKind, CXString> clang_getTypeKindSpelling;
-        public delegate* unmanaged[Cdecl]<CXType, CXString> clang_Type_getObjCEncoding;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXString> clang_getDeclObjCTypeEncoding;
-        public delegate* unmanaged[Cdecl]<CXType, CXCursor> clang_getTypeDeclaration;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_getPointeeType;
-        public delegate* unmanaged[Cdecl]<CXType, CXString> clang_getTypedefName;
-        public delegate* unmanaged[Cdecl]<CXType, uint> clang_getAddressSpace;
-        public delegate* unmanaged[Cdecl]<CXType, uint> clang_isRestrictQualifiedType;
-        public delegate* unmanaged[Cdecl]<CXType, uint> clang_isVolatileQualifiedType;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_isFunctionInlined;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_isMacroBuiltin;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_isMacroFunctionLike;
-        public delegate* unmanaged[Cdecl]<CXType, uint> clang_isConstQualifiedType;
-        public delegate* unmanaged[Cdecl]<CXType, CXType> clang_getCanonicalType;
-        public delegate* unmanaged[Cdecl]<CXType, CXType, uint> clang_equalTypes;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint, ulong> clang_Cursor_getTemplateArgumentUnsignedValue;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint, long> clang_Cursor_getTemplateArgumentValue;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint, CXType> clang_Cursor_getTemplateArgumentType;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint, CXTemplateArgumentKind> clang_Cursor_getTemplateArgumentKind;
-        public delegate* unmanaged[Cdecl]<CXCursor, int> clang_Cursor_getNumTemplateArguments;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint, CXCursor> clang_Cursor_getArgument;
-        public delegate* unmanaged[Cdecl]<CXCursor, int> clang_Cursor_getNumArguments;
-        public delegate* unmanaged[Cdecl]<CXCursor, int> clang_getFieldDeclBitWidth;
-        public delegate* unmanaged[Cdecl]<CXCursor, ulong> clang_getEnumConstantDeclUnsignedValue;
-        public delegate* unmanaged[Cdecl]<CXCursor, long> clang_getEnumConstantDeclValue;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXType> clang_getEnumDeclIntegerType;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXType> clang_getTypedefDeclUnderlyingType;
-        public delegate* unmanaged[Cdecl]<CXType, CXString> clang_getTypeSpelling;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXType> clang_getCursorType;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXSourceRange> clang_getCursorExtent;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXSourceLocation> clang_getCursorLocation;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceLocation, CXCursor> clang_getCursor;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXFile> clang_getIncludedFile;
-        public delegate* unmanaged[Cdecl]<CXCursor*, void> clang_disposeOverriddenCursors;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursor**, ulong*, void> clang_getOverriddenCursors;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursor> clang_getCursorLexicalParent;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursor> clang_getCursorSemanticParent;
-        public delegate* unmanaged[Cdecl]<CXCursorSet, CXCursor, uint> clang_CXCursorSet_insert;
-        public delegate* unmanaged[Cdecl]<CXCursorSet, CXCursor, uint> clang_CXCursorSet_contains;
-        public delegate* unmanaged[Cdecl]<CXCursorSet, void> clang_disposeCXCursorSet;
-        public delegate* unmanaged[Cdecl]<CXCursorSet> clang_createCXCursorSet;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXTranslationUnit> clang_Cursor_getTranslationUnit;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXTLSKind> clang_getCursorTLSKind;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXLanguageKind> clang_getCursorLanguage;
-        public delegate* unmanaged[Cdecl]<CXCursor, int> clang_Cursor_hasVarDeclExternalStorage;
-        public delegate* unmanaged[Cdecl]<CXCursor, int> clang_Cursor_hasVarDeclGlobalStorage;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursor> clang_Cursor_getVarDeclInitializer;
-        public delegate* unmanaged[Cdecl]<CXPlatformAvailability*, void> clang_disposeCXPlatformAvailability;
-        public delegate* unmanaged[Cdecl]<CXCursor, long*, CXString*, long*, CXString*, CXPlatformAvailability*, int, int> clang_getCursorPlatformAvailability;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXAvailabilityKind> clang_getCursorAvailability;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXVisibilityKind> clang_getCursorVisibility;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXLinkageKind> clang_getCursorLinkage;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, uint> clang_isUnexposed;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, uint> clang_isPreprocessing;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, uint> clang_isTranslationUnit;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, uint> clang_isInvalid;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_Cursor_hasAttrs;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, uint> clang_isAttribute;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, uint> clang_isStatement;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, uint> clang_isExpression;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, uint> clang_isReference;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_isInvalidDeclaration;
-        public delegate* unmanaged[Cdecl]<CXCursorKind, uint> clang_isDeclaration;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursorKind> clang_getCursorKind;
-        public delegate* unmanaged[Cdecl]<CXCursor, uint> clang_hashCursor;
-        public delegate* unmanaged[Cdecl]<CXCursor, int> clang_Cursor_isNull;
-        public delegate* unmanaged[Cdecl]<CXCursor, CXCursor, uint> clang_equalCursors;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXCursor> clang_getTranslationUnitCursor;
-        public delegate* unmanaged[Cdecl]<CXCursor> clang_getNullCursor;
-        public delegate* unmanaged[Cdecl]<CXTargetInfo, int> clang_TargetInfo_getPointerWidth;
-        public delegate* unmanaged[Cdecl]<CXTargetInfo, CXString> clang_TargetInfo_getTriple;
-        public delegate* unmanaged[Cdecl]<CXTargetInfo, void> clang_TargetInfo_dispose;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXTargetInfo> clang_getTranslationUnitTargetInfo;
-        public delegate* unmanaged[Cdecl]<CXTUResourceUsage, void> clang_disposeCXTUResourceUsage;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXTUResourceUsage> clang_getCXTUResourceUsage;
-        public delegate* unmanaged[Cdecl]<CXTUResourceUsageKind, CString> clang_getTUResourceUsageName;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, uint, CXUnsavedFile*, uint, int> clang_reparseTranslationUnit;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, uint> clang_defaultReparseOptions;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, void> clang_disposeTranslationUnit;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, uint> clang_suspendTranslationUnit;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CString, uint, int> clang_saveTranslationUnit;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, uint> clang_defaultSaveOptions;
-        public delegate* unmanaged[Cdecl]<CXIndex, CString, CString*, int, CXUnsavedFile*, uint, uint, CXTranslationUnit*, CXErrorCode> clang_parseTranslationUnit2FullArgv;
-        public delegate* unmanaged[Cdecl]<CXIndex, CString, CString*, int, CXUnsavedFile*, uint, uint, CXTranslationUnit*, CXErrorCode> clang_parseTranslationUnit2;
-        public delegate* unmanaged[Cdecl]<CXIndex, CString, CString*, int, CXUnsavedFile*, uint, uint, CXTranslationUnit> clang_parseTranslationUnit;
-        public delegate* unmanaged[Cdecl]<uint> clang_defaultEditingTranslationUnitOptions;
-        public delegate* unmanaged[Cdecl]<CXIndex, CString, CXTranslationUnit*, CXErrorCode> clang_createTranslationUnit2;
-        public delegate* unmanaged[Cdecl]<CXIndex, CString, CXTranslationUnit> clang_createTranslationUnit;
-        public delegate* unmanaged[Cdecl]<CXIndex, CString, int, CString*, uint, CXUnsavedFile*, CXTranslationUnit> clang_createTranslationUnitFromSourceFile;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXString> clang_getTranslationUnitSpelling;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, uint, CXSourceRange*, CXString> clang_getDiagnosticFixIt;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, uint> clang_getDiagnosticNumFixIts;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, uint, CXSourceRange> clang_getDiagnosticRange;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, uint> clang_getDiagnosticNumRanges;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, CXString> clang_getDiagnosticCategoryText;
-        public delegate* unmanaged[Cdecl]<uint, CXString> clang_getDiagnosticCategoryName;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, uint> clang_getDiagnosticCategory;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, CXString*, CXString> clang_getDiagnosticOption;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, CXString> clang_getDiagnosticSpelling;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, CXSourceLocation> clang_getDiagnosticLocation;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, CXDiagnosticSeverity> clang_getDiagnosticSeverity;
-        public delegate* unmanaged[Cdecl]<uint> clang_defaultDiagnosticDisplayOptions;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, uint, CXString> clang_formatDiagnostic;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, void> clang_disposeDiagnostic;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXDiagnosticSet> clang_getDiagnosticSetFromTU;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, uint, CXDiagnostic> clang_getDiagnostic;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, uint> clang_getNumDiagnostics;
-        public delegate* unmanaged[Cdecl]<CXDiagnostic, CXDiagnosticSet> clang_getChildDiagnostics;
-        public delegate* unmanaged[Cdecl]<CXDiagnosticSet, void> clang_disposeDiagnosticSet;
-        public delegate* unmanaged[Cdecl]<CString, CXLoadDiag_Error*, CXString*, CXDiagnosticSet> clang_loadDiagnostics;
-        public delegate* unmanaged[Cdecl]<CXDiagnosticSet, uint, CXDiagnostic> clang_getDiagnosticInSet;
-        public delegate* unmanaged[Cdecl]<CXDiagnosticSet, uint> clang_getNumDiagnosticsInSet;
-        public delegate* unmanaged[Cdecl]<CXSourceRangeList*, void> clang_disposeSourceRangeList;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXSourceRangeList*> clang_getAllSkippedRanges;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, CXSourceRangeList*> clang_getSkippedRanges;
-        public delegate* unmanaged[Cdecl]<CXSourceRange, CXSourceLocation> clang_getRangeEnd;
-        public delegate* unmanaged[Cdecl]<CXSourceRange, CXSourceLocation> clang_getRangeStart;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void> clang_getFileLocation;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void> clang_getSpellingLocation;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void> clang_getInstantiationLocation;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation, CXString*, ulong*, ulong*, void> clang_getPresumedLocation;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation, CXFile*, ulong*, ulong*, ulong*, void> clang_getExpansionLocation;
-        public delegate* unmanaged[Cdecl]<CXSourceRange, int> clang_Range_isNull;
-        public delegate* unmanaged[Cdecl]<CXSourceRange, CXSourceRange, uint> clang_equalRanges;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation, CXSourceLocation, CXSourceRange> clang_getRange;
-        public delegate* unmanaged[Cdecl]<CXSourceRange> clang_getNullRange;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation, int> clang_Location_isFromMainFile;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation, int> clang_Location_isInSystemHeader;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, uint, CXSourceLocation> clang_getLocationForOffset;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, uint, uint, CXSourceLocation> clang_getLocation;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation, CXSourceLocation, uint> clang_equalLocations;
-        public delegate* unmanaged[Cdecl]<CXSourceLocation> clang_getNullLocation;
-        public delegate* unmanaged[Cdecl]<CXFile, CXString> clang_File_tryGetRealPathName;
-        public delegate* unmanaged[Cdecl]<CXFile, CXFile, int> clang_File_isEqual;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, ulong*, CString> clang_getFileContents;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CString, CXFile> clang_getFile;
-        public delegate* unmanaged[Cdecl]<CXTranslationUnit, CXFile, uint> clang_isFileMultipleIncludeGuarded;
-        public delegate* unmanaged[Cdecl]<CXFile, CXFileUniqueID*, int> clang_getFileUniqueID;
-        public delegate* unmanaged[Cdecl]<CXFile, time_t> clang_getFileTime;
-        public delegate* unmanaged[Cdecl]<CXFile, CXString> clang_getFileName;
-        public delegate* unmanaged[Cdecl]<CXIndex, CString, void> clang_CXIndex_setInvocationEmissionPathOption;
-        public delegate* unmanaged[Cdecl]<CXIndex, uint> clang_CXIndex_getGlobalOptions;
-        public delegate* unmanaged[Cdecl]<CXIndex, uint, void> clang_CXIndex_setGlobalOptions;
-        public delegate* unmanaged[Cdecl]<CXIndex, void> clang_disposeIndex;
-        public delegate* unmanaged[Cdecl]<int, int, CXIndex> clang_createIndex;
-        public delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, void> clang_ModuleMapDescriptor_dispose;
-        public delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, uint, CString*, ulong*, CXErrorCode> clang_ModuleMapDescriptor_writeToBuffer;
-        public delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, CString, CXErrorCode> clang_ModuleMapDescriptor_setUmbrellaHeader;
-        public delegate* unmanaged[Cdecl]<CXModuleMapDescriptor, CString, CXErrorCode> clang_ModuleMapDescriptor_setFrameworkModuleName;
-        public delegate* unmanaged[Cdecl]<uint, CXModuleMapDescriptor> clang_ModuleMapDescriptor_create;
-        public delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, void> clang_VirtualFileOverlay_dispose;
-        public delegate* unmanaged[Cdecl]<void*, void> clang_free;
-        public delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, uint, CString*, ulong*, CXErrorCode> clang_VirtualFileOverlay_writeToBuffer;
-        public delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, int, CXErrorCode> clang_VirtualFileOverlay_setCaseSensitivity;
-        public delegate* unmanaged[Cdecl]<CXVirtualFileOverlay, CString, CString, CXErrorCode> clang_VirtualFileOverlay_addFileMapping;
-        public delegate* unmanaged[Cdecl]<uint, CXVirtualFileOverlay> clang_VirtualFileOverlay_create;
-        public delegate* unmanaged[Cdecl]<ulong> clang_getBuildSessionTimestamp;
-        public delegate* unmanaged[Cdecl]<CXStringSet*, void> clang_disposeStringSet;
-        public delegate* unmanaged[Cdecl]<CXString, void> clang_disposeString;
-        public delegate* unmanaged[Cdecl]<CXString, CString> clang_getCString;
-
-        #endregion
-
-        #region "Variables"
-        // These pointers hold the locations in the native library where global variables are located at runtime.
-        //	The value pointed by these pointers are updated by reading/writing memory.
-
-
-
-        #endregion
-    }
-
-    private static _VirtualTable _virtualTable;
 }


### PR DESCRIPTION
- Remove bindgen for variable externs.
- Switch back to using `DllImport` for function externs.
- Update bindings for `clang` and libraries in tests.