### PR TITLE
Fix parsing of macro definitions that are JSON body

### DIFF
--- a/src/cs/production/C2CS/UseCases/AbstractSyntaxTreeC/Data/CAbstractSyntaxTree.cs
+++ b/src/cs/production/C2CS/UseCases/AbstractSyntaxTreeC/Data/CAbstractSyntaxTree.cs
@@ -45,5 +45,5 @@ public record CAbstractSyntaxTree
     public ImmutableArray<CType> Types { get; set; } = ImmutableArray<CType>.Empty;
 
     [JsonPropertyName("constants")]
-    public ImmutableArray<CMacroObject> Constants { get; set; } = ImmutableArray<CMacroObject>.Empty;
+    public ImmutableArray<CMacroDefinition> Constants { get; set; } = ImmutableArray<CMacroDefinition>.Empty;
 }

--- a/src/cs/production/C2CS/UseCases/AbstractSyntaxTreeC/Data/CKind.cs
+++ b/src/cs/production/C2CS/UseCases/AbstractSyntaxTreeC/Data/CKind.cs
@@ -18,5 +18,5 @@ public enum CKind
     OpaqueType,
     Typedef,
     Variable,
-    MacroObjectLike
+    MacroDefinition
 }

--- a/src/cs/production/C2CS/UseCases/AbstractSyntaxTreeC/Data/CMacroDefinition.cs
+++ b/src/cs/production/C2CS/UseCases/AbstractSyntaxTreeC/Data/CMacroDefinition.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Serialization;
 
 namespace C2CS.UseCases.AbstractSyntaxTreeC;
 
-public record CMacroObject : CNode
+public record CMacroDefinition : CNode
 {
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
@@ -16,6 +16,6 @@ public record CMacroObject : CNode
 
     public override string ToString()
     {
-        return $"MacroObject '{Name}' @ {Location.ToString()}";
+        return $"Macro '{Name}' @ {Location.ToString()}";
     }
 }

--- a/src/cs/production/C2CS/UseCases/AbstractSyntaxTreeC/Data/CNode.cs
+++ b/src/cs/production/C2CS/UseCases/AbstractSyntaxTreeC/Data/CNode.cs
@@ -29,7 +29,7 @@ public record CNode : IComparable<CNode>
             CRecord => CKind.Record,
             CTypedef => CKind.Typedef,
             CVariable => CKind.Variable,
-            CMacroObject => CKind.MacroObjectLike,
+            CMacroDefinition => CKind.MacroDefinition,
             _ => CKind.Unknown
         };
     }


### PR DESCRIPTION
Found when generating bindings for `flecs`. The macro `ECS_HTTP_REPLY_INIT` with the following body crashed `C2CS`: 
```c
(ecs_http_reply_t){200,ECS_STRBUF_INIT,"OK","application/json",ECS_STRBUF_INIT}
```