### PR TITLE
Fix C# code gen for fixed buffer field names that match C# keywords

### DIFF
--- a/src/cs/production/C2CS/UseCases/BindgenCSharp/Data/CSharpStructField.cs
+++ b/src/cs/production/C2CS/UseCases/BindgenCSharp/Data/CSharpStructField.cs
@@ -9,6 +9,7 @@ public record CSharpStructField : CSharpNode
     public readonly int Offset;
     public readonly int Padding;
     public readonly bool IsWrapped;
+    public readonly string BackingFieldName;
 
     public CSharpStructField(
         string name,
@@ -23,6 +24,7 @@ public record CSharpStructField : CSharpNode
         Offset = offset;
         Padding = padding;
         IsWrapped = isWrapped;
+        BackingFieldName = name.StartsWith("@") ? $"_{name[1..]}" : $"_{name}";
     }
 
     // Required for debugger string with records

--- a/src/cs/production/C2CS/UseCases/BindgenCSharp/Logic/CSharpCodeGenerator.cs
+++ b/src/cs/production/C2CS/UseCases/BindgenCSharp/Logic/CSharpCodeGenerator.cs
@@ -279,7 +279,7 @@ public {field.Type.Name} {field.Name};
 
 		var code = $@"
 [FieldOffset({field.Offset})] // size = {field.Type.SizeOf}, padding = {field.Padding}
-public fixed {typeName} _{field.Name}[{field.Type.SizeOf}/{field.Type.AlignOf}]; // {field.Type.OriginalName}
+public fixed {typeName} {field.BackingFieldName}[{field.Type.SizeOf}/{field.Type.AlignOf}]; // {field.Type.OriginalName}
 ".Trim();
 
 		return ParseMemberCode<FieldDeclarationSyntax>(code);
@@ -300,7 +300,7 @@ public string {field.Name}
 	{{
 		fixed ({structName}*@this = &this)
 		{{
-			var pointer = &@this->_{field.Name}[0];
+			var pointer = &@this->{field.BackingFieldName}[0];
             var cString = new CString8U(pointer);
             return Runtime.String8U(cString);
 		}}
@@ -317,7 +317,7 @@ public string {field.Name}
 	{{
 		fixed ({structName}*@this = &this)
 		{{
-			var pointer = &@this->_{field.Name}[0];
+			var pointer = &@this->{field.BackingFieldName}[0];
             var cString = new CString16U(pointer);
             return Runtime.String16U(cString);
 		}}
@@ -340,7 +340,7 @@ public Span<{elementType}> {field.Name}
 	{{
 		fixed ({structName}*@this = &this)
 		{{
-			var pointer = &@this->_{field.Name}[0];
+			var pointer = &@this->{field.BackingFieldName}[0];
 			var span = new Span<{elementType}>(pointer, {field.Type.ArraySize});
 			return span;
 		}}


### PR DESCRIPTION
Fix the issue where a field name for a fixed buffer is not properly generated causing generated C# to not compile.