### PR TITLE
Update Runtime.Platform for iOS, Android, and Browser

### DIFF
--- a/src/cs/production/C2CS.Runtime/Runtime.Library.cs
+++ b/src/cs/production/C2CS.Runtime/Runtime.Library.cs
@@ -15,53 +15,6 @@ namespace C2CS
     {
         private static ImmutableArray<string> _nativeSearchDirectories;
 
-        public static IntPtr LibraryLoad(string libraryName)
-        {
-            if (string.IsNullOrEmpty(libraryName))
-            {
-                return IntPtr.Zero;
-            }
-
-            var libraryFilePath = LibraryFilePath(libraryName);
-            if (string.IsNullOrEmpty(libraryFilePath))
-            {
-                PrintLibraryNotFound(libraryName);
-                return IntPtr.Zero;
-            }
-
-            Unsafe.SkipInit<IntPtr>(out var handle);
-
-            if (!NativeLibrary.TryLoad(libraryFilePath, out handle))
-            {
-                PrintLibraryLoadError(libraryFilePath);
-                return IntPtr.Zero;
-            }
-
-            return handle;
-        }
-
-        public static void LibraryUnload(IntPtr libraryHandle)
-        {
-            NativeLibrary.Free(libraryHandle);
-        }
-
-        public static IntPtr LibraryGetExport(IntPtr libraryHandle, string name)
-        {
-            if (libraryHandle == IntPtr.Zero)
-            {
-                return IntPtr.Zero;
-            }
-
-            Unsafe.SkipInit<IntPtr>(out var address);
-
-            if (!NativeLibrary.TryGetExport(libraryHandle, name, out address))
-            {
-                return IntPtr.Zero;
-            }
-
-            return address;
-        }
-
         private static void GetNativeLibrarySearchDirectories()
         {
             // For security purposes we don't allow loading a library by just any path;

--- a/src/cs/production/C2CS.Runtime/Runtime.Platform.cs
+++ b/src/cs/production/C2CS.Runtime/Runtime.Platform.cs
@@ -11,33 +11,7 @@ namespace C2CS
         /// <summary>
         ///     Gets the current <see cref="RuntimePlatform" />.
         /// </summary>
-        public static RuntimePlatform Platform
-        {
-            get
-            {
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    return RuntimePlatform.Windows;
-                }
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    return RuntimePlatform.macOS;
-                }
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    return RuntimePlatform.Linux;
-                }
-
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
-                {
-                    return RuntimePlatform.Linux;
-                }
-
-                return RuntimePlatform.Unknown;
-            }
-        }
+        public static RuntimePlatform Platform => GetRuntimePlatform();
 
         /// <summary>
         ///     Gets the library file name extension given a <see cref="RuntimePlatform" />.
@@ -53,13 +27,14 @@ namespace C2CS
                 case RuntimePlatform.Windows:
                     return ".dll";
                 case RuntimePlatform.macOS:
+                case RuntimePlatform.tvOS:
                 case RuntimePlatform.iOS:
                     return ".dylib";
                 case RuntimePlatform.Linux:
                 case RuntimePlatform.FreeBSD:
                 case RuntimePlatform.Android:
                     return ".so";
-                case RuntimePlatform.Web:
+                case RuntimePlatform.Browser:
                     throw new NotImplementedException();
                 case RuntimePlatform.Unknown:
                     throw new NotImplementedException();
@@ -82,18 +57,60 @@ namespace C2CS
                 case RuntimePlatform.Windows:
                     return string.Empty;
                 case RuntimePlatform.macOS:
+                case RuntimePlatform.tvOS:
                 case RuntimePlatform.iOS:
                 case RuntimePlatform.Linux:
                 case RuntimePlatform.FreeBSD:
                 case RuntimePlatform.Android:
                     return "lib";
-                case RuntimePlatform.Web:
+                case RuntimePlatform.Browser:
                     throw new NotImplementedException();
                 case RuntimePlatform.Unknown:
                     throw new NotImplementedException();
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimePlatform), runtimePlatform, null);
             }
+        }
+
+        private static RuntimePlatform GetRuntimePlatform()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return RuntimePlatform.Windows;
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                return RuntimePlatform.macOS;
+            }
+
+            if (OperatingSystem.IsLinux())
+            {
+                return RuntimePlatform.Linux;
+            }
+
+            if (OperatingSystem.IsAndroid())
+            {
+                return RuntimePlatform.Android;
+            }
+
+            if (OperatingSystem.IsIOS())
+            {
+                return RuntimePlatform.iOS;
+            }
+
+            if (OperatingSystem.IsTvOS())
+            {
+                return RuntimePlatform.tvOS;
+            }
+
+            if (OperatingSystem.IsBrowser())
+            {
+                return RuntimePlatform.Browser;
+            }
+
+            return RuntimePlatform.Unknown;
         }
     }
 }

--- a/src/cs/production/C2CS.Runtime/Runtime.Platform.cs
+++ b/src/cs/production/C2CS.Runtime/Runtime.Platform.cs
@@ -67,7 +67,6 @@ namespace C2CS
                     throw new NotImplementedException();
                 case RuntimePlatform.Unknown:
                     throw new NotImplementedException();
-                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(runtimePlatform), runtimePlatform, null);
             }

--- a/src/cs/production/C2CS.Runtime/Runtime.cs
+++ b/src/cs/production/C2CS.Runtime/Runtime.cs
@@ -19,9 +19,5 @@ namespace C2CS
     [SuppressMessage("ReSharper", "FieldCanBeMadeReadOnly.Global", Justification = "Public API.")]
     public static partial class Runtime
     {
-        static Runtime()
-        {
-            GetNativeLibrarySearchDirectories();
-        }
     }
 }

--- a/src/cs/production/C2CS.Runtime/RuntimePlatform.cs
+++ b/src/cs/production/C2CS.Runtime/RuntimePlatform.cs
@@ -65,6 +65,6 @@ namespace C2CS
         /// </summary>
         Browser = 8,
 
-        // TODO: tvOS, RaspberryPi, WebAssembly, PlayStation4, PlayStationVita, Switch etc
+        // TODO: RaspberryPi, PlayStation4, PlayStationVita, Switch etc
     }
 }

--- a/src/cs/production/C2CS.Runtime/RuntimePlatform.cs
+++ b/src/cs/production/C2CS.Runtime/RuntimePlatform.cs
@@ -63,7 +63,7 @@ namespace C2CS
         /// <summary>
         ///     Versions of WebAssembly (64-bit) on some WASI (WebAssembly System Interface) compliant host program such as a modern web browser.
         /// </summary>
-        Web = 8,
+        Browser = 8,
 
         // TODO: tvOS, RaspberryPi, WebAssembly, PlayStation4, PlayStationVita, Switch etc
     }


### PR DESCRIPTION
- Makes previous enum `RuntimePlatform` actually work for iOS + Android + Browser