### PR TITLE
Fix logic for determining size of Clang types

### DIFF
--- a/src/cs/production/C2CS/UseCases/CExtractAbstractSyntaxTree/Data/CType.cs
+++ b/src/cs/production/C2CS/UseCases/CExtractAbstractSyntaxTree/Data/CType.cs
@@ -17,7 +17,7 @@ public class CType
     public CKind Kind { get; set; } = CKind.Unknown;
 
     [JsonPropertyName("sizeOf")]
-    public int? SizeOf { get; set; }
+    public int SizeOf { get; set; }
 
     [JsonPropertyName("alignOf")]
     public int? AlignOf { get; set; }

--- a/src/cs/production/C2CS/UseCases/CSharpBindgen/Logic/CSharpMapper.cs
+++ b/src/cs/production/C2CS/UseCases/CSharpBindgen/Logic/CSharpMapper.cs
@@ -865,7 +865,7 @@ var x = {value};
     private CSharpType Type(CType cType, string? typeName = null)
     {
         var typeName2 = typeName ?? TypeName(cType);
-        var sizeOf = cType.SizeOf ?? 0;
+        var sizeOf = cType.SizeOf;
         var alignOf = cType.AlignOf ?? 0;
         var fixedBufferSize = cType.ArraySize ?? 0;
 
@@ -887,7 +887,7 @@ var x = {value};
         }
 
         var name = type.Name;
-        var elementTypeSize = type.ElementSize ?? type.SizeOf ?? 0;
+        var elementTypeSize = type.ElementSize ?? type.SizeOf;
         string typeName;
 
         if (name.EndsWith("*", StringComparison.InvariantCulture) || name.EndsWith("]", StringComparison.InvariantCulture))


### PR DESCRIPTION
Found when generating bindings for `libuv`